### PR TITLE
New subfleet not being attached to an airline on import #479

### DIFF
--- a/app/Services/ImportExport/AircraftImporter.php
+++ b/app/Services/ImportExport/AircraftImporter.php
@@ -4,6 +4,7 @@ namespace App\Services\ImportExport;
 
 use App\Contracts\ImportExport;
 use App\Models\Aircraft;
+use App\Models\Airline;
 use App\Models\Enums\AircraftState;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Subfleet;
@@ -32,7 +33,8 @@ class AircraftImporter extends ImportExport
     ];
 
     /**
-     * Find the subfleet specified, or just create it on the fly
+     * Find the subfleet specified, or just create it on the fly and attach it to the
+     * first airline that's been found
      *
      * @param $type
      *
@@ -40,11 +42,12 @@ class AircraftImporter extends ImportExport
      */
     protected function getSubfleet($type)
     {
-        $subfleet = Subfleet::firstOrCreate([
+        return Subfleet::firstOrCreate([
             'type' => $type,
-        ], ['name' => $type]);
-
-        return $subfleet;
+        ], [
+            'name'       => $type,
+            'airline_id' => Airline::where('active', true)->first()->id,
+        ]);
     }
 
     /**

--- a/resources/views/admin/subfleets/table.blade.php
+++ b/resources/views/admin/subfleets/table.blade.php
@@ -15,7 +15,7 @@
                 {{ $subfleet->name }}
                 </a>
             </td>
-            <td>{{ $subfleet->airline->name }}</td>
+            <td>{{ optional($subfleet->airline)->name }}</td>
             <td>{{ $subfleet->type }}</td>
             <td>{{ $subfleet->aircraft->count() }}</td>
             <td class="text-right">

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -580,7 +580,6 @@ class ImporterTest extends TestCase
 
         $this->assertNotNull($aircraft);
         $this->assertNotNull($aircraft->hex_code);
-        //$this->assertEquals($subfleet->id, $aircraft->id);
         $this->assertNotNull($aircraft->subfleet);
         $this->assertNotNull($aircraft->subfleet->airline);
         $this->assertEquals('A32X', $aircraft->subfleet->type);

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -564,7 +564,8 @@ class ImporterTest extends TestCase
      */
     public function testAircraftImporter(): void
     {
-        $subfleet = factory(App\Models\Subfleet::class)->create(['type' => 'A32X']);
+        factory(App\Models\Airline::class)->create();
+        // $subfleet = factory(App\Models\Subfleet::class)->create(['type' => 'A32X']);
 
         $file_path = base_path('tests/data/aircraft.csv');
         $status = $this->importSvc->importAircraft($file_path);
@@ -579,8 +580,10 @@ class ImporterTest extends TestCase
 
         $this->assertNotNull($aircraft);
         $this->assertNotNull($aircraft->hex_code);
-        $this->assertEquals($subfleet->id, $aircraft->id);
-        $this->assertEquals($subfleet->type, $aircraft->subfleet->type);
+        //$this->assertEquals($subfleet->id, $aircraft->id);
+        $this->assertNotNull($aircraft->subfleet);
+        $this->assertNotNull($aircraft->subfleet->airline);
+        $this->assertEquals('A32X', $aircraft->subfleet->type);
         $this->assertEquals('A320-211', $aircraft->name);
         $this->assertEquals('N309US', $aircraft->registration);
         $this->assertEquals(null, $aircraft->zfw);


### PR DESCRIPTION
When aircraft are being imported, the subfleet is created on the fly, but the reference to the airline is left out (the DB column is nullable). For now, just attach the first airline. Modify the test to not create the subfleet ahead of time, only an airline.

Also call the airline name, etc using `optional()`

closes  #479