### PR TITLE
Upstream null version; build version tags not being saved properly #575

### DIFF
--- a/.travis/deploy_script.sh
+++ b/.travis/deploy_script.sh
@@ -7,11 +7,10 @@ fi
 cd $TRAVIS_BUILD_DIR
 
 if test "$TRAVIS_TAG"; then
-  PKG_NAME=$TRAVIS_TAG
   VERSION=$TRAVIS_TAG
 
   # Pass in the tag as the version to write out
-  php artisan phpvms:version --write $VERSION
+  php artisan phpvms:version --write --write-full-version "${VERSION}"
 else
   echo "On branch $TRAVIS_BRANCH"
 
@@ -25,19 +24,20 @@ else
   BASE_VERSION=$(php artisan phpvms:version --base-only)
 
   # This now includes the pre-release version, so "-dev" by default
-  PKG_NAME=${BASE_VERSION}
+  VERSION=${BASE_VERSION}
 
   # Don't pass in a version here, just write out the latest hash
-  php artisan phpvms:version --write >VERSION
-  VERSION=$(cat VERSION)
+  php artisan phpvms:version --write "${VERSION}"
 fi
+
+FILE_NAME="phpvms-${VERSION}"
+TAR_NAME="$FILE_NAME.tar.gz"
+ZIP_NAME="$FILE_NAME.zip"
 
 echo "Version: $VERSION"
 echo "Package name: $TAR_NAME"
 
-FILE_NAME="phpvms-$PKG_NAME"
-TAR_NAME="$FILE_NAME.tar.gz"
-ZIP_NAME="$FILE_NAME.zip"
+echo "==========================="
 
 echo "Cleaning files"
 

--- a/app/Console/Commands/Version.php
+++ b/app/Console/Commands/Version.php
@@ -34,7 +34,7 @@ class Version extends Command
             // If a version is being passed in, the update the build, etc data against this
             if ($this->argument('version')) {
                 $version = \SemVer\SemVer\Version::fromString($this->argument('version'));
-                if ($this->option('write_full_version')) {
+                if ($this->option('write-full-version')) {
                     $cfg['current']['major'] = $version->getMajor();
                     $cfg['current']['minor'] = $version->getMinor();
                     $cfg['current']['patch'] = $version->getPatch();

--- a/app/Console/Commands/Version.php
+++ b/app/Console/Commands/Version.php
@@ -51,7 +51,7 @@ class Version extends Command
             }
 
             // Always write out the build ID/build number which is the commit hash
-            $build_number = $this->versionSvc->getBuildId($cfg);
+            $build_number = $this->versionSvc->generateBuildId($cfg);
             $cfg['current']['commit'] = $build_number;
             $cfg['build']['number'] = $build_number;
 

--- a/app/Http/Composers/VersionComposer.php
+++ b/app/Http/Composers/VersionComposer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Composers;
+
+use App\Services\VersionService;
+use Illuminate\View\View;
+
+class VersionComposer
+{
+    protected $versionSvc;
+
+    public function __construct(VersionService $versionSvc)
+    {
+        $this->versionSvc = $versionSvc;
+    }
+
+    public function compose(View $view)
+    {
+        $view->with('version', $this->versionSvc->getCurrentVersion(false));
+        $view->with('version_full', $this->versionSvc->getCurrentVersion(true));
+    }
+}

--- a/app/Providers/ComposerServiceProvider.php
+++ b/app/Providers/ComposerServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Providers;
+
+use App\Http\Composers\VersionComposer;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
+
+class ComposerServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        // Attach the version number to the admin sidebar
+        View::composer('admin.sidebar', VersionComposer::class);
+    }
+}

--- a/app/Services/VersionService.php
+++ b/app/Services/VersionService.php
@@ -76,7 +76,7 @@ class VersionService extends Service
     }
 
     /**
-     * Download the latest version from github
+     * Download the latest version from github and return the version number
      */
     private function getLatestVersionGithub()
     {
@@ -112,7 +112,7 @@ class VersionService extends Service
             );
         }
 
-        return $releases;
+        return null;
     }
 
     /**
@@ -188,8 +188,11 @@ class VersionService extends Service
         }
 
         // Replace "dev" with "alpha", since
-
         $latest_version = $this->getLatestVersion();
+
+        if (empty($latest_version)) {
+            return false;
+        }
 
         // Convert to semver
         if ($this->isGreaterThan($latest_version, $current_version)) {

--- a/app/Services/VersionService.php
+++ b/app/Services/VersionService.php
@@ -133,17 +133,28 @@ class VersionService extends Service
      */
     public function getBuildId($cfg)
     {
-        // No version number specified, query git
-        if (empty(trim($cfg['build']['number']))) {
-            exec($cfg['git']['git-local'], $version);
-            $version = substr($version[0], 0, $cfg['build']['length']);
+        return $cfg['build']['number'];
+    }
 
-            // prefix with the date in YYMMDD format
-            $date = date('ymd');
-            $version = $date.'.'.$version;
-        } else {
-            $version = $cfg['build']['number'];
+    /**
+     * Generate a build ID
+     *
+     * @param array $cfg The version config
+     *
+     * @return false|string
+     */
+    public function generateBuildId($cfg)
+    {
+        $date = date('ymd');
+        exec($cfg['git']['git-local'], $version);
+        if (empty($version)) {
+            return $date;
         }
+
+        $version = substr($version[0], 0, $cfg['build']['length']);
+
+        // prefix with the date in YYMMDD format
+        $version = $date.'.'.$version;
 
         return $version;
     }
@@ -172,8 +183,9 @@ class VersionService extends Service
         if ($include_build) {
             // Get the current build id
             $build_number = $this->getBuildId($cfg);
-            $cfg['build']['number'] = $build_number;
-            $version = $version.'+'.$build_number;
+            if (!empty($build_number)) {
+                $version = $version.'+'.$build_number;
+            }
         }
 
         return $version;

--- a/app/Services/VersionService.php
+++ b/app/Services/VersionService.php
@@ -133,12 +133,19 @@ class VersionService extends Service
      */
     public function getBuildId($cfg)
     {
-        exec($cfg['git']['git-local'], $version);
-        $version = substr($version[0], 0, $cfg['build']['length']);
+        // No version number specified, query git
+        if (empty(trim($cfg['build']['number']))) {
+            exec($cfg['git']['git-local'], $version);
+            $version = substr($version[0], 0, $cfg['build']['length']);
 
-        // prefix with the date in YYMMDD format
-        $date = date('ymd');
-        return $date.'.'.$version;
+            // prefix with the date in YYMMDD format
+            $date = date('ymd');
+            $version = $date.'.'.$version;
+        } else {
+            $version = $cfg['build']['number'];
+        }
+
+        return $version;
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -77,6 +77,7 @@ return [
         App\Providers\AuthServiceProvider::class,
         App\Providers\BindServiceProviders::class,
         App\Providers\BroadcastServiceProvider::class,
+        App\Providers\ComposerServiceProvider::class,
         App\Providers\CronServiceProvider::class,
         App\Providers\DirectiveServiceProvider::class,
         App\Providers\EventServiceProvider::class,

--- a/config/version.yml
+++ b/config/version.yml
@@ -29,4 +29,4 @@ format:
   build: '{$build}'
   version: '{$major}.{$minor}.{$patch} (build {$build})'
   full: 'version {{''format.version''}}'
-  compact: 'v{$major}.{$minor}.{$patch}+{$build}'
+  compact: '{$major}.{$minor}.{$patch}+{$build}'

--- a/resources/views/admin/app.blade.php
+++ b/resources/views/admin/app.blade.php
@@ -110,6 +110,8 @@
       checkboxClass: 'icheckbox_square-blue',
       radioClass: 'icheckbox_square-blue'
     });
+
+    $('[data-toggle="popover"]').popover();
   };
 
   $(document).ready(function () {

--- a/resources/views/admin/sidebar.blade.php
+++ b/resources/views/admin/sidebar.blade.php
@@ -19,9 +19,15 @@
 
     <br/>
 
-    <div class="row">
+    <div class="row" style="margin-bottom: 20px;">
       <div class="col-xs-12 text-center">
-        <p class="small">@version</p>
+{{--        <p class="small">{{ $version }}</p>--}}
+        <a class="small"
+            data-container="body"
+            data-toggle="popover"
+            data-placement="top" data-content="{{$version_full}}">
+          version {{ $version }}
+        </a>
       </div>
     </div>
   </div>

--- a/resources/views/admin/sidebar.blade.php
+++ b/resources/views/admin/sidebar.blade.php
@@ -21,11 +21,11 @@
 
     <div class="row" style="margin-bottom: 20px;">
       <div class="col-xs-12 text-center">
-{{--        <p class="small">{{ $version }}</p>--}}
         <a class="small"
             data-container="body"
             data-toggle="popover"
-            data-placement="top" data-content="{{$version_full}}">
+            data-placement="right"
+           data-content="{{$version_full}}">
           version {{ $version }}
         </a>
       </div>


### PR DESCRIPTION
- Fix where pre-release/build metadata tag not being saved
- Cleanup deploy script so it's less confusing where the version is coming from
- View composer to set the proper version ID with pre-release tag in the admin
- Popover to show the full version incl date/build ID string

refs #575