### PR TITLE
Fix issue where user stats aren't incremented on PIREP auto accept

### DIFF
--- a/app/Cron/Nightly/RecalculateStats.php
+++ b/app/Cron/Nightly/RecalculateStats.php
@@ -7,7 +7,7 @@ use App\Events\CronNightly;
 use App\Models\Enums\UserState;
 use App\Repositories\UserRepository;
 use App\Services\UserService;
-use Log;
+use Illuminate\Support\Facades\Log;
 
 /**
  * This recalculates the balances on all of the journals

--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -279,7 +279,7 @@ class PirepController extends Controller
             // Can they fly this aircraft?
             if (setting('pireps.restrict_aircraft_to_rank', false)
                 && !$this->userSvc->aircraftAllowed(Auth::user(), $pirep->aircraft_id)) {
-                Log::info('Pilot ' . Auth::user()->id . ' not allowed to fly aircraft');
+                Log::info('Pilot '.Auth::user()->id.' not allowed to fly aircraft');
                 return $this->flashError(
                     'You are not allowed to fly this aircraft!',
                     'frontend.pireps.create'
@@ -290,7 +290,7 @@ class PirepController extends Controller
             /* @noinspection NotOptimalIfConditionsInspection */
             if (setting('pireps.only_aircraft_at_dpt_airport')
                 && $pirep->aircraft_id !== $pirep->dpt_airport_id) {
-                Log::info('Aircraft ' . $pirep->aircraft_id . ' not at departure airport '.$pirep->dpt_airport_id.', erroring out');
+                Log::info('Aircraft '.$pirep->aircraft_id.' not at departure airport '.$pirep->dpt_airport_id.', erroring out');
                 return $this->flashError(
                     'This aircraft is not positioned at the departure airport!',
                     'frontend.pireps.create'

--- a/app/Listeners/BidEvents.php
+++ b/app/Listeners/BidEvents.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Contracts\Listener;
+use App\Events\PirepAccepted;
+use App\Services\PirepService;
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * Do stuff with bids - like if a PIREP is accepted, then remove the bid
+ */
+class BidEvents extends Listener
+{
+    private $pirepSvc;
+
+    /**
+     * FinanceEvents constructor.
+     *
+     * @param PirepService $pirepSvc
+     */
+    public function __construct(
+        PirepService $pirepSvc
+    ) {
+        $this->pirepSvc = $pirepSvc;
+    }
+
+    /**
+     * @param $events
+     */
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen(
+            PirepAccepted::class,
+            'App\Listeners\BidEvents@onPirepAccept'
+        );
+    }
+
+    /**
+     * When a PIREP is accepted, remove any bids
+     *
+     * @param PirepAccepted $event
+     *
+     * @throws \UnexpectedValueException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     * @throws \Prettus\Validator\Exceptions\ValidatorException
+     */
+    public function onPirepAccept(PirepAccepted $event): void
+    {
+        $this->pirepSvc->removeBid($event->pirep);
+    }
+}

--- a/app/Models/Rank.php
+++ b/app/Models/Rank.php
@@ -7,9 +7,10 @@ use App\Contracts\Model;
 /**
  * Class Rank
  *
- * @property int   hours
- * @property float manual_base_pay_rate
- * @property float acars_base_pay_rate
+ * @property string name
+ * @property int    hours
+ * @property float  manual_base_pay_rate
+ * @property float  acars_base_pay_rate
  */
 class Rank extends Model
 {
@@ -28,7 +29,6 @@ class Rank extends Model
 
     protected $casts = [
         'hours'               => 'integer',
-        'base_pay_rate'       => 'float',
         'auto_approve_acars'  => 'bool',
         'auto_approve_manual' => 'bool',
         'auto_promote'        => 'bool',

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Events\Expenses;
 use App\Events\UserStatsChanged;
 use App\Listeners\AwardListener;
+use App\Listeners\BidEvents;
 use App\Listeners\ExpenseListener;
 use App\Listeners\FinanceEvents;
 use App\Listeners\NotificationEvents;
@@ -29,6 +30,7 @@ class EventServiceProvider extends ServiceProvider
     ];
 
     protected $subscribe = [
+        BidEvents::class,
         FinanceEvents::class,
         NotificationEvents::class,
     ];

--- a/app/Services/FleetService.php
+++ b/app/Services/FleetService.php
@@ -7,9 +7,6 @@ use App\Models\Flight;
 use App\Models\Rank;
 use App\Models\Subfleet;
 
-/**
- * Class FleetService
- */
 class FleetService extends Service
 {
     /**

--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -260,7 +260,7 @@ class PirepService extends Service
 
     /**
      * @param Pirep $pirep
-     * @param int $new_state
+     * @param int   $new_state
      *
      * @throws \Exception
      *

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -325,6 +325,9 @@ class UserService extends Service
             'state'   => PirepState::ACCEPTED,
         ];
 
+        $flight_count = Pirep::where($w)->count();
+        $user->flights = $flight_count;
+
         $flight_time = Pirep::where($w)->sum('flight_time');
         $user->flight_time = $flight_time;
 

--- a/tests/PIREPTest.php
+++ b/tests/PIREPTest.php
@@ -221,6 +221,8 @@ class PIREPTest extends TestCase
         $this->assertGreaterThan($user->rank_id, $pilot->rank_id);
         $this->assertEquals($last_pirep->arr_airport_id, $pilot->curr_airport_id);
 
+        $this->assertEquals(2, $pilot->flights);
+
         //
         // Submit another PIREP, adding another 6 hours
         // it should automatically be accepted
@@ -238,6 +240,9 @@ class PIREPTest extends TestCase
         $this->pirepSvc->submit($pirep);
 
         $pilot->refresh();
+
+        $this->assertEquals(3, $pilot->flights);
+
         $latest_pirep = Pirep::where('id', $pilot->last_pirep_id)->first();
 
         // Make sure PIREP was auto updated


### PR DESCRIPTION
Addresses #332

* Fix for PIREP `accept()` call not incrementing user stats
* Moved the bids removal into a listener to decouple it from the accept code directly