### PR TITLE
User country mapping; ignore unused groups #443 

### DIFF
--- a/app/Services/RoleService.php
+++ b/app/Services/RoleService.php
@@ -39,7 +39,7 @@ class RoleService extends Service
     {
         // Update the permissions, filter out null/invalid values
         $perms = collect($permissions)->filter(static function ($v, $k) {
-            return $v;
+            return !empty($v);
         });
 
         $role->permissions()->sync($perms);

--- a/app/Support/Countries.php
+++ b/app/Support/Countries.php
@@ -12,15 +12,13 @@ class Countries
     /**
      * Get a select box list of all the countries
      *
-     * @return static
+     * @return \Illuminate\Support\Collection
      */
     public static function getSelectList()
     {
-        $countries = collect((new ISO3166())->all())
+        return collect((new ISO3166())->all())
             ->mapWithKeys(static function ($item, $key) {
                 return [strtolower($item['alpha2']) => $item['name']];
             });
-
-        return $countries;
     }
 }

--- a/modules/Importer/Services/Importers/GroupImporter.php
+++ b/modules/Importer/Services/Importers/GroupImporter.php
@@ -78,6 +78,14 @@ class GroupImporter extends BaseImporter
                 continue;
             }
 
+            // Map the "core" roles, which are active/inactive pilots to a new ID of
+            // -1; so then we can ignore/not add these groups, and then ignore them
+            // for any of the users that are being imported. these groups are unused
+            if ($row->core === 1 || $row->core === '1') {
+                $this->idMapper->addMapping('group', $row->groupid, -1);
+                continue;
+            }
+
             $name = str_slug($row->name);
             $role = Role::firstOrCreate(
                 ['name' => $name],

--- a/modules/Importer/Services/Importers/UserImport.php
+++ b/modules/Importer/Services/Importers/UserImport.php
@@ -70,6 +70,7 @@ class UserImport extends BaseImporter
                 'rank_id'         => $rank_id,
                 'home_airport_id' => $row->hub,
                 'curr_airport_id' => $row->hub,
+                'country'         => $row->location,
                 'flights'         => (int) $row->totalflights,
                 'flight_time'     => Time::hoursToMinutes($row->totalhours),
                 'state'           => $state,

--- a/modules/Importer/Services/Importers/UserImport.php
+++ b/modules/Importer/Services/Importers/UserImport.php
@@ -100,7 +100,6 @@ class UserImport extends BaseImporter
     {
         // Be default add them to the user role, and then determine if they
         // belong to any other groups, and add them to that
-        $roleMappings = [];
         $newRoles = [];
 
         // Figure out what other groups they belong to... read from the old table, and map
@@ -109,12 +108,11 @@ class UserImport extends BaseImporter
         foreach ($old_user_groups as $oldGroup) {
             $newRoleId = $this->idMapper->getMapping('group', $oldGroup->groupid);
 
-            // Only lookup a new role ID if found
-            // if (!in_array($newRoleId, $roleMappings)) {
-            //     $roleMappings[$newRoleId] = Role::where(['id' => $newRoleId])->first();
-            // }
+            // This role should be ignored
+            if ($newRoleId === -1) {
+                continue;
+            }
 
-            // $newRoles[] = $roleMappings[$newRoleId];
             $newRoles[] = $newRoleId;
         }
 


### PR DESCRIPTION
- Make sure a user's country is copied over
- Ignore the old "core" groups of active/in-active pilots.