### PR TITLE
Remove unique email entry

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -63,7 +63,7 @@ class User extends Authenticatable
 
     public static $rules = [
         'name' => 'required',
-        'email' => 'required|email|unique:users,email',
+        'email' => 'required|email',
     ];
 
     /**


### PR DESCRIPTION
When updating a user through the users admin, it comes up saying "The email has already been taken." because of the unique rules set in the model. The only time I can think of right at this point to make sure it is unique is on registering, but that's handled by the Validator anyway so this shouldn't be an issue. Unless you're keeping this here for a reason.