### PR TITLE
Error page not showing when database isn't configured

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -151,6 +151,8 @@ if (!function_exists('setting')) {
      * @param       $key
      * @param mixed $default
      *
+     * @throws \Exception
+     *
      * @return mixed|null
      */
     function setting($key, $default = null)
@@ -160,6 +162,8 @@ if (!function_exists('setting')) {
         try {
             $value = $settingRepo->retrieve($key);
         } catch (SettingNotFound $e) {
+            return $default;
+        } catch (Exception $e) {
             return $default;
         }
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -19,5 +19,5 @@ Options -Indexes
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^ index.php [L]
+    RewriteRule ^ /index.php [L]
 </IfModule>


### PR DESCRIPTION
Can't replicate #511 but did find an issue with error pages not showing if database, etc, isn't setup yet, since it can't find the default theme.

refs #511  