### PR TITLE
Increase ID column size; seed ID generator with uniqid() #630

### DIFF
--- a/app/Contracts/Model.php
+++ b/app/Contracts/Model.php
@@ -13,7 +13,7 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model
     /**
      * Max length of ID for string columns
      */
-    public const ID_MAX_LENGTH = 12;
+    public const ID_MAX_LENGTH = 16;
 
     /**
      * For the factories, skip the mutators. Only apply to one instance

--- a/app/Database/migrations/2017_06_08_0000_create_users_table.php
+++ b/app/Database/migrations/2017_06_08_0000_create_users_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\Migration;
+use App\Models\Pirep;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -24,7 +25,7 @@ class CreateUsersTable extends Migration
             $table->string('country', 2)->nullable();
             $table->string('home_airport_id', 5)->nullable();
             $table->string('curr_airport_id', 5)->nullable();
-            $table->string('last_pirep_id', \App\Models\Pirep::ID_MAX_LENGTH)->nullable();
+            $table->string('last_pirep_id', Pirep::ID_MAX_LENGTH)->nullable();
             $table->unsignedBigInteger('flights')->default(0);
             $table->unsignedBigInteger('flight_time')->nullable()->default(0);
             $table->unsignedBigInteger('transfer_time')->nullable()->default(0);

--- a/app/Database/migrations/2017_12_20_005147_create_acars_tables.php
+++ b/app/Database/migrations/2017_12_20_005147_create_acars_tables.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\Migration;
+use App\Contracts\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,8 +15,8 @@ class CreateAcarsTables extends Migration
     public function up()
     {
         Schema::create('acars', function (Blueprint $table) {
-            $table->string('id', 12);
-            $table->string('pirep_id', \App\Contracts\Model::ID_MAX_LENGTH);
+            $table->string('id', Model::ID_MAX_LENGTH);
+            $table->string('pirep_id', Model::ID_MAX_LENGTH);
             $table->unsignedTinyInteger('type');
             $table->unsignedInteger('nav_type')->nullable();
             $table->unsignedInteger('order')->default(0);

--- a/app/Database/migrations/2018_01_03_014930_create_stats_table.php
+++ b/app/Database/migrations/2018_01_03_014930_create_stats_table.php
@@ -2,6 +2,7 @@
 
 use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateStatsTable extends Migration
 {
@@ -22,28 +23,6 @@ class CreateStatsTable extends Migration
             $table->primary('id');
             $table->timestamps();
         });
-        /*$this->addCounterGroups([
-            'flights' => 1,
-        ]);
-
-        $stats = [
-            [
-                'id' => $this->formatSettingId('flights.total_flights'),
-                'order' => $this->getNextOrderNumber('flights'),
-                'value' => 0,
-                'type' => 'int',
-                'description' => 'Total number of flights in the VA',
-            ],
-            [
-                'id' => $this->formatSettingId('flights.total_time'),
-                'order' => $this->getNextOrderNumber('flights'),
-                'value' => 0,
-                'type' => 'int',
-                'description' => 'Total number of hours in the VA',
-            ],
-        ];
-
-        $this->addData('stats', $stats);*/
     }
 
     /**
@@ -53,6 +32,6 @@ class CreateStatsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('settings');
+        Schema::dropIfExists('stats');
     }
 }

--- a/app/Database/migrations/2020_03_09_141152_increase_id_lengths.php
+++ b/app/Database/migrations/2020_03_09_141152_increase_id_lengths.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Increase string ID lengths because of collisions
+ */
+class IncreaseIdLengths extends Migration
+{
+    public function up()
+    {
+        $tables = [
+            'acars'               => ['id', 'pirep_id'],
+            'bids'                => ['flight_id'],
+            'flights'             => ['id'],
+            'pireps'              => ['id', 'flight_id'],
+            'flight_fare'         => ['flight_id'],
+            'flight_field_values' => ['flight_id'],
+            'flight_subfleet'     => ['flight_id'],
+            'pirep_comments'      => ['pirep_id'],
+            'pirep_fares'         => ['pirep_id'],
+            'pirep_field_values'  => ['pirep_id'],
+            'users'               => ['last_pirep_id'],
+        ];
+
+        foreach ($tables as $table_name => $columns) {
+            Schema::table($table_name, function (Blueprint $table) use ($columns) {
+                foreach ($columns as $column) {
+                    $table->string($column, 36)->change();
+                }
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/app/Support/Utils.php
+++ b/app/Support/Utils.php
@@ -26,7 +26,7 @@ class Utils
             $length = Model::ID_MAX_LENGTH;
         }
 
-        $hashids = new Hashids('', $length);
+        $hashids = new Hashids(uniqid(), $length);
         $mt = str_replace('.', '', microtime(true));
         return $hashids->encode($mt);
     }

--- a/modules/Importer/Services/Importers/FlightImporter.php
+++ b/modules/Importer/Services/Importers/FlightImporter.php
@@ -54,7 +54,7 @@ class FlightImporter extends BaseImporter
                 // $flight = Flight::updateOrCreate($w, $attrs);
                 $flight = Flight::create(array_merge($w, $attrs));
             } catch (\Exception $e) {
-                //$this->error($e);
+                $this->error($e);
             }
 
             $this->idMapper->addMapping('flights', $row->id, $flight->id);


### PR DESCRIPTION
Salting for hash ID wasn't unique enough. Taking this time to increase ID column sizes to 36 chars (UUID) and increase the current hash ID size from 12 to 16. Closes #630