### PR TITLE
Rename Interfaces to Contracts to better match Laravel conventions

### DIFF
--- a/app/Awards/PilotFlightAwards.php
+++ b/app/Awards/PilotFlightAwards.php
@@ -2,7 +2,7 @@
 
 namespace App\Awards;
 
-use App\Interfaces\Award;
+use App\Contracts\Award;
 
 /**
  * Simple example of an awards class, where you can apply an award when a user

--- a/app/Contracts/Award.php
+++ b/app/Contracts/Award.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use App\Facades\Utils;
 use App\Models\Award as AwardModel;

--- a/app/Contracts/Controller.php
+++ b/app/Contracts/Controller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;

--- a/app/Contracts/Enum.php
+++ b/app/Contracts/Enum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 /**
  * Borrowed some ideas from myclabs/php-enum after this was created

--- a/app/Contracts/FormRequest.php
+++ b/app/Contracts/FormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 /**
  * Class FormRequest

--- a/app/Contracts/ImportExport.php
+++ b/app/Contracts/ImportExport.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use App\Models\Airline;
 use Illuminate\Validation\ValidationException;

--- a/app/Contracts/Listener.php
+++ b/app/Contracts/Listener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 /**
  * Class Listener

--- a/app/Contracts/Metar.php
+++ b/app/Contracts/Metar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use Cache;
 use Log;

--- a/app/Contracts/Migration.php
+++ b/app/Contracts/Migration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use DB;
 

--- a/app/Contracts/Model.php
+++ b/app/Contracts/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 /**
  * Class Model

--- a/app/Contracts/Repository.php
+++ b/app/Contracts/Repository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use Illuminate\Validation\Validator;
 

--- a/app/Contracts/Service.php
+++ b/app/Contracts/Service.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 /**
  * Class Service

--- a/app/Contracts/Unit.php
+++ b/app/Contracts/Unit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use ArrayAccess;
 

--- a/app/Contracts/Widget.php
+++ b/app/Contracts/Widget.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Interfaces;
+namespace App\Contracts;
 
 use Arrilot\Widgets\AbstractWidget;
 

--- a/app/Cron/Hourly/RemoveExpiredBids.php
+++ b/app/Cron/Hourly/RemoveExpiredBids.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Hourly;
 
-use App\Events\CronHourly;
 use App\Contracts\Listener;
+use App\Events\CronHourly;
 use App\Models\Bid;
 use Carbon\Carbon;
 

--- a/app/Cron/Hourly/RemoveExpiredBids.php
+++ b/app/Cron/Hourly/RemoveExpiredBids.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Hourly;
 
 use App\Events\CronHourly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Bid;
 use Carbon\Carbon;
 

--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Hourly;
 
-use App\Events\CronHourly;
 use App\Contracts\Listener;
+use App\Events\CronHourly;
 use App\Models\Pirep;
 use Carbon\Carbon;
 

--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Hourly;
 
 use App\Events\CronHourly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Pirep;
 use Carbon\Carbon;
 

--- a/app/Cron/Monthly/ApplyExpenses.php
+++ b/app/Cron/Monthly/ApplyExpenses.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Monthly;
 
 use App\Events\CronMonthly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Enums\ExpenseType;
 use App\Services\Finance\RecurringFinanceService;
 

--- a/app/Cron/Monthly/ApplyExpenses.php
+++ b/app/Cron/Monthly/ApplyExpenses.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Monthly;
 
-use App\Events\CronMonthly;
 use App\Contracts\Listener;
+use App\Events\CronMonthly;
 use App\Models\Enums\ExpenseType;
 use App\Services\Finance\RecurringFinanceService;
 

--- a/app/Cron/Nightly/ApplyExpenses.php
+++ b/app/Cron/Nightly/ApplyExpenses.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Nightly;
 
-use App\Events\CronNightly;
 use App\Contracts\Listener;
+use App\Events\CronNightly;
 use App\Models\Enums\ExpenseType;
 use App\Services\Finance\RecurringFinanceService;
 

--- a/app/Cron/Nightly/ApplyExpenses.php
+++ b/app/Cron/Nightly/ApplyExpenses.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Nightly;
 
 use App\Events\CronNightly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Enums\ExpenseType;
 use App\Services\Finance\RecurringFinanceService;
 

--- a/app/Cron/Nightly/PilotLeave.php
+++ b/app/Cron/Nightly/PilotLeave.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Nightly;
 
 use App\Events\CronNightly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Enums\UserState;
 use App\Models\User;
 use App\Services\UserService;

--- a/app/Cron/Nightly/PilotLeave.php
+++ b/app/Cron/Nightly/PilotLeave.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Nightly;
 
-use App\Events\CronNightly;
 use App\Contracts\Listener;
+use App\Events\CronNightly;
 use App\Models\Enums\UserState;
 use App\Models\User;
 use App\Services\UserService;

--- a/app/Cron/Nightly/RecalculateBalances.php
+++ b/app/Cron/Nightly/RecalculateBalances.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Nightly;
 
-use App\Events\CronNightly;
 use App\Contracts\Listener;
+use App\Events\CronNightly;
 use App\Models\Journal;
 use App\Repositories\JournalRepository;
 use Log;

--- a/app/Cron/Nightly/RecalculateBalances.php
+++ b/app/Cron/Nightly/RecalculateBalances.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Nightly;
 
 use App\Events\CronNightly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Journal;
 use App\Repositories\JournalRepository;
 use Log;

--- a/app/Cron/Nightly/RecalculateStats.php
+++ b/app/Cron/Nightly/RecalculateStats.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Nightly;
 
 use App\Events\CronNightly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Enums\UserState;
 use App\Repositories\UserRepository;
 use App\Services\UserService;

--- a/app/Cron/Nightly/RecalculateStats.php
+++ b/app/Cron/Nightly/RecalculateStats.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Nightly;
 
-use App\Events\CronNightly;
 use App\Contracts\Listener;
+use App\Events\CronNightly;
 use App\Models\Enums\UserState;
 use App\Repositories\UserRepository;
 use App\Services\UserService;

--- a/app/Cron/Nightly/SetActiveFlights.php
+++ b/app/Cron/Nightly/SetActiveFlights.php
@@ -3,7 +3,7 @@
 namespace App\Cron\Nightly;
 
 use App\Events\CronNightly;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Enums\Days;
 use App\Models\Flight;
 use Carbon\Carbon;

--- a/app/Cron/Nightly/SetActiveFlights.php
+++ b/app/Cron/Nightly/SetActiveFlights.php
@@ -2,8 +2,8 @@
 
 namespace App\Cron\Nightly;
 
-use App\Events\CronNightly;
 use App\Contracts\Listener;
+use App\Events\CronNightly;
 use App\Models\Enums\Days;
 use App\Models\Flight;
 use Carbon\Carbon;

--- a/app/Database/migrations/2017_06_07_014930_create_settings_table.php
+++ b/app/Database/migrations/2017_06_07_014930_create_settings_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use App\Services\Installer\MigrationService;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/app/Database/migrations/2017_06_08_0000_create_users_table.php
+++ b/app/Database/migrations/2017_06_08_0000_create_users_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2017_06_08_0001_roles_permissions_tables.php
+++ b/app/Database/migrations/2017_06_08_0001_roles_permissions_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 class RolesPermissionsTables extends Migration

--- a/app/Database/migrations/2017_06_08_0005_create_password_resets_table.php
+++ b/app/Database/migrations/2017_06_08_0005_create_password_resets_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2017_06_08_0006_create_sessions_table.php
+++ b/app/Database/migrations/2017_06_08_0006_create_sessions_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2017_06_08_191703_create_airlines_table.php
+++ b/app/Database/migrations/2017_06_08_191703_create_airlines_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 class CreateAirlinesTable extends Migration

--- a/app/Database/migrations/2017_06_09_010621_create_aircrafts_table.php
+++ b/app/Database/migrations/2017_06_09_010621_create_aircrafts_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use App\Models\Enums\AircraftState;
 use App\Models\Enums\AircraftStatus;
 use Illuminate\Database\Schema\Blueprint;

--- a/app/Database/migrations/2017_06_10_040335_create_fares_table.php
+++ b/app/Database/migrations/2017_06_10_040335_create_fares_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 class CreateFaresTable extends Migration

--- a/app/Database/migrations/2017_06_11_135707_create_airports_table.php
+++ b/app/Database/migrations/2017_06_11_135707_create_airports_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 class CreateAirportsTable extends Migration

--- a/app/Database/migrations/2017_06_17_214650_create_flight_tables.php
+++ b/app/Database/migrations/2017_06_17_214650_create_flight_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use App\Models\Enums\FlightType;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -14,7 +14,7 @@ class CreateFlightTables extends Migration
     public function up()
     {
         Schema::create('flights', function (Blueprint $table) {
-            $table->string('id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->unsignedInteger('airline_id');
             $table->unsignedInteger('flight_number');
             $table->string('route_code', 5)->nullable();
@@ -47,7 +47,7 @@ class CreateFlightTables extends Migration
         });
 
         Schema::create('flight_fare', function (Blueprint $table) {
-            $table->string('flight_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('flight_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->unsignedInteger('fare_id');
             $table->string('price', 10)->nullable();
             $table->string('cost', 10)->nullable();
@@ -71,7 +71,7 @@ class CreateFlightTables extends Migration
          */
         Schema::create('flight_field_values', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('flight_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('flight_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->string('name', 50);
             $table->string('slug', 50)->nullable();
             $table->text('value');
@@ -83,7 +83,7 @@ class CreateFlightTables extends Migration
         Schema::create('flight_subfleet', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedInteger('subfleet_id');
-            $table->string('flight_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('flight_id', \App\Contracts\Model::ID_MAX_LENGTH);
 
             $table->index(['subfleet_id', 'flight_id']);
             $table->index(['flight_id', 'subfleet_id']);

--- a/app/Database/migrations/2017_06_21_165410_create_ranks_table.php
+++ b/app/Database/migrations/2017_06_21_165410_create_ranks_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 class CreateRanksTable extends Migration

--- a/app/Database/migrations/2017_06_23_011011_create_subfleet_tables.php
+++ b/app/Database/migrations/2017_06_23_011011_create_subfleet_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 /**

--- a/app/Database/migrations/2017_06_28_195426_create_pirep_tables.php
+++ b/app/Database/migrations/2017_06_28_195426_create_pirep_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use App\Models\Enums\FlightType;
 use App\Models\Enums\PirepState;
 use App\Models\Enums\PirepStatus;
@@ -16,7 +16,7 @@ class CreatePirepTables extends Migration
     public function up()
     {
         Schema::create('pireps', function (Blueprint $table) {
-            $table->string('id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('airline_id');
             $table->unsignedInteger('aircraft_id')->nullable();
@@ -57,7 +57,7 @@ class CreatePirepTables extends Migration
 
         Schema::create('pirep_comments', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('pirep_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('pirep_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->unsignedInteger('user_id');
             $table->text('comment');
             $table->timestamps();
@@ -65,7 +65,7 @@ class CreatePirepTables extends Migration
 
         Schema::create('pirep_fares', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('pirep_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('pirep_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->unsignedInteger('fare_id');
             $table->unsignedInteger('count')->nullable()->default(0);
 
@@ -81,7 +81,7 @@ class CreatePirepTables extends Migration
 
         Schema::create('pirep_field_values', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('pirep_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('pirep_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->string('name', 50);
             $table->string('slug', 50)->nullable();
             $table->string('value')->nullable();

--- a/app/Database/migrations/2017_12_12_174519_create_bids_table.php
+++ b/app/Database/migrations/2017_12_12_174519_create_bids_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -16,7 +16,7 @@ class CreateBidsTable extends Migration
         Schema::create('bids', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');
-            $table->string('flight_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('flight_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->timestamps();
 
             $table->index('user_id');

--- a/app/Database/migrations/2017_12_14_225241_create_jobs_table.php
+++ b/app/Database/migrations/2017_12_14_225241_create_jobs_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2017_12_14_225337_create_failed_jobs_table.php
+++ b/app/Database/migrations/2017_12_14_225337_create_failed_jobs_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2017_12_20_004147_create_navdata_tables.php
+++ b/app/Database/migrations/2017_12_20_004147_create_navdata_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2017_12_20_005147_create_acars_tables.php
+++ b/app/Database/migrations/2017_12_20_005147_create_acars_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -15,7 +15,7 @@ class CreateAcarsTables extends Migration
     {
         Schema::create('acars', function (Blueprint $table) {
             $table->string('id', 12);
-            $table->string('pirep_id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('pirep_id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->unsignedTinyInteger('type');
             $table->unsignedInteger('nav_type')->nullable();
             $table->unsignedInteger('order')->default(0);

--- a/app/Database/migrations/2018_01_03_014930_create_stats_table.php
+++ b/app/Database/migrations/2018_01_03_014930_create_stats_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 class CreateStatsTable extends Migration

--- a/app/Database/migrations/2018_01_08_142204_create_news_table.php
+++ b/app/Database/migrations/2018_01_08_142204_create_news_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2018_01_28_180522_create_awards_table.php
+++ b/app/Database/migrations/2018_01_28_180522_create_awards_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2018_02_26_185121_create_expenses_table.php
+++ b/app/Database/migrations/2018_02_26_185121_create_expenses_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2018_02_28_231807_create_journal_transactions_table.php
+++ b/app/Database/migrations/2018_02_28_231807_create_journal_transactions_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2018_02_28_231813_create_journals_table.php
+++ b/app/Database/migrations/2018_02_28_231813_create_journals_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2018_02_28_232438_create_ledgers_table.php
+++ b/app/Database/migrations/2018_02_28_232438_create_ledgers_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 

--- a/app/Database/migrations/2018_04_01_193443_create_files_table.php
+++ b/app/Database/migrations/2018_04_01_193443_create_files_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Interfaces\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,7 +14,7 @@ class CreateFilesTable extends Migration
     public function up()
     {
         Schema::create('files', function (Blueprint $table) {
-            $table->string('id', \App\Interfaces\Model::ID_MAX_LENGTH);
+            $table->string('id', \App\Contracts\Model::ID_MAX_LENGTH);
             $table->string('name');
             $table->string('description')->nullable();
             $table->string('disk')->nullable();

--- a/app/Http/Controllers/Admin/AircraftController.php
+++ b/app/Http/Controllers/Admin/AircraftController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Requests\CreateAircraftRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateAircraftRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Aircraft;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Expense;

--- a/app/Http/Controllers/Admin/AircraftController.php
+++ b/app/Http/Controllers/Admin/AircraftController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateAircraftRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateAircraftRequest;
-use App\Contracts\Controller;
 use App\Models\Aircraft;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Expense;

--- a/app/Http/Controllers/Admin/AirlinesController.php
+++ b/app/Http/Controllers/Admin/AirlinesController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\CreateAirlineRequest;
 use App\Http\Requests\UpdateAirlineRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AirlineRepository;
 use App\Support\Countries;
 use Flash;

--- a/app/Http/Controllers/Admin/AirlinesController.php
+++ b/app/Http/Controllers/Admin/AirlinesController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateAirlineRequest;
 use App\Http\Requests\UpdateAirlineRequest;
-use App\Contracts\Controller;
 use App\Repositories\AirlineRepository;
 use App\Support\Countries;
 use Flash;

--- a/app/Http/Controllers/Admin/AirportController.php
+++ b/app/Http/Controllers/Admin/AirportController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Requests\CreateAirportRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateAirportRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Airport;
 use App\Models\Expense;
 use App\Repositories\AirportRepository;

--- a/app/Http/Controllers/Admin/AirportController.php
+++ b/app/Http/Controllers/Admin/AirportController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateAirportRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateAirportRequest;
-use App\Contracts\Controller;
 use App\Models\Airport;
 use App\Models\Expense;
 use App\Repositories\AirportRepository;

--- a/app/Http/Controllers/Admin/AwardController.php
+++ b/app/Http/Controllers/Admin/AwardController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateAwardRequest;
 use App\Http\Requests\UpdateAwardRequest;
-use App\Contracts\Controller;
 use App\Repositories\AwardRepository;
 use App\Services\AwardService;
 use Flash;

--- a/app/Http/Controllers/Admin/AwardController.php
+++ b/app/Http/Controllers/Admin/AwardController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\CreateAwardRequest;
 use App\Http\Requests\UpdateAwardRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AwardRepository;
 use App\Services\AwardService;
 use Flash;

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Facades\Utils;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\NewsRepository;
 use App\Repositories\PirepRepository;
 use App\Repositories\UserRepository;

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Facades\Utils;
 use App\Contracts\Controller;
+use App\Facades\Utils;
 use App\Repositories\NewsRepository;
 use App\Repositories\PirepRepository;
 use App\Repositories\UserRepository;

--- a/app/Http/Controllers/Admin/ExpenseController.php
+++ b/app/Http/Controllers/Admin/ExpenseController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Http\Requests\ImportRequest;
 use App\Contracts\Controller;
+use App\Http\Requests\ImportRequest;
 use App\Models\Enums\ExpenseType;
 use App\Models\Expense;
 use App\Repositories\AirlineRepository;

--- a/app/Http/Controllers/Admin/ExpenseController.php
+++ b/app/Http/Controllers/Admin/ExpenseController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\ImportRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\ExpenseType;
 use App\Models\Expense;
 use App\Repositories\AirlineRepository;

--- a/app/Http/Controllers/Admin/FareController.php
+++ b/app/Http/Controllers/Admin/FareController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Requests\CreateFareRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateFareRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\FareRepository;
 use App\Services\ExportService;
 use App\Services\ImportService;

--- a/app/Http/Controllers/Admin/FareController.php
+++ b/app/Http/Controllers/Admin/FareController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateFareRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateFareRequest;
-use App\Contracts\Controller;
 use App\Repositories\FareRepository;
 use App\Services\ExportService;
 use App\Services\ImportService;

--- a/app/Http/Controllers/Admin/FileController.php
+++ b/app/Http/Controllers/Admin/FileController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\File;
 use App\Services\FileService;
 use Flash;

--- a/app/Http/Controllers/Admin/FinanceController.php
+++ b/app/Http/Controllers/Admin/FinanceController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\JournalType;
 use App\Models\Journal;
 use App\Models\JournalTransaction;

--- a/app/Http/Controllers/Admin/FlightController.php
+++ b/app/Http/Controllers/Admin/FlightController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\CreateFlightRequest;
 use App\Http\Requests\UpdateFlightRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\Days;
 use App\Models\Enums\FlightType;
 use App\Models\Flight;

--- a/app/Http/Controllers/Admin/FlightController.php
+++ b/app/Http/Controllers/Admin/FlightController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateFlightRequest;
 use App\Http\Requests\UpdateFlightRequest;
-use App\Contracts\Controller;
 use App\Models\Enums\Days;
 use App\Models\Enums\FlightType;
 use App\Models\Flight;

--- a/app/Http/Controllers/Admin/FlightFieldController.php
+++ b/app/Http/Controllers/Admin/FlightFieldController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\FlightFieldRepository;
 use Flash;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Admin/PirepController.php
+++ b/app/Http/Controllers/Admin/PirepController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Facades\Utils;
 use App\Http\Requests\CreatePirepRequest;
 use App\Http\Requests\UpdatePirepRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\PirepSource;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;

--- a/app/Http/Controllers/Admin/PirepController.php
+++ b/app/Http/Controllers/Admin/PirepController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Facades\Utils;
 use App\Http\Requests\CreatePirepRequest;
 use App\Http\Requests\UpdatePirepRequest;
-use App\Contracts\Controller;
 use App\Models\Enums\PirepSource;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;

--- a/app/Http/Controllers/Admin/PirepFieldController.php
+++ b/app/Http/Controllers/Admin/PirepFieldController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\CreatePirepFieldRequest;
 use App\Http\Requests\UpdatePirepFieldRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\PirepFieldRepository;
 use Flash;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Admin/PirepFieldController.php
+++ b/app/Http/Controllers/Admin/PirepFieldController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreatePirepFieldRequest;
 use App\Http\Requests\UpdatePirepFieldRequest;
-use App\Contracts\Controller;
 use App\Repositories\PirepFieldRepository;
 use Flash;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Admin/RankController.php
+++ b/app/Http/Controllers/Admin/RankController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateRankRequest;
 use App\Http\Requests\UpdateRankRequest;
-use App\Contracts\Controller;
 use App\Repositories\RankRepository;
 use App\Repositories\SubfleetRepository;
 use App\Services\FleetService;

--- a/app/Http/Controllers/Admin/RankController.php
+++ b/app/Http/Controllers/Admin/RankController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\CreateRankRequest;
 use App\Http\Requests\UpdateRankRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\RankRepository;
 use App\Repositories\SubfleetRepository;
 use App\Services\FleetService;

--- a/app/Http/Controllers/Admin/RolesController.php
+++ b/app/Http/Controllers/Admin/RolesController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateRoleRequest;
 use App\Http\Requests\UpdateRoleRequest;
-use App\Contracts\Controller;
 use App\Repositories\PermissionsRepository;
 use App\Repositories\RoleRepository;
 use Flash;

--- a/app/Http/Controllers/Admin/RolesController.php
+++ b/app/Http/Controllers/Admin/RolesController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\CreateRoleRequest;
 use App\Http\Requests\UpdateRoleRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\PermissionsRepository;
 use App\Repositories\RoleRepository;
 use Flash;

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Setting;
 use Illuminate\Http\Request;
 use Log;

--- a/app/Http/Controllers/Admin/SubfleetController.php
+++ b/app/Http/Controllers/Admin/SubfleetController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Requests\CreateSubfleetRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateSubfleetRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Airline;
 use App\Models\Enums\FuelType;
 use App\Models\Expense;

--- a/app/Http/Controllers/Admin/SubfleetController.php
+++ b/app/Http/Controllers/Admin/SubfleetController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Http\Requests\CreateSubfleetRequest;
 use App\Http\Requests\ImportRequest;
 use App\Http\Requests\UpdateSubfleetRequest;
-use App\Contracts\Controller;
 use App\Models\Airline;
 use App\Models\Enums\FuelType;
 use App\Models\Expense;

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Facades\Utils;
 use App\Http\Requests\CreateUserRequest;
 use App\Http\Requests\UpdateUserRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Rank;
 use App\Models\Role;
 use App\Models\User;

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Contracts\Controller;
 use App\Facades\Utils;
 use App\Http\Requests\CreateUserRequest;
 use App\Http\Requests\UpdateUserRequest;
-use App\Contracts\Controller;
 use App\Models\Rank;
 use App\Models\Role;
 use App\Models\User;

--- a/app/Http/Controllers/Api/AcarsController.php
+++ b/app/Http/Controllers/Api/AcarsController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Contracts\Controller;
 use App\Exceptions\PirepCancelled;
 use App\Http\Requests\Acars\EventRequest;
 use App\Http\Requests\Acars\LogRequest;
 use App\Http\Requests\Acars\PositionRequest;
 use App\Http\Resources\AcarsRoute as AcarsRouteResource;
-use App\Contracts\Controller;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepStatus;

--- a/app/Http/Controllers/Api/AcarsController.php
+++ b/app/Http/Controllers/Api/AcarsController.php
@@ -7,7 +7,7 @@ use App\Http\Requests\Acars\EventRequest;
 use App\Http\Requests\Acars\LogRequest;
 use App\Http\Requests\Acars\PositionRequest;
 use App\Http\Resources\AcarsRoute as AcarsRouteResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepStatus;

--- a/app/Http/Controllers/Api/AirlineController.php
+++ b/app/Http/Controllers/Api/AirlineController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Resources\Airline as AirlineResource;
 use App\Contracts\Controller;
+use App\Http\Resources\Airline as AirlineResource;
 use App\Repositories\AirlineRepository;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Api/AirlineController.php
+++ b/app/Http/Controllers/Api/AirlineController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Resources\Airline as AirlineResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AirlineRepository;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Api/AirportController.php
+++ b/app/Http/Controllers/Api/AirportController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Resources\Airport as AirportResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AirportRepository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;

--- a/app/Http/Controllers/Api/AirportController.php
+++ b/app/Http/Controllers/Api/AirportController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Resources\Airport as AirportResource;
 use App\Contracts\Controller;
+use App\Http\Resources\Airport as AirportResource;
 use App\Repositories\AirportRepository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;

--- a/app/Http/Controllers/Api/FleetController.php
+++ b/app/Http/Controllers/Api/FleetController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Resources\Aircraft as AircraftResource;
 use App\Http\Resources\Subfleet as SubfleetResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AircraftRepository;
 use App\Repositories\SubfleetRepository;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Api/FleetController.php
+++ b/app/Http/Controllers/Api/FleetController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Contracts\Controller;
 use App\Http\Resources\Aircraft as AircraftResource;
 use App\Http\Resources\Subfleet as SubfleetResource;
-use App\Contracts\Controller;
 use App\Repositories\AircraftRepository;
 use App\Repositories\SubfleetRepository;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Resources\Flight as FlightResource;
 use App\Http\Resources\Navdata as NavdataResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\Criteria\WhereCriteria;
 use App\Repositories\FlightRepository;
 use App\Services\FlightService;

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Contracts\Controller;
 use App\Http\Resources\Flight as FlightResource;
 use App\Http\Resources\Navdata as NavdataResource;
-use App\Contracts\Controller;
 use App\Repositories\Criteria\WhereCriteria;
 use App\Repositories\FlightRepository;
 use App\Services\FlightService;

--- a/app/Http/Controllers/Api/NewsController.php
+++ b/app/Http/Controllers/Api/NewsController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Resources\News as NewsResource;
 use App\Contracts\Controller;
+use App\Http\Resources\News as NewsResource;
 use App\Repositories\NewsRepository;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Api/NewsController.php
+++ b/app/Http/Controllers/Api/NewsController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Resources\News as NewsResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\NewsRepository;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Api/PirepController.php
+++ b/app/Http/Controllers/Api/PirepController.php
@@ -17,7 +17,7 @@ use App\Http\Resources\JournalTransaction as JournalTransactionResource;
 use App\Http\Resources\Pirep as PirepResource;
 use App\Http\Resources\PirepComment as PirepCommentResource;
 use App\Http\Resources\PirepFieldCollection;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepFieldSource;

--- a/app/Http/Controllers/Api/PirepController.php
+++ b/app/Http/Controllers/Api/PirepController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Contracts\Controller;
 use App\Exceptions\AircraftNotAtAirport;
 use App\Exceptions\AircraftPermissionDenied;
 use App\Exceptions\PirepCancelled;
@@ -17,7 +18,6 @@ use App\Http\Resources\JournalTransaction as JournalTransactionResource;
 use App\Http\Resources\Pirep as PirepResource;
 use App\Http\Resources\PirepComment as PirepCommentResource;
 use App\Http\Resources\PirepFieldCollection;
-use App\Contracts\Controller;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepFieldSource;

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Resources\Setting as SettingResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\SettingRepository;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Resources\Setting as SettingResource;
 use App\Contracts\Controller;
+use App\Http\Resources\Setting as SettingResource;
 use App\Repositories\SettingRepository;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Api/StatusController.php
+++ b/app/Http/Controllers/Api/StatusController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use PragmaRX\Version\Package\Facade as Version;
 
 /**

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Contracts\Controller;
 use App\Http\Resources\Bid as BidResource;
 use App\Http\Resources\Pirep as PirepResource;
 use App\Http\Resources\Subfleet as SubfleetResource;
 use App\Http\Resources\User as UserResource;
-use App\Contracts\Controller;
 use App\Models\Bid;
 use App\Models\Enums\PirepState;
 use App\Repositories\Criteria\WhereCriteria;

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -6,7 +6,7 @@ use App\Http\Resources\Bid as BidResource;
 use App\Http\Resources\Pirep as PirepResource;
 use App\Http\Resources\Subfleet as SubfleetResource;
 use App\Http\Resources\User as UserResource;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Bid;
 use App\Models\Enums\PirepState;
 use App\Repositories\Criteria\WhereCriteria;

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
 
 /**

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\UserState;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Facades\Utils;
 use App\Contracts\Controller;
+use App\Facades\Utils;
 use App\Models\Enums\UserState;
 use App\Models\User;
 use App\Repositories\AirlineRepository;

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Facades\Utils;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\UserState;
 use App\Models\User;
 use App\Repositories\AirlineRepository;

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Frontend/AcarsController.php
+++ b/app/Http/Controllers/Frontend/AcarsController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AcarsRepository;
 use App\Services\GeoService;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Frontend/AirportController.php
+++ b/app/Http/Controllers/Frontend/AirportController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\AirportRepository;
 use App\Repositories\FlightRepository;
 use Flash;

--- a/app/Http/Controllers/Frontend/DashboardController.php
+++ b/app/Http/Controllers/Frontend/DashboardController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Repositories\PirepRepository;
 use Illuminate\Support\Facades\Auth;
 

--- a/app/Http/Controllers/Frontend/DownloadController.php
+++ b/app/Http/Controllers/Frontend/DownloadController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\File;
 use Auth;
 use Flash;

--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Bid;
 use App\Repositories\AirlineRepository;
 use App\Repositories\AirportRepository;

--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\User;
 use Illuminate\Database\QueryException;
 use Log;

--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Frontend;
 
+use App\Contracts\Controller;
 use App\Facades\Utils;
 use App\Http\Requests\CreatePirepRequest;
 use App\Http\Requests\UpdatePirepRequest;
-use App\Contracts\Controller;
 use App\Models\Enums\PirepSource;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;

--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Frontend;
 use App\Facades\Utils;
 use App\Http\Requests\CreatePirepRequest;
 use App\Http\Requests\UpdatePirepRequest;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\PirepSource;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;

--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Facades\Utils;
 use App\Contracts\Controller;
+use App\Facades\Utils;
 use App\Models\User;
 use App\Repositories\AirlineRepository;
 use App\Repositories\AirportRepository;

--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Facades\Utils;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\User;
 use App\Repositories\AirlineRepository;
 use App\Repositories\AirportRepository;

--- a/app/Http/Controllers/Frontend/UserController.php
+++ b/app/Http/Controllers/Frontend/UserController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\Enums\UserState;
 use App\Repositories\Criteria\WhereCriteria;
 use App\Repositories\UserRepository;

--- a/app/Http/Requests/Acars/CommentRequest.php
+++ b/app/Http/Requests/Acars/CommentRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 
 /**
  * Class CommentRequest

--- a/app/Http/Requests/Acars/EventRequest.php
+++ b/app/Http/Requests/Acars/EventRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 use App\Models\Pirep;
 use Auth;
 

--- a/app/Http/Requests/Acars/FieldsRequest.php
+++ b/app/Http/Requests/Acars/FieldsRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 
 /**
  * Class PrefileRequest

--- a/app/Http/Requests/Acars/FileRequest.php
+++ b/app/Http/Requests/Acars/FileRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 use App\Models\Pirep;
 use Auth;
 

--- a/app/Http/Requests/Acars/LogRequest.php
+++ b/app/Http/Requests/Acars/LogRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 use App\Models\Pirep;
 use Auth;
 

--- a/app/Http/Requests/Acars/PositionRequest.php
+++ b/app/Http/Requests/Acars/PositionRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 use App\Models\Pirep;
 use Auth;
 

--- a/app/Http/Requests/Acars/PrefileRequest.php
+++ b/app/Http/Requests/Acars/PrefileRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 
 /**
  * Class PrefileRequest

--- a/app/Http/Requests/Acars/RouteRequest.php
+++ b/app/Http/Requests/Acars/RouteRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 use App\Models\Pirep;
 use Auth;
 

--- a/app/Http/Requests/Acars/UpdateRequest.php
+++ b/app/Http/Requests/Acars/UpdateRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Acars;
 
-use App\Interfaces\FormRequest;
+use App\Contracts\FormRequest;
 use App\Models\Pirep;
 use Auth;
 

--- a/app/Http/Resources/Response.php
+++ b/app/Http/Resources/Response.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Resources;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use Illuminate\Http\Resources\Json\Resource;
 
 /**

--- a/app/Listeners/AwardListener.php
+++ b/app/Listeners/AwardListener.php
@@ -3,7 +3,7 @@
 namespace App\Listeners;
 
 use App\Events\UserStatsChanged;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Award;
 
 /**

--- a/app/Listeners/AwardListener.php
+++ b/app/Listeners/AwardListener.php
@@ -2,8 +2,8 @@
 
 namespace App\Listeners;
 
-use App\Events\UserStatsChanged;
 use App\Contracts\Listener;
+use App\Events\UserStatsChanged;
 use App\Models\Award;
 
 /**

--- a/app/Listeners/ExpenseListener.php
+++ b/app/Listeners/ExpenseListener.php
@@ -3,7 +3,7 @@
 namespace App\Listeners;
 
 use App\Events\Expenses;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 
 /**
  * Class ExpenseListener

--- a/app/Listeners/ExpenseListener.php
+++ b/app/Listeners/ExpenseListener.php
@@ -2,8 +2,8 @@
 
 namespace App\Listeners;
 
-use App\Events\Expenses;
 use App\Contracts\Listener;
+use App\Events\Expenses;
 
 /**
  * Class ExpenseListener

--- a/app/Listeners/FinanceEvents.php
+++ b/app/Listeners/FinanceEvents.php
@@ -4,7 +4,7 @@ namespace App\Listeners;
 
 use App\Events\PirepAccepted;
 use App\Events\PirepRejected;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Services\Finance\PirepFinanceService;
 use Illuminate\Contracts\Events\Dispatcher;
 

--- a/app/Listeners/FinanceEvents.php
+++ b/app/Listeners/FinanceEvents.php
@@ -2,9 +2,9 @@
 
 namespace App\Listeners;
 
+use App\Contracts\Listener;
 use App\Events\PirepAccepted;
 use App\Events\PirepRejected;
-use App\Contracts\Listener;
 use App\Services\Finance\PirepFinanceService;
 use Illuminate\Contracts\Events\Dispatcher;
 

--- a/app/Listeners/NotificationEvents.php
+++ b/app/Listeners/NotificationEvents.php
@@ -4,7 +4,7 @@ namespace App\Listeners;
 
 use App\Events\UserRegistered;
 use App\Events\UserStateChanged;
-use App\Interfaces\Listener;
+use App\Contracts\Listener;
 use App\Models\Enums\UserState;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Mail;

--- a/app/Listeners/NotificationEvents.php
+++ b/app/Listeners/NotificationEvents.php
@@ -2,9 +2,9 @@
 
 namespace App\Listeners;
 
+use App\Contracts\Listener;
 use App\Events\UserRegistered;
 use App\Events\UserStateChanged;
-use App\Contracts\Listener;
 use App\Models\Enums\UserState;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Mail;

--- a/app/Models/Acars.php
+++ b/app/Models/Acars.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Traits\HashIdTrait;
 use App\Support\Units\Distance;
 use App\Support\Units\Fuel;

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Traits\ExpensableTrait;
 use App\Models\Traits\FilesTrait;

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Enums\JournalType;
 use App\Models\Traits\FilesTrait;
 use App\Models\Traits\JournalTrait;

--- a/app/Models/Airport.php
+++ b/app/Models/Airport.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Traits\ExpensableTrait;
 use App\Models\Traits\FilesTrait;
 

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * The Award model

--- a/app/Models/Bid.php
+++ b/app/Models/Bid.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 class Bid extends Model
 {

--- a/app/Models/Enums/AcarsType.php
+++ b/app/Models/Enums/AcarsType.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class AcarsType

--- a/app/Models/Enums/ActiveState.php
+++ b/app/Models/Enums/ActiveState.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class ActiveState

--- a/app/Models/Enums/AircraftState.php
+++ b/app/Models/Enums/AircraftState.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class AircraftState

--- a/app/Models/Enums/AircraftStatus.php
+++ b/app/Models/Enums/AircraftStatus.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class AircraftState

--- a/app/Models/Enums/AnalyticsDimensions.php
+++ b/app/Models/Enums/AnalyticsDimensions.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class AnalyticsDimensions

--- a/app/Models/Enums/AnalyticsMetrics.php
+++ b/app/Models/Enums/AnalyticsMetrics.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class AnalyticsMetrics

--- a/app/Models/Enums/Days.php
+++ b/app/Models/Enums/Days.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class Days

--- a/app/Models/Enums/ExpenseType.php
+++ b/app/Models/Enums/ExpenseType.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class ExpenseType

--- a/app/Models/Enums/FlightType.php
+++ b/app/Models/Enums/FlightType.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class FlightType

--- a/app/Models/Enums/FuelType.php
+++ b/app/Models/Enums/FuelType.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class FuelType

--- a/app/Models/Enums/JournalType.php
+++ b/app/Models/Enums/JournalType.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class JournalType

--- a/app/Models/Enums/NavaidType.php
+++ b/app/Models/Enums/NavaidType.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class NavaidType

--- a/app/Models/Enums/PirepFieldSource.php
+++ b/app/Models/Enums/PirepFieldSource.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class AcarsType

--- a/app/Models/Enums/PirepSource.php
+++ b/app/Models/Enums/PirepSource.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class PirepSource

--- a/app/Models/Enums/PirepState.php
+++ b/app/Models/Enums/PirepState.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class PirepState

--- a/app/Models/Enums/PirepStatus.php
+++ b/app/Models/Enums/PirepStatus.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Tied to the ACARS statuses/states.

--- a/app/Models/Enums/UserState.php
+++ b/app/Models/Enums/UserState.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Enums;
 
-use App\Interfaces\Enum;
+use App\Contracts\Enum;
 
 /**
  * Class UserState

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Traits\ReferenceTrait;
 
 /**

--- a/app/Models/Fare.php
+++ b/app/Models/Fare.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class Fare

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Traits\HashIdTrait;
 use App\Models\Traits\ReferenceTrait;
 use Illuminate\Support\Facades\Storage;

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Enums\Days;
 use App\Models\Traits\HashIdTrait;
 use App\Support\Units\Distance;

--- a/app/Models/FlightField.php
+++ b/app/Models/FlightField.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class FlightField

--- a/app/Models/FlightFieldValue.php
+++ b/app/Models/FlightFieldValue.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class FlightFieldValue

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -6,7 +6,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Support\Money;
 use Carbon\Carbon;
 

--- a/app/Models/JournalTransaction.php
+++ b/app/Models/JournalTransaction.php
@@ -6,7 +6,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Traits\ReferenceTrait;
 
 /**

--- a/app/Models/Ledger.php
+++ b/app/Models/Ledger.php
@@ -6,7 +6,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Support\Money;
 use Carbon\Carbon;
 

--- a/app/Models/Navdata.php
+++ b/app/Models/Navdata.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class Navdata

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class News

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepFieldSource;
 use App\Models\Enums\PirepState;

--- a/app/Models/PirepComment.php
+++ b/app/Models/PirepComment.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class PirepEvent

--- a/app/Models/PirepFare.php
+++ b/app/Models/PirepFare.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class PirepFare

--- a/app/Models/PirepField.php
+++ b/app/Models/PirepField.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class PirepField

--- a/app/Models/PirepFieldValue.php
+++ b/app/Models/PirepFieldValue.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Enums\PirepFieldSource;
 
 /**

--- a/app/Models/Rank.php
+++ b/app/Models/Rank.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class Rank

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class Setting

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Traits\ExpensableTrait;
 

--- a/app/Models/Traits/HashIdTrait.php
+++ b/app/Models/Traits/HashIdTrait.php
@@ -2,7 +2,7 @@
 
 namespace App\Models\Traits;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 use Hashids\Hashids;
 
 trait HashIdTrait

--- a/app/Models/Traits/ReferenceTrait.php
+++ b/app/Models/Traits/ReferenceTrait.php
@@ -5,13 +5,13 @@ namespace App\Models\Traits;
 /**
  * Trait ReferenceTrait
  *
- * @property \App\Interfaces\Model $ref_model
- * @property mixed                 $ref_model_id
+ * @property \App\Contracts\Model $ref_model
+ * @property mixed                $ref_model_id
  */
 trait ReferenceTrait
 {
     /**
-     * @param \App\Interfaces\Model $object
+     * @param \App\Contracts\Model $object
      *
      * @return self
      */
@@ -27,7 +27,7 @@ trait ReferenceTrait
     /**
      * Return an instance of the object or null
      *
-     * @return \App\Interfaces\Model|null
+     * @return \App\Contracts\Model|null
      */
     public function getReferencedObject()
     {

--- a/app/Models/UserAward.php
+++ b/app/Models/UserAward.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class UserAward

--- a/app/Repositories/AcarsRepository.php
+++ b/app/Repositories/AcarsRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\PirepState;

--- a/app/Repositories/AircraftRepository.php
+++ b/app/Repositories/AircraftRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Aircraft;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/AirlineRepository.php
+++ b/app/Repositories/AirlineRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Airline;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/AirportRepository.php
+++ b/app/Repositories/AirportRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Airport;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/AwardRepository.php
+++ b/app/Repositories/AwardRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Award;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/ExpenseRepository.php
+++ b/app/Repositories/ExpenseRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Expense;
 use Illuminate\Support\Collection;
 use Prettus\Repository\Contracts\CacheableInterface;

--- a/app/Repositories/FareRepository.php
+++ b/app/Repositories/FareRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Fare;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/FlightFieldRepository.php
+++ b/app/Repositories/FlightFieldRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\FlightField;
 
 /**

--- a/app/Repositories/FlightRepository.php
+++ b/app/Repositories/FlightRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Flight;
 use App\Repositories\Criteria\WhereCriteria;
 use Illuminate\Http\Request;

--- a/app/Repositories/JournalRepository.php
+++ b/app/Repositories/JournalRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Journal;
 use App\Models\JournalTransaction;
 use App\Support\Money;

--- a/app/Repositories/NavdataRepository.php
+++ b/app/Repositories/NavdataRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Navdata;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/NewsRepository.php
+++ b/app/Repositories/NewsRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\News;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/PermissionsRepository.php
+++ b/app/Repositories/PermissionsRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Permission;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/PirepFieldRepository.php
+++ b/app/Repositories/PirepFieldRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\PirepField;
 
 /**

--- a/app/Repositories/PirepRepository.php
+++ b/app/Repositories/PirepRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;
 use App\Models\User;

--- a/app/Repositories/RankRepository.php
+++ b/app/Repositories/RankRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Rank;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/RoleRepository.php
+++ b/app/Repositories/RoleRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Role;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/SettingRepository.php
+++ b/app/Repositories/SettingRepository.php
@@ -2,8 +2,8 @@
 
 namespace App\Repositories;
 
-use App\Exceptions\SettingNotFound;
 use App\Contracts\Repository;
+use App\Exceptions\SettingNotFound;
 use App\Models\Setting;
 use Illuminate\Support\Carbon;
 use Log;

--- a/app/Repositories/SettingRepository.php
+++ b/app/Repositories/SettingRepository.php
@@ -3,7 +3,7 @@
 namespace App\Repositories;
 
 use App\Exceptions\SettingNotFound;
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Setting;
 use Illuminate\Support\Carbon;
 use Log;

--- a/app/Repositories/SubfleetRepository.php
+++ b/app/Repositories/SubfleetRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Subfleet;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Repositories;
 
-use App\Interfaces\Repository;
+use App\Contracts\Repository;
 use App\Models\Enums\UserState;
 use App\Models\User;
 use App\Repositories\Criteria\WhereCriteria;

--- a/app/Services/AnalyticsService.php
+++ b/app/Services/AnalyticsService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Enums\AnalyticsDimensions;
 use DB;
 use Irazasyed\LaravelGAMP\Facades\GAMP;

--- a/app/Services/AwardService.php
+++ b/app/Services/AwardService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Support\ClassLoader;
 use Module;
 
@@ -14,7 +14,7 @@ class AwardService extends Service
     /**
      * Find any of the award classes
      *
-     * @return \App\Interfaces\Award[]
+     * @return \App\Contracts\Award[]
      */
     public function findAllAwardClasses(): array
     {

--- a/app/Services/DatabaseService.php
+++ b/app/Services/DatabaseService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Support\Database;
 use Carbon\Carbon;
 use Webpatser\Uuid\Uuid;

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services;
 
-use App\Interfaces\ImportExport;
-use App\Interfaces\Service;
+use App\Contracts\ImportExport;
+use App\Contracts\Service;
 use App\Services\ImportExport\AircraftExporter;
 use App\Services\ImportExport\AirportExporter;
 use App\Services\ImportExport\ExpenseExporter;

--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Fare;
 use App\Models\Flight;
 use App\Models\Pirep;

--- a/app/Services/FileService.php
+++ b/app/Services/FileService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\File;
 
 /**

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -3,7 +3,7 @@
 namespace App\Services\Finance;
 
 use App\Events\Expenses as ExpensesEvent;
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Enums\ExpenseType;
 use App\Models\Enums\PirepSource;
 use App\Models\Expense;

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services\Finance;
 
-use App\Events\Expenses as ExpensesEvent;
 use App\Contracts\Service;
+use App\Events\Expenses as ExpensesEvent;
 use App\Models\Enums\ExpenseType;
 use App\Models\Enums\PirepSource;
 use App\Models\Expense;

--- a/app/Services/Finance/RecurringFinanceService.php
+++ b/app/Services/Finance/RecurringFinanceService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\Finance;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Airline;
 use App\Models\Enums\ExpenseType;
 use App\Models\Expense;

--- a/app/Services/FleetService.php
+++ b/app/Services/FleetService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Flight;
 use App\Models\Rank;
 use App\Models\Subfleet;

--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services;
 
-use App\Exceptions\BidExists;
 use App\Contracts\Service;
+use App\Exceptions\BidExists;
 use App\Models\Bid;
 use App\Models\Flight;
 use App\Models\FlightFieldValue;

--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -3,7 +3,7 @@
 namespace App\Services;
 
 use App\Exceptions\BidExists;
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Bid;
 use App\Models\Flight;
 use App\Models\FlightFieldValue;

--- a/app/Services/GeoService.php
+++ b/app/Services/GeoService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Flight;

--- a/app/Services/ImportExport/AircraftExporter.php
+++ b/app/Services/ImportExport/AircraftExporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Aircraft;
 
 /**

--- a/app/Services/ImportExport/AircraftImporter.php
+++ b/app/Services/ImportExport/AircraftImporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Aircraft;
 use App\Models\Enums\AircraftState;
 use App\Models\Enums\AircraftStatus;

--- a/app/Services/ImportExport/AirportExporter.php
+++ b/app/Services/ImportExport/AirportExporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Airport;
 
 /**

--- a/app/Services/ImportExport/AirportImporter.php
+++ b/app/Services/ImportExport/AirportImporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Airport;
 
 /**

--- a/app/Services/ImportExport/ExpenseExporter.php
+++ b/app/Services/ImportExport/ExpenseExporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Aircraft;
 use App\Models\Airport;
 use App\Models\Expense;

--- a/app/Services/ImportExport/ExpenseImporter.php
+++ b/app/Services/ImportExport/ExpenseImporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Aircraft;
 use App\Models\Airport;
 use App\Models\Expense;

--- a/app/Services/ImportExport/FareExporter.php
+++ b/app/Services/ImportExport/FareExporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Fare;
 
 /**

--- a/app/Services/ImportExport/FareImporter.php
+++ b/app/Services/ImportExport/FareImporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Fare;
 
 /**

--- a/app/Services/ImportExport/FlightExporter.php
+++ b/app/Services/ImportExport/FlightExporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Enums\Days;
 use App\Models\Flight;
 

--- a/app/Services/ImportExport/FlightImporter.php
+++ b/app/Services/ImportExport/FlightImporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Airport;
 use App\Models\Enums\Days;
 use App\Models\Enums\FlightType;

--- a/app/Services/ImportExport/SubfleetExporter.php
+++ b/app/Services/ImportExport/SubfleetExporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Flight;
 use App\Models\Subfleet;
 

--- a/app/Services/ImportExport/SubfleetImporter.php
+++ b/app/Services/ImportExport/SubfleetImporter.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\ImportExport;
 
-use App\Interfaces\ImportExport;
+use App\Contracts\ImportExport;
 use App\Models\Fare;
 use App\Models\Subfleet;
 use App\Services\FareService;

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services;
 
-use App\Interfaces\ImportExport;
-use App\Interfaces\Service;
+use App\Contracts\ImportExport;
+use App\Contracts\Service;
 use App\Models\Airport;
 use App\Models\Expense;
 use App\Repositories\FlightRepository;

--- a/app/Services/Installer/MigrationService.php
+++ b/app/Services/Installer/MigrationService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\Installer;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Setting;
 use DB;
 use Log;

--- a/app/Services/Metar/AviationWeather.php
+++ b/app/Services/Metar/AviationWeather.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\Metar;
 
-use App\Interfaces\Metar;
+use App\Contracts\Metar;
 use App\Support\Http;
 use Cache;
 

--- a/app/Services/ModuleService.php
+++ b/app/Services/ModuleService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 
 /**
  * Class ModuleService

--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -7,7 +7,7 @@ use App\Events\PirepFiled;
 use App\Events\PirepRejected;
 use App\Events\UserStateChanged;
 use App\Events\UserStatsChanged;
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Acars;
 use App\Models\Bid;
 use App\Models\Enums\AcarsType;

--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -2,12 +2,12 @@
 
 namespace App\Services;
 
+use App\Contracts\Service;
 use App\Events\PirepAccepted;
 use App\Events\PirepFiled;
 use App\Events\PirepRejected;
 use App\Events\UserStateChanged;
 use App\Events\UserStatsChanged;
-use App\Contracts\Service;
 use App\Models\Acars;
 use App\Models\Bid;
 use App\Models\Enums\AcarsType;

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -2,10 +2,10 @@
 
 namespace App\Services;
 
+use App\Contracts\Service;
 use App\Events\UserRegistered;
 use App\Events\UserStateChanged;
 use App\Events\UserStatsChanged;
-use App\Contracts\Service;
 use App\Models\Enums\PirepState;
 use App\Models\Enums\UserState;
 use App\Models\Pirep;

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -5,7 +5,7 @@ namespace App\Services;
 use App\Events\UserRegistered;
 use App\Events\UserStateChanged;
 use App\Events\UserStatsChanged;
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use App\Models\Enums\PirepState;
 use App\Models\Enums\UserState;
 use App\Models\Pirep;

--- a/app/Support/Units/Altitude.php
+++ b/app/Support/Units/Altitude.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 class Altitude extends Unit

--- a/app/Support/Units/Distance.php
+++ b/app/Support/Units/Distance.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 class Distance extends Unit

--- a/app/Support/Units/Fuel.php
+++ b/app/Support/Units/Fuel.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Mass;
 
 class Fuel extends Unit

--- a/app/Support/Units/Mass.php
+++ b/app/Support/Units/Mass.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Mass as MassUnit;
 
 class Mass extends Unit

--- a/app/Support/Units/Pressure.php
+++ b/app/Support/Units/Pressure.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Pressure as PressureUnit;
 
 /**

--- a/app/Support/Units/Temperature.php
+++ b/app/Support/Units/Temperature.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Temperature as TemperatureUnit;
 
 /**

--- a/app/Support/Units/Velocity.php
+++ b/app/Support/Units/Velocity.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Velocity as VelocityUnit;
 
 /**

--- a/app/Support/Units/Volume.php
+++ b/app/Support/Units/Volume.php
@@ -2,7 +2,7 @@
 
 namespace App\Support\Units;
 
-use App\Interfaces\Unit;
+use App\Contracts\Unit;
 use PhpUnitsOfMeasure\PhysicalQuantity\Volume as VolumeUnit;
 
 /**

--- a/app/Widgets/AirspaceMap.php
+++ b/app/Widgets/AirspaceMap.php
@@ -2,7 +2,7 @@
 
 namespace App\Widgets;
 
-use App\Interfaces\Widget;
+use App\Contracts\Widget;
 
 /**
  * Show the live map in a view

--- a/app/Widgets/LatestNews.php
+++ b/app/Widgets/LatestNews.php
@@ -2,7 +2,7 @@
 
 namespace App\Widgets;
 
-use App\Interfaces\Widget;
+use App\Contracts\Widget;
 use App\Repositories\NewsRepository;
 
 /**

--- a/app/Widgets/LatestPilots.php
+++ b/app/Widgets/LatestPilots.php
@@ -2,7 +2,7 @@
 
 namespace App\Widgets;
 
-use App\Interfaces\Widget;
+use App\Contracts\Widget;
 use App\Repositories\UserRepository;
 
 /**

--- a/app/Widgets/LatestPireps.php
+++ b/app/Widgets/LatestPireps.php
@@ -2,7 +2,7 @@
 
 namespace App\Widgets;
 
-use App\Interfaces\Widget;
+use App\Contracts\Widget;
 use App\Models\Enums\PirepState;
 use App\Repositories\PirepRepository;
 

--- a/app/Widgets/LiveMap.php
+++ b/app/Widgets/LiveMap.php
@@ -2,7 +2,7 @@
 
 namespace App\Widgets;
 
-use App\Interfaces\Widget;
+use App\Contracts\Widget;
 use App\Repositories\AcarsRepository;
 use App\Services\GeoService;
 

--- a/app/Widgets/Weather.php
+++ b/app/Widgets/Weather.php
@@ -2,7 +2,7 @@
 
 namespace App\Widgets;
 
-use App\Interfaces\Widget;
+use App\Contracts\Widget;
 use App\Support\Metar;
 
 /**
@@ -22,7 +22,7 @@ class Weather extends Widget
     public function run()
     {
         /**
-         * @var \App\Interfaces\Metar
+         * @var \App\Contracts\Metar
          */
         $klass = config('phpvms.metar');
         $metar_class = new $klass();

--- a/modules/Installer/Http/Controllers/InstallerController.php
+++ b/modules/Installer/Http/Controllers/InstallerController.php
@@ -3,7 +3,7 @@
 namespace Modules\Installer\Http\Controllers;
 
 use App\Facades\Utils;
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Models\User;
 use App\Repositories\AirlineRepository;
 use App\Services\AnalyticsService;

--- a/modules/Installer/Http/Controllers/UpdaterController.php
+++ b/modules/Installer/Http/Controllers/UpdaterController.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Installer\Http\Controllers;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use App\Services\Installer\MigrationService;
 use Illuminate\Http\Request;
 use Log;

--- a/modules/Installer/Services/ConfigService.php
+++ b/modules/Installer/Services/ConfigService.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Installer\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use Illuminate\Encryption\Encrypter;
 use Log;
 use Nwidart\Modules\Support\Stub;

--- a/modules/Installer/Services/DatabaseService.php
+++ b/modules/Installer/Services/DatabaseService.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Installer\Services;
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 use Log;
 use PDO;
 

--- a/modules/Installer/Services/RequirementsService.php
+++ b/modules/Installer/Services/RequirementsService.php
@@ -3,7 +3,7 @@
 namespace Modules\Installer\Services;
 
 
-use App\Interfaces\Service;
+use App\Contracts\Service;
 
 class RequirementsService extends Service
 {

--- a/modules/Sample/Awards/SampleAward.php
+++ b/modules/Sample/Awards/SampleAward.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Sample\Awards;
 
-use App\Interfaces\Award;
+use App\Contracts\Award;
 
 /**
  * Class SampleAward

--- a/modules/Sample/Http/Controllers/Admin/AdminController.php
+++ b/modules/Sample/Http/Controllers/Admin/AdminController.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Sample\Http\Controllers\Admin;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use Illuminate\Http\Request;
 
 /**

--- a/modules/Sample/Http/Controllers/Api/SampleController.php
+++ b/modules/Sample/Http/Controllers/Api/SampleController.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Sample\Http\Controllers\Api;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use Illuminate\Http\Request;
 
 /**

--- a/modules/Sample/Http/Controllers/SampleController.php
+++ b/modules/Sample/Http/Controllers/SampleController.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Sample\Http\Controllers;
 
-use App\Interfaces\Controller;
+use App\Contracts\Controller;
 use Illuminate\Http\Request;
 
 /**

--- a/modules/Sample/Models/SampleTable.php
+++ b/modules/Sample/Models/SampleTable.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Sample\Models;
 
-use App\Interfaces\Model;
+use App\Contracts\Model;
 
 /**
  * Class SampleTable

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -15,7 +15,7 @@ class ImporterTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->importBaseClass = new \App\Interfaces\ImportExport();
+        $this->importBaseClass = new \App\Contracts\ImportExport();
         $this->importSvc = app(\App\Services\ImportService::class);
         $this->fareSvc = app(\App\Services\FareService::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -139,7 +139,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
                 $this->transformData($value);
             }
 
-            if (is_subclass_of($value, App\Interfaces\Unit::class)) {
+            if (is_subclass_of($value, App\Contracts\Unit::class)) {
                 $data[$key] = $value->__toString();
             }
 


### PR DESCRIPTION
Rather large change, but pretty simple - renamed the `App\Interfaces` namespace and all classes underneath to `App\Contracts`, to better match what they're called by Laravel