### PR TITLE
Fix 404s to requirements/setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ The latest documentation, with installation instructions is available
 1. Upload to your server
 2. Visit the site, and follow the link to the installer
 
-[View installation details](http://docs.phpvms.net/basics/installation)
+[View installation details](http://docs.phpvms.net/setup/installation)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The latest documentation, with installation instructions is available
 - Database:
   - MySQL 5.5+ (or MySQL variant, including MariaDB and Percona)
 
-[View more details on requirements](http://docs.phpvms.net/basics/requirements)
+[View more details on requirements](http://docs.phpvms.net/setup/requirements)
 
 ## Installer
 


### PR DESCRIPTION
It looks like the documentation structure had changed without the README being updated. Both links should now go to the correct page.