### PR TITLE
Refresh theme cache on settings page load #554

### DIFF
--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -17,6 +17,7 @@ class SettingsController extends Controller
      */
     private function getThemes(): array
     {
+        Theme::rebuildCache();
         $themes = Theme::all();
         $theme_list = [];
         foreach ($themes as $t) {

--- a/resources/views/admin/settings/table.blade.php
+++ b/resources/views/admin/settings/table.blade.php
@@ -1,7 +1,7 @@
 {{ Form::model($grouped_settings, ['route' => ['admin.settings.update'], 'method' => 'post']) }}
 @foreach($grouped_settings as $group => $settings)
   <div class="card border-blue-bottom">
-    <div class="content table-responsive table-full-width">
+    <div class="content table-responsive">
       <div class="row">
         <table class="table table-hover" id="flights-table">
           <thead>
@@ -77,6 +77,7 @@
 </div>
 
 {{ Form::close() }}
+
 <script>
   $(document).ready(function () {
     $('#datepicker').datetimepicker({

--- a/resources/views/layouts/.gitignore
+++ b/resources/views/layouts/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything so if we update via git, nothing is overwritten
+
+/*
+/*/
+!.gitignore
+!/default


### PR DESCRIPTION
* Refresh the theme cache when the settings page is loaded
* Fix to the theme on the settings page
* Add `.gitignore` in the `views/layouts` directory

closes #554 