### PR TITLE
Don't return bids by default, fix user flight column #639

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -90,7 +90,7 @@ class UserController extends Controller
     public function get($id)
     {
         $user = $this->userRepo
-            ->with(['airline', 'bids', 'rank'])
+            ->with(['airline', 'rank'])
             ->find($id);
 
         return new UserResource($user);

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -3,7 +3,6 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
-use App\Http\Resources\Flight as FlightResource;
 
 /**
  * @mixin \App\Models\User
@@ -30,7 +29,6 @@ class User extends Resource
 
         $res['airline'] = Airline::make($this->airline);
         $res['bids'] = UserBid::collection($this->whenLoaded('bids'));
-        $res['flights'] = new FlightResource($this->whenLoaded('flights'));
         $res['rank'] = Rank::make($this->rank);
 
         /*

--- a/app/Http/Resources/UserBid.php
+++ b/app/Http/Resources/UserBid.php
@@ -4,17 +4,20 @@ namespace App\Http\Resources;
 
 use App\Contracts\Resource;
 
+/**
+ * @mixin \App\Models\Bid
+ */
 class UserBid extends Resource
 {
     public function toArray($request)
     {
         return [
-            'id'        => $this->id,
-            'user_id'   => $this->user_id,
-            'flight_id' => $this->flight_id,
-            'flights'   => Flight::collection($this->whenLoaded('flight')),
-            //'created_at' => $this->created_at,
-            //'updated_at' => $this->updated_at,
+            'id'         => $this->id,
+            'user_id'    => $this->user_id,
+            'flight_id'  => $this->flight_id,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'flight'     => new Flight($this->whenLoaded('flight')),
         ];
     }
 }

--- a/app/Models/Bid.php
+++ b/app/Models/Bid.php
@@ -3,7 +3,14 @@
 namespace App\Models;
 
 use App\Contracts\Model;
+use Carbon\Carbon;
 
+/**
+ * @property string user_id
+ * @property string flight_id
+ * @property Carbon created_at
+ * @property Carbon updated_at
+ */
 class Bid extends Model
 {
     public $table = 'bids';

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -201,10 +201,10 @@ class User extends Authenticatable
     /**
      * These are the flights they've bid on
      */
-    public function flights()
-    {
-        return $this->belongsToMany(Flight::class, 'bids');
-    }
+    // public function flights()
+    // {
+    //     return $this->belongsToMany(Flight::class, 'bids');
+    // }
 
     /**
      * The bid rows

--- a/tests/BidTest.php
+++ b/tests/BidTest.php
@@ -73,12 +73,12 @@ class BidTest extends TestCase
 
         // Query the API and see that the user has the bids
         // And pull the flight details for the user/bids
-        $req = $this->get('/api/user', $headers);
+        $req = $this->get('/api/user/bids', $headers);
         $req->assertStatus(200);
 
         $body = $req->json()['data'];
-        $this->assertCount(1, $body['bids']);
-        $this->assertEquals($flight->id, $body['bids'][0]['flight_id']);
+        $req->assertStatus(200);
+        $this->assertEquals($flight->id, $body[0]['flight_id']);
 
         $req = $this->get('/api/users/'.$user->id.'/bids', $headers);
 
@@ -109,17 +109,15 @@ class BidTest extends TestCase
         $bids = $user->bids()->get();
         $this->assertTrue($bids->isEmpty());
 
-        $req = $this->get('/api/user', $headers);
+        $req = $this->get('/api/user/bids', $headers);
         $req->assertStatus(200);
 
         $body = $req->json()['data'];
-        $this->assertEquals($user->id, $body['id']);
-        $this->assertCount(0, $body['bids']);
+        $this->assertCount(0, $body);
 
         $req = $this->get('/api/users/'.$user->id.'/bids', $headers);
         $req->assertStatus(200);
         $body = $req->json()['data'];
-
         $this->assertCount(0, $body);
     }
 
@@ -196,12 +194,11 @@ class BidTest extends TestCase
 
         // Query the API and see that the user has the bids
         // And pull the flight details for the user/bids
-        $req = $this->get('/api/user', $headers);
+        $req = $this->get('/api/user/bids', $headers);
         $req->assertStatus(200);
 
         $body = $req->json()['data'];
-        $this->assertEquals($user->id, $body['id']);
-        $this->assertCount(0, $body['bids']);
+        $this->assertCount(0, $body);
 
         $req = $this->get('/api/users/'.$user->id.'/bids', $headers);
         $req->assertStatus(200);

--- a/tests/PIREPTest.php
+++ b/tests/PIREPTest.php
@@ -84,8 +84,8 @@ class PIREPTest extends TestCase
         /**
          * Now set the PIREP state to ACCEPTED
          */
-        $new_pirep_count = $pirep->pilot->flights + 1;
-        $new_flight_time = $pirep->pilot->flight_time + $pirep->flight_time;
+        $new_pirep_count = $pirep->user->flights + 1;
+        $new_flight_time = $pirep->user->flight_time + $pirep->flight_time;
 
         $this->pirepSvc->changeState($pirep, PirepState::ACCEPTED);
         $this->assertEquals($new_pirep_count, $pirep->pilot->flights);


### PR DESCRIPTION
Don't load bids, but fix response so that it can be loaded and response looks the same as `/api/user/bids`. User flight count not being returned properly in the API

closes #639