### PR TITLE
Importing not updating existing items #486

### DIFF
--- a/app/Services/ImportExport/AircraftImporter.php
+++ b/app/Services/ImportExport/AircraftImporter.php
@@ -69,7 +69,7 @@ class AircraftImporter extends ImportExport
 
         // Set a default status
         $row['status'] = trim($row['status']);
-        if ($row['status'] === null || $row['status'] === '') {
+        if (empty($row['status'])) {
             $row['status'] = AircraftStatus::ACTIVE;
         }
 
@@ -77,12 +77,10 @@ class AircraftImporter extends ImportExport
         $row['state'] = AircraftState::PARKED;
 
         // Try to add or update
-        $aircraft = Aircraft::firstOrNew([
-            'registration' => $row['registration'],
-        ], $row);
-
         try {
-            $aircraft->save();
+            Aircraft::updateOrCreate([
+                'registration' => $row['registration'],
+            ], $row);
         } catch (\Exception $e) {
             $this->errorLog('Error in row '.$index.': '.$e->getMessage());
             return false;

--- a/app/Services/ImportExport/AirportImporter.php
+++ b/app/Services/ImportExport/AirportImporter.php
@@ -45,12 +45,10 @@ class AirportImporter extends ImportExport
         $row['id'] = $row['icao'];
         $row['hub'] = get_truth_state($row['hub']);
 
-        $airport = Airport::firstOrNew([
-            'id' => $row['icao'],
-        ], $row);
-
         try {
-            $airport->save();
+            $airport = Airport::updateOrCreate([
+                'id' => $row['icao'],
+            ], $row);
         } catch (\Exception $e) {
             $this->errorLog('Error in row '.$index.': '.$e->getMessage());
             return false;

--- a/app/Services/ImportExport/ExpenseImporter.php
+++ b/app/Services/ImportExport/ExpenseImporter.php
@@ -7,7 +7,7 @@ use App\Models\Aircraft;
 use App\Models\Airport;
 use App\Models\Expense;
 use App\Models\Subfleet;
-use Log;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Import expenses
@@ -53,12 +53,10 @@ class ExpenseImporter extends ImportExport
             $row['active'] = true;
         }
 
-        $expense = Expense::firstOrNew([
-            'name' => $row['name'],
-        ], $row);
-
         try {
-            $expense->save();
+            $expense = Expense::updateOrCreate([
+                'name' => $row['name'],
+            ], $row);
         } catch (\Exception $e) {
             $this->errorLog('Error in row '.$index.': '.$e->getMessage());
             return false;

--- a/app/Services/ImportExport/FareImporter.php
+++ b/app/Services/ImportExport/FareImporter.php
@@ -36,13 +36,11 @@ class FareImporter extends ImportExport
      */
     public function import(array $row, $index): bool
     {
-        // Try to add or update
-        $fare = Fare::firstOrNew([
-            'code' => $row['code'],
-        ], $row);
-
         try {
-            $fare->save();
+            // Try to add or update
+            $fare = Fare::updateOrCreate([
+                'code' => $row['code'],
+            ], $row);
         } catch (\Exception $e) {
             $this->errorLog('Error in row '.$index.': '.$e->getMessage());
             return false;

--- a/app/Services/ImportExport/FlightImporter.php
+++ b/app/Services/ImportExport/FlightImporter.php
@@ -111,7 +111,7 @@ class FlightImporter extends ImportExport
         // Check for a valid value
         $flight_type = $row['flight_type'];
         if (!array_key_exists($flight_type, FlightType::labels())) {
-            $flight_type = 'J';
+            $flight_type = FlightType::SCHED_PAX;
         }
 
         $flight->setAttribute('flight_type', $flight_type);
@@ -216,7 +216,7 @@ class FlightImporter extends ImportExport
         $count = 0;
         $subfleets = $this->parseMultiColumnValues($col);
         foreach ($subfleets as $subfleet_type) {
-            $subfleet = Subfleet::firstOrCreate(
+            $subfleet = Subfleet::updateOrCreate(
                 ['type' => $subfleet_type],
                 ['name' => $subfleet_type]
             );
@@ -246,7 +246,7 @@ class FlightImporter extends ImportExport
                 $fare_attributes = [];
             }
 
-            $fare = Fare::firstOrCreate(['code' => $fare_code], ['name' => $fare_code]);
+            $fare = Fare::updateOrCreate(['code' => $fare_code], ['name' => $fare_code]);
             $this->fareSvc->setForFlight($flight, $fare, $fare_attributes);
         }
     }

--- a/app/Services/ImportExport/SubfleetImporter.php
+++ b/app/Services/ImportExport/SubfleetImporter.php
@@ -48,12 +48,10 @@ class SubfleetImporter extends ImportExport
         $airline = $this->getAirline($row['airline']);
         $row['airline_id'] = $airline->id;
 
-        $subfleet = Subfleet::firstOrNew([
-            'type' => $row['type'],
-        ], $row);
-
         try {
-            $subfleet->save();
+            $subfleet = Subfleet::updateOrCreate([
+                'type' => $row['type'],
+            ], $row);
         } catch (\Exception $e) {
             $this->errorLog('Error in row '.$index.': '.$e->getMessage());
             return false;
@@ -80,7 +78,7 @@ class SubfleetImporter extends ImportExport
                 $fare_attributes = [];
             }
 
-            $fare = Fare::firstOrCreate(['code' => $fare_code], ['name' => $fare_code]);
+            $fare = Fare::updateOrCreate(['code' => $fare_code], ['name' => $fare_code]);
             $this->fareSvc->setForSubfleet($subfleet, $fare, $fare_attributes);
         }
     }

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -3,6 +3,7 @@
 use App\Contracts\ImportExport;
 use App\Models\Aircraft;
 use App\Models\Airport;
+use App\Models\Enums\AircraftStatus;
 use App\Models\Enums\Days;
 use App\Models\Enums\ExpenseType;
 use App\Models\Enums\FlightType;
@@ -583,7 +584,20 @@ class ImporterTest extends TestCase
         $this->assertEquals('A320-211', $aircraft->name);
         $this->assertEquals('N309US', $aircraft->registration);
         $this->assertEquals(null, $aircraft->zfw);
-        $this->assertEquals('A', $aircraft->status);
+        $this->assertEquals(AircraftStatus::ACTIVE, $aircraft->status);
+
+        // Now try importing the updated file, the status for the aircraft should change
+        // to being stored
+
+        $file_path = base_path('tests/data/aircraft-update.csv');
+        $status = $this->importSvc->importAircraft($file_path);
+        $this->assertCount(1, $status['success']);
+
+        $aircraft = Aircraft::where([
+            'registration' => 'N309US',
+        ])->first();
+
+        $this->assertEquals(AircraftStatus::STORED, $aircraft->status);
     }
 
     /**

--- a/tests/data/aircraft-update.csv
+++ b/tests/data/aircraft-update.csv
@@ -1,0 +1,3 @@
+subfleet,iata, icao, name,registration,hex_code,zfw,status
+A32X,A320,320,A320-211,N309US,,,S
+74X,747 400, ,,


### PR DESCRIPTION
Using `firstOrNew` instead of `updateOrCreate` when creating/importing the models was causing the rows to not be updated for the 'simple' imports.