### PR TITLE
Flight search for departure/arrival airports not using column names

### DIFF
--- a/app/Contracts/Controller.php
+++ b/app/Contracts/Controller.php
@@ -12,7 +12,9 @@ use Illuminate\Http\Request;
  */
 abstract class Controller extends \Illuminate\Routing\Controller
 {
-    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+    use AuthorizesRequests;
+    use DispatchesJobs;
+    use ValidatesRequests;
 
     /**
      * Write a error to the flash and redirect the user to a route

--- a/app/Events/BaseEvent.php
+++ b/app/Events/BaseEvent.php
@@ -8,5 +8,7 @@ use Illuminate\Queue\SerializesModels;
 
 class BaseEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
 }

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -13,9 +13,6 @@ use Illuminate\Support\Facades\Auth;
 use Prettus\Repository\Criteria\RequestCriteria;
 use Prettus\Repository\Exceptions\RepositoryException;
 
-/**
- * Class FlightController
- */
 class FlightController extends Controller
 {
     private $flightRepo;

--- a/app/Repositories/FlightRepository.php
+++ b/app/Repositories/FlightRepository.php
@@ -96,12 +96,20 @@ class FlightRepository extends Repository implements CacheableInterface
             $where['route_code'] = $request->route_code;
         }
 
+        if ($request->filled('dpt_airport_id')) {
+            $where['dpt_airport_id'] = strtoupper($request->dpt_airport_id);
+        }
+
         if ($request->filled('dep_icao')) {
-            $where['dpt_airport_id'] = $request->dep_icao;
+            $where['dpt_airport_id'] = strtoupper($request->dep_icao);
+        }
+
+        if ($request->filled('arr_airport_id')) {
+            $where['arr_airport_id'] = strtoupper($request->arr_airport_id);
         }
 
         if ($request->filled('arr_icao')) {
-            $where['arr_airport_id'] = $request->arr_icao;
+            $where['arr_airport_id'] = strtoupper($request->arr_icao);
         }
 
         // Distance, greater than

--- a/modules/Importer/Services/BaseImporter.php
+++ b/modules/Importer/Services/BaseImporter.php
@@ -13,8 +13,10 @@ use Modules\Importer\Utils\ImporterDB;
 
 abstract class BaseImporter implements ShouldQueue
 {
-    use LoggerTrait, Dispatchable, InteractsWithQueue, Queueable;
-
+    use LoggerTrait;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
     /**
      * Holds the connection to the legacy database
      *

--- a/resources/views/admin/flights/search.blade.php
+++ b/resources/views/admin/flights/search.blade.php
@@ -7,11 +7,11 @@
                 {{ Form::label('flight_number', 'Flight Number:') }}
                 {{ Form::text('flight_number', null, ['class' => 'form-control']) }}
                 &nbsp;
-                {{ Form::label('dep_icao', 'Departure:') }}
-                {{ Form::select('dep_icao', $airports, null , ['class' => 'form-control']) }}
+                {{ Form::label('dpt_airport_id', 'Departure:') }}
+                {{ Form::select('dpt_airport_id', $airports, null , ['class' => 'form-control']) }}
                 &nbsp;
-                {{ Form::label('arr_icao', 'Arrival:') }}
-                {{ Form::select('arr_icao', $airports, null , ['class' => 'form-control']) }}
+                {{ Form::label('arr_airport_id', 'Arrival:') }}
+                {{ Form::select('arr_airport_id', $airports, null , ['class' => 'form-control']) }}
                 &nbsp;
                 {{ Form::submit('find', ['class' => 'btn btn-primary']) }}
                 &nbsp;

--- a/tests/FlightTest.php
+++ b/tests/FlightTest.php
@@ -342,6 +342,26 @@ class FlightTest extends TestCase
         $this->assertEquals($flight->id, $body['data'][0]['id']);
     }
 
+    public function testFlightSearchApiDepartureAirport()
+    {
+        $this->user = factory(App\Models\User::class)->create();
+        factory(App\Models\Flight::class, 10)->create([
+            'airline_id' => $this->user->airline_id,
+        ]);
+
+        $flight = factory(App\Models\Flight::class)->create([
+            'airline_id'     => $this->user->airline_id,
+            'dpt_airport_id' => 'KAUS',
+        ]);
+
+        $query = 'dpt_airport_id=kaus';
+        $req = $this->get('/api/flights/search?'.$query);
+        $body = $req->json();
+
+        $this->assertCount(1, $body['data']);
+        $this->assertEquals($flight->id, $body['data'][0]['id']);
+    }
+
     public function testFlightSearchApiDistance()
     {
         $total_flights = 10;


### PR DESCRIPTION
Allow the use of `dpt_airport_id` and `arr_airport_id` in the flight search too