### PR TITLE
Use optional() around the airport fields

### DIFF
--- a/app/Services/GeoService.php
+++ b/app/Services/GeoService.php
@@ -291,17 +291,17 @@ class GeoService extends Service
         $route = new GeoJson();
 
         //# Departure Airport
-        $route->addPoint($flight->dpt_airport->lat, $flight->dpt_airport->lon, [
-            'name'  => $flight->dpt_airport->icao,
-            'popup' => $flight->dpt_airport->full_name,
+        $route->addPoint(optional($flight->dpt_airport)->lat, optional($flight->dpt_airport)->lon, [
+            'name'  => $flight->dpt_airport_id,
+            'popup' => optional($flight->dpt_airport)->full_name,
             'icon'  => 'airport',
         ]);
 
         if ($flight->route) {
             $all_route_points = $this->getCoordsFromRoute(
-                $flight->dpt_airport->icao,
-                $flight->arr_airport->icao,
-                [$flight->dpt_airport->lat, $flight->dpt_airport->lon],
+                $flight->dpt_airport_id,
+                $flight->arr_airport_id,
+                [optional($flight->dpt_airport)->lat, optional($flight->dpt_airport)->lon],
                 $flight->route
             );
 
@@ -315,9 +315,9 @@ class GeoService extends Service
             }
         }
 
-        $route->addPoint($flight->arr_airport->lat, $flight->arr_airport->lon, [
-            'name'  => $flight->arr_airport->icao,
-            'popup' => $flight->arr_airport->full_name,
+        $route->addPoint(optional($flight->arr_airport)->lat, optional($flight->arr_airport)->lon, [
+            'name'  => $flight->arr_airport_id,
+            'popup' => optional($flight->arr_airport)->full_name,
             'icon'  => 'airport',
         ]);
 
@@ -342,9 +342,9 @@ class GeoService extends Service
         /*
          * PLANNED ROUTE
          */
-        $planned->addPoint($pirep->dpt_airport->lat, $pirep->dpt_airport->lon, [
-            'name'  => $pirep->dpt_airport->icao,
-            'popup' => $pirep->dpt_airport->full_name,
+        $planned->addPoint(optional($pirep->dpt_airport)->lat, optional($pirep->dpt_airport)->lon, [
+            'name'  => $pirep->dpt_airport_id,
+            'popup' => optional($pirep->dpt_airport)->full_name,
         ]);
 
         $planned_route = $this->acarsRepo->forPirep($pirep->id, AcarsType::ROUTE);
@@ -355,9 +355,9 @@ class GeoService extends Service
             ]);
         }
 
-        $planned->addPoint($pirep->arr_airport->lat, $pirep->arr_airport->lon, [
-            'name'  => $pirep->arr_airport->icao,
-            'popup' => $pirep->arr_airport->full_name,
+        $planned->addPoint(optional($pirep->arr_airport)->lat, optional($pirep->arr_airport)->lon, [
+            'name'  => $pirep->arr_airport_id,
+            'popup' => optional($pirep->arr_airport)->full_name,
             'icon'  => 'airport',
         ]);
 

--- a/app/Services/GeoService.php
+++ b/app/Services/GeoService.php
@@ -293,7 +293,7 @@ class GeoService extends Service
         //# Departure Airport
         $route->addPoint(optional($flight->dpt_airport)->lat, optional($flight->dpt_airport)->lon, [
             'name'  => $flight->dpt_airport_id,
-            'popup' => optional($flight->dpt_airport)->full_name,
+            'popup' => optional($flight->dpt_airport)->full_name ?? $flight->dpt_airport_id,
             'icon'  => 'airport',
         ]);
 
@@ -317,7 +317,7 @@ class GeoService extends Service
 
         $route->addPoint(optional($flight->arr_airport)->lat, optional($flight->arr_airport)->lon, [
             'name'  => $flight->arr_airport_id,
-            'popup' => optional($flight->arr_airport)->full_name,
+            'popup' => optional($flight->arr_airport)->full_name ?? $flight->arr_airport_id,
             'icon'  => 'airport',
         ]);
 
@@ -344,7 +344,7 @@ class GeoService extends Service
          */
         $planned->addPoint(optional($pirep->dpt_airport)->lat, optional($pirep->dpt_airport)->lon, [
             'name'  => $pirep->dpt_airport_id,
-            'popup' => optional($pirep->dpt_airport)->full_name,
+            'popup' => optional($pirep->dpt_airport)->full_name ?? $pirep->dpt_airport_id,
         ]);
 
         $planned_route = $this->acarsRepo->forPirep($pirep->id, AcarsType::ROUTE);
@@ -357,7 +357,7 @@ class GeoService extends Service
 
         $planned->addPoint(optional($pirep->arr_airport)->lat, optional($pirep->arr_airport)->lon, [
             'name'  => $pirep->arr_airport_id,
-            'popup' => optional($pirep->arr_airport)->full_name,
+            'popup' => optional($pirep->arr_airport)->full_name ?? $pirep->arr_airport_id,
             'icon'  => 'airport',
         ]);
 

--- a/resources/views/admin/flights/show_fields.blade.php
+++ b/resources/views/admin/flights/show_fields.blade.php
@@ -5,7 +5,7 @@
       <h3 class="box-title">{{ Form::label('dpt_airport_id', 'Dep ICAO') }}</h3>
     </div>
     <div class="box-body"><p class="lead">
-        {{ $flight->dpt_airport->icao }} - {{ $flight->dpt_airport->name }}
+        {{ $flight->dpt_airport_id }} - {{ optional($flight->dpt_airport)->name }}
       </p></div>
   </div>
 </div>
@@ -17,7 +17,7 @@
       <h3 class="box-title">{{ Form::label('arr_airport_id', 'Arrival ICAO') }}</h3>
     </div>
     <div class="box-body"><p class="lead">
-        {{ $flight->arr_airport->icao }} - {{ $flight->arr_airport->name }}
+        {{ $flight->arr_airport_id }} - {{ optional($flight->arr_airport)->name }}
       </p>
     </div>
   </div>
@@ -43,7 +43,7 @@
       @if($flight->alt_airport_id)
         <div class="form-group">
           {{ Form::label('alt_airport_id', 'Alt Airport Id:') }}
-          <p>{{ $flight->alt_airport->icao }}</p>
+          <p>{{ $flight->alt_airport_id }}</p>
         </div>
     @endif
 

--- a/resources/views/admin/flights/table.blade.php
+++ b/resources/views/admin/flights/table.blade.php
@@ -19,11 +19,11 @@
             {{$flight->ident}}
           </a>
         </td>
-        <td>{{ $flight->dpt_airport->icao }}</td>
+        <td>{{ $flight->dpt_airport_id }}</td>
         <td>
-          {{ $flight->arr_airport->icao }}
+          {{ $flight->arr_airport_id }}
           @if($flight->alt_airport)
-            (Alt: {{ $flight->alt_airport->icao }})
+            (Alt: {{ $flight->alt_airport_id }})
           @endif
         </td>
         {{--<td>{{ $flight->route }}</td>--}}

--- a/resources/views/layouts/default/airports/show.blade.php
+++ b/resources/views/layouts/default/airports/show.blade.php
@@ -58,9 +58,9 @@
                   {{ $flight->ident }}
                 </a>
               </td>
-              <td class="text-left">{{ $flight->dpt_airport->name }}
+              <td class="text-left">{{ optional($flight->dpt_airport)->name }}
                 (<a href="{{route('frontend.airports.show',
-                         ['id'=>$flight->dpt_airport->icao])}}">{{$flight->dpt_airport->icao}}</a>)
+                         ['id' => $flight->dpt_airport_id])}}">{{$flight->dpt_airport_id}}</a>)
               </td>
               <td>{{ $flight->dpt_time }}</td>
               <td>{{ $flight->arr_time }}</td>

--- a/resources/views/layouts/default/flights/show.blade.php
+++ b/resources/views/layouts/default/flights/show.blade.php
@@ -15,10 +15,10 @@
             <tr>
               <td>@lang('common.departure')</td>
               <td>
-                {{ $flight->dpt_airport->name }}
+                {{ optional($flight->dpt_airport)->name ?? $flight->dpt_airport_id }}
                 (<a href="{{route('frontend.airports.show', [
-                            'id' => $flight->dpt_airport->icao
-                            ])}}">{{$flight->dpt_airport->icao}}</a>)
+                            'id' => $flight->dpt_airport_id
+                            ])}}">{{$flight->dpt_airport_id}}</a>)
                 @ {{ $flight->dpt_time }}
               </td>
             </tr>
@@ -26,20 +26,20 @@
             <tr>
               <td>@lang('common.arrival')</td>
               <td>
-                {{ $flight->arr_airport->name }}
+                {{ optional($flight->arr_airport)->name ?? $flight->arr_airport_id }}
                 (<a href="{{route('frontend.airports.show', [
-                            'id' => $flight->arr_airport->icao
-                            ])}}">{{$flight->arr_airport->icao}}</a>)
+                            'id' => $flight->arr_airport_id
+                            ])}}">{{$flight->arr_airport_id }}</a>)
                 @ {{ $flight->arr_time }}</td>
             </tr>
             @if($flight->alt_airport_id)
               <tr>
                 <td>@lang('flights.alternateairport')</td>
                 <td>
-                  {{ $flight->alt_airport->name }}
+                  {{ optional($flight->alt_airport)->name ?? $flight->alt_airport_id }}
                   (<a href="{{route('frontend.airports.show', [
-                            'id' => $flight->alt_airport->icao
-                            ])}}">{{$flight->alt_airport->icao}}</a>)
+                            'id' => $flight->alt_airport_id
+                            ])}}">{{$flight->alt_airport_id}}</a>)
                 </td>
               </tr>
             @endif

--- a/resources/views/layouts/default/flights/table.blade.php
+++ b/resources/views/layouts/default/flights/table.blade.php
@@ -17,7 +17,7 @@
                "x-saved-class" is the class to add/remove if the bid exists or not
                If you change it, remember to change it in the in-array line as well
           --}}
-          @if (!setting('pilots.only_flights_from_current') || $flight->dpt_airport->icao == Auth::user()->current_airport->icao)
+          @if (!setting('pilots.only_flights_from_current') || $flight->dpt_airport_id == Auth::user()->current_airport->icao)
             <button class="btn btn-round btn-icon btn-icon-mini save_flight
                            {{ in_array($flight->id, $saved, true) ? 'btn-info':'' }}"
                     x-id="{{ $flight->id }}"
@@ -33,17 +33,17 @@
         <div class="col-sm-7">
           {{--<table class="table-condensed"></table>--}}
           <span class="title">{{ strtoupper(__('flights.dep')) }}&nbsp;</span>
-          {{ $flight->dpt_airport->name }}
+          {{ optional($flight->dpt_airport)->name ?? $flight->dpt_airport_id }}
           (<a href="{{route('frontend.airports.show', [
-                'id' => $flight->dpt_airport->icao
-              ])}}">{{$flight->dpt_airport->icao}}</a>)
+                'id' => $flight->dpt_airport_id
+              ])}}">{{$flight->dpt_airport_id}}</a>)
           @if($flight->dpt_time), {{ $flight->dpt_time }}@endif
           <br/>
           <span class="title">{{ strtoupper(__('flights.arr')) }}&nbsp;</span>
-          {{ $flight->arr_airport->name }}
+          {{ optional($flight->arr_airport)->name ?? $flight->arr_airport_id }}
           (<a href="{{route('frontend.airports.show', [
-                'id' => $flight->arr_airport->icao
-              ])}}">{{$flight->arr_airport->icao}}</a>)
+                'id' => $flight->arr_airport_id
+              ])}}">{{$flight->arr_airport_id}}</a>)
           @if($flight->arr_time), {{ $flight->arr_time }}@endif
           <br/>
           @if($flight->distance)


### PR DESCRIPTION
- Use `optional()` around getting airports in case it's an airport that doesn't exist in the local database
- Use `xxx_airport_id` fields in some places to prevent additional lookup queries