### PR TITLE
API: Flight fields are an array when empty #618

### DIFF
--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -97,7 +97,6 @@ class FlightController extends Controller
                     'field_values',
                 ])
                 ->paginate();
-
         } catch (RepositoryException $e) {
             return response($e, 503);
         }

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -88,7 +88,16 @@ class FlightController extends Controller
             $this->flightRepo->pushCriteria(new WhereCriteria($request, $where));
             $this->flightRepo->pushCriteria(new RequestCriteria($request));
 
-            $flights = $this->flightRepo->paginate();
+            $flights = $this->flightRepo
+                ->with([
+                    'airline',
+                    'subfleets',
+                    'subfleets.aircraft',
+                    'subfleets.fares',
+                    'field_values',
+                ])
+                ->paginate();
+
         } catch (RepositoryException $e) {
             return response($e, 503);
         }

--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -3,18 +3,25 @@
 namespace App\Http\Resources;
 
 use App\Support\Units\Distance;
+use stdClass;
 
 class Flight extends Response
 {
     /**
      * Set the fields on the flight object
      *
-     * @return array
+     * @mixin \App\Models\Flight
      */
     private function setFields()
     {
+        /** @var \Illuminate\Support\Collection $field_values */
+        $field_values = $this->field_values;
+        if (empty($field_values) || $field_values->count() === 0) {
+            return new stdClass();
+        }
+
         $fields = [];
-        foreach ($this->field_values as $field) {
+        foreach ($field_values as $field) {
             $fields[$field->name] = $field->value;
         }
 

--- a/resources/views/admin/flights/fields.blade.php
+++ b/resources/views/admin/flights/fields.blade.php
@@ -235,7 +235,7 @@
     <div class="checkbox">
       <label class="checkbox-inline">
         {{ Form::label('active', 'Active:') }}
-        {{ Form::hidden('active', 0, false) }}
+        <input name="active" type="hidden" value="0" />
         {{ Form::checkbox('active') }}
       </label>
     </div>


### PR DESCRIPTION
- Return empty flight fields as an object, not array
- Eager loading of the flight relations

Closes #618 