### PR TITLE
Remove 4 char restriction from ICAO; use decimal type for lat/lon #590

### DIFF
--- a/app/Database/migrations/2020_02_26_044305_modify_airports_coordinates.php
+++ b/app/Database/migrations/2020_02_26_044305_modify_airports_coordinates.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * Turn the airport coordinates and other lat/lon coords into decimal type

--- a/app/Database/migrations/2020_02_26_044305_modify_airports_coordinates.php
+++ b/app/Database/migrations/2020_02_26_044305_modify_airports_coordinates.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Turn the airport coordinates and other lat/lon coords into decimal type
+ */
+class ModifyAirportsCoordinates extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('acars', function ($table) {
+            $table->decimal('lat', 10, 5)->change()->default(0.0)->nullable();
+            $table->decimal('lon', 11, 5)->change()->default(0.0)->nullable();
+        });
+
+        Schema::table('airports', function ($table) {
+            $table->decimal('lat', 10, 5)->change()->default(0.0)->nullable();
+            $table->decimal('lon', 11, 5)->change()->default(0.0)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/app/Models/Airport.php
+++ b/app/Models/Airport.php
@@ -66,7 +66,7 @@ class Airport extends Model
      * Validation rules
      */
     public static $rules = [
-        'icao'                 => 'required|size:4',
+        'icao'                 => 'required',
         'iata'                 => 'sometimes|nullable',
         'name'                 => 'required',
         'location'             => 'sometimes',


### PR DESCRIPTION
- Remove 4 char restriction on ICAO (accept 3 char IDs, custom)
- Change from float to more precise decimal column

closes #590 