### PR TITLE
Set a default model value for airports on PIREP

### DIFF
--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -437,9 +437,9 @@ class Pirep extends Model
     public function dpt_airport()
     {
         return $this->belongsTo(Airport::class, 'dpt_airport_id')->withDefault([
-            'id'   => $this->attributes['dep_airport_id'],
-            'icao' => $this->attributes['dep_airport_id'],
-            'name' => $this->attributes['dep_airport_id'],
+            'id'   => $this->attributes['dpt_airport_id'],
+            'icao' => $this->attributes['dpt_airport_id'],
+            'name' => $this->attributes['dpt_airport_id'],
             'lat'  => 0,
             'lon'  => 0,
         ]);

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -420,13 +420,16 @@ class Pirep extends Model
 
     public function arr_airport()
     {
-        return $this->belongsTo(Airport::class, 'arr_airport_id')->withDefault([
-            'id'   => $this->attributes['arr_airport_id'],
-            'icao' => $this->attributes['arr_airport_id'],
-            'name' => $this->attributes['arr_airport_id'],
-            'lat'  => 0,
-            'lon'  => 0,
-        ]);
+        return $this->belongsTo(Airport::class, 'arr_airport_id')
+            ->withDefault(function ($model) {
+                if (!empty($this->attributes['arr_airport_id'])) {
+                    $model->id = $this->attributes['arr_airport_id'];
+                    $model->icao = $this->attributes['arr_airport_id'];
+                    $model->name = $this->attributes['arr_airport_id'];
+                }
+
+                return $model;
+            });
     }
 
     public function alt_airport()
@@ -436,13 +439,16 @@ class Pirep extends Model
 
     public function dpt_airport()
     {
-        return $this->belongsTo(Airport::class, 'dpt_airport_id')->withDefault([
-            'id'   => $this->attributes['dpt_airport_id'],
-            'icao' => $this->attributes['dpt_airport_id'],
-            'name' => $this->attributes['dpt_airport_id'],
-            'lat'  => 0,
-            'lon'  => 0,
-        ]);
+        return $this->belongsTo(Airport::class, 'dpt_airport_id')
+            ->withDefault(function ($model) {
+                if (!empty($this->attributes['dpt_airport_id'])) {
+                    $model->id = $this->attributes['dpt_airport_id'];
+                    $model->icao = $this->attributes['dpt_airport_id'];
+                    $model->name = $this->attributes['dpt_airport_id'];
+                }
+
+                return $model;
+            });
     }
 
     public function comments()

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -420,7 +420,13 @@ class Pirep extends Model
 
     public function arr_airport()
     {
-        return $this->belongsTo(Airport::class, 'arr_airport_id');
+        return $this->belongsTo(Airport::class, 'arr_airport_id')->withDefault([
+            'id'   => $this->attributes['arr_airport_id'],
+            'icao' => $this->attributes['arr_airport_id'],
+            'name' => $this->attributes['arr_airport_id'],
+            'lat'  => 0,
+            'lon'  => 0,
+        ]);
     }
 
     public function alt_airport()
@@ -430,7 +436,13 @@ class Pirep extends Model
 
     public function dpt_airport()
     {
-        return $this->belongsTo(Airport::class, 'dpt_airport_id');
+        return $this->belongsTo(Airport::class, 'dpt_airport_id')->withDefault([
+            'id'   => $this->attributes['dep_airport_id'],
+            'icao' => $this->attributes['dep_airport_id'],
+            'name' => $this->attributes['dep_airport_id'],
+            'lat'  => 0,
+            'lon'  => 0,
+        ]);
     }
 
     public function comments()

--- a/app/Repositories/AirportRepository.php
+++ b/app/Repositories/AirportRepository.php
@@ -7,9 +7,6 @@ use App\Models\Airport;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;
 
-/**
- * Class AirportRepository
- */
 class AirportRepository extends Repository implements CacheableInterface
 {
     use CacheableRepository;
@@ -22,6 +19,32 @@ class AirportRepository extends Repository implements CacheableInterface
     public function model()
     {
         return Airport::class;
+    }
+
+    /**
+     * Returns an airport, or a empty model with just some default values
+     *
+     * @param       $id
+     * @param array $columns
+     *
+     * @return \App\Models\Airport|mixed|null
+     */
+    public function findWithoutFail($id, array $columns = ['*'])
+    {
+        $value = parent::findWithoutFail($id, $columns);
+        if (!empty($value)) {
+            return $value;
+        }
+
+        // Not found, return a 'generic' airport object
+        return new Airport([
+            'id'   => $id,
+            'icao' => $id,
+            'iata' => $id,
+            'name' => $id,
+            'lat'  => 0,
+            'lon'  => 0,
+        ]);
     }
 
     /**

--- a/app/Repositories/AirportRepository.php
+++ b/app/Repositories/AirportRepository.php
@@ -22,36 +22,10 @@ class AirportRepository extends Repository implements CacheableInterface
     }
 
     /**
-     * Returns an airport, or a empty model with just some default values
-     *
-     * @param       $id
-     * @param array $columns
-     *
-     * @return \App\Models\Airport|mixed|null
-     */
-    public function findWithoutFail($id, array $columns = ['*'])
-    {
-        $value = parent::findWithoutFail($id, $columns);
-        if (!empty($value)) {
-            return $value;
-        }
-
-        // Not found, return a 'generic' airport object
-        return new Airport([
-            'id'   => $id,
-            'icao' => $id,
-            'iata' => $id,
-            'name' => $id,
-            'lat'  => 0,
-            'lon'  => 0,
-        ]);
-    }
-
-    /**
      * Return the list of airports formatted for a select box
      *
-     * @param mixed $add_blank
-     * @param mixed $only_hubs
+     * @param bool $add_blank
+     * @param bool $only_hubs
      *
      * @return array
      */

--- a/app/Services/GeoService.php
+++ b/app/Services/GeoService.php
@@ -231,23 +231,13 @@ class GeoService extends Service
             ]);
         }*/
 
-        // If there is a position update from ACARS, show where it is
-        // Otherwise, just assume it's at the arrival airport currently
-        if ($pirep->position) {
-            $position = [
-                'lat' => $pirep->position->lat,
-                'lon' => $pirep->position->lon,
-            ];
-        } else {
-            // if arrived, show it being at the arrival airport
-            $position = [
-                'lat' => $pirep->arr_airport->lat,
-                'lon' => $pirep->arr_airport->lon,
-            ];
-        }
-
         return [
-            'position' => $position,
+            // If there is a position update from ACARS, show where it is
+            // Otherwise, just assume it's at the arrival airport currently
+            'position' => [
+                'lat' => optional($pirep->position)->lat ?? $pirep->arr_airport->lat,
+                'lon' => optional($pirep->position)->lon ?? $pirep->arr_airport->lon,
+            ],
             'line'     => $route->getLine(),
             'points'   => $route->getPoints(),
             'airports' => [

--- a/app/Services/ImportExport/FlightImporter.php
+++ b/app/Services/ImportExport/FlightImporter.php
@@ -108,14 +108,6 @@ class FlightImporter extends ImportExport
 
         // Any specific transformations
 
-        // Check/calculate the distance
-        if (empty($row['distance'])) {
-            $row['distance'] = $this->airportSvc->calculateDistance(
-                $row['dpt_airport'],
-                $row['arr_airport']
-            );
-        }
-
         // Check for a valid value
         $flight_type = $row['flight_type'];
         if (!array_key_exists($flight_type, FlightType::labels())) {
@@ -137,6 +129,14 @@ class FlightImporter extends ImportExport
         $this->processAirport($row['arr_airport']);
         if ($row['alt_airport']) {
             $this->processAirport($row['alt_airport']);
+        }
+
+        // Check/calculate the distance
+        if (empty($row['distance'])) {
+            $row['distance'] = $this->airportSvc->calculateDistance(
+                $row['dpt_airport'],
+                $row['arr_airport']
+            );
         }
 
         $this->processSubfleets($flight, $row['subfleets']);


### PR DESCRIPTION
If an airport isn't added, PIREP can error out. This makes sure there's at least a default model if it's not found