### PR TITLE
Change currency from settings #671

### DIFF
--- a/app/Models/Traits/JournalTrait.php
+++ b/app/Models/Traits/JournalTrait.php
@@ -12,7 +12,7 @@ trait JournalTrait
     public static function bootJournalTrait()
     {
         static::created(function ($model) {
-            $model->initJournal(config('phpvms.currency'));
+            $model->initJournal(setting('units.currency'));
         });
     }
 

--- a/app/Repositories/JournalRepository.php
+++ b/app/Repositories/JournalRepository.php
@@ -110,7 +110,7 @@ class JournalRepository extends Repository implements CacheableInterface
             'journal_id'        => $journal->id,
             'credit'            => $credit ? $credit->getAmount() : null,
             'debit'             => $debit ? $debit->getAmount() : null,
-            'currency'          => config('phpvms.currency'),
+            'currency'          => setting('units.currency', 'USD'),
             'memo'              => $memo,
             'post_date'         => $post_date,
             'transaction_group' => $transaction_group,

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -63,11 +63,11 @@ class PirepFinanceService extends Service
     public function processFinancesForPirep(Pirep $pirep)
     {
         if (!$pirep->airline->journal) {
-            $pirep->airline->journal = $pirep->airline->initJournal(config('phpvms.currency'));
+            $pirep->airline->journal = $pirep->airline->initJournal(setting('units.currency', 'USD'));
         }
 
         if (!$pirep->user->journal) {
-            $pirep->user->journal = $pirep->user->initJournal(config('phpvms.currency'));
+            $pirep->user->journal = $pirep->user->initJournal(setting('units.currency', 'USD'));
         }
 
         // Clean out the expenses first

--- a/app/Services/FinanceService.php
+++ b/app/Services/FinanceService.php
@@ -168,4 +168,16 @@ class FinanceService extends Service
             'transactions' => $transactions,
         ];
     }
+
+    /**
+     * Change the currencies on the journals and transactions to the current currency value
+     */
+    public function changeJournalCurrencies(): void
+    {
+        $currency = setting('units.currency', 'USD');
+        $update = ['currency' => $currency];
+
+        Journal::query()->update($update);
+        JournalTransaction::query()->update($update);
+    }
 }

--- a/app/Services/Installer/SeederService.php
+++ b/app/Services/Installer/SeederService.php
@@ -248,7 +248,7 @@ class SeederService extends Service
 
             // See if any of the options have changed
             if ($row->type === 'select') {
-                if ($row->options !== $setting['options']) {
+                if (!empty($row->options) && $row->options !== $setting['options']) {
                     Log::info('Options for '.$id.' changed, update available');
                     return true;
                 }

--- a/app/Support/Money.php
+++ b/app/Support/Money.php
@@ -56,7 +56,7 @@ class Money
      */
     public static function convertToSubunit($amount)
     {
-        $currency = config('phpvms.currency');
+        $currency = setting('units.currency', 'USD');
         return (int) $amount * config('money.'.$currency.'.subunit');
     }
 
@@ -71,7 +71,7 @@ class Money
     public static function currency()
     {
         try {
-            return new Currency(config('phpvms.currency', 'USD'));
+            return new Currency(setting('units.currency', 'USD'));
         } catch (\OutOfBoundsException $e) {
             return new Currency('USD');
         }

--- a/config/phpvms.php
+++ b/config/phpvms.php
@@ -36,14 +36,6 @@ return [
     'registration_redirect' => '/profile',
 
     /*
-     * The ISO "Currency Code" to use, the list is in config/money.php
-     *
-     * Note, do not change this after you've set it, unless you don't
-     * care that the currencies aren't "exchanged" into the new format
-     */
-    'currency' => 'USD',
-
-    /*
      * Point to the class to use to retrieve the METAR string. If this
      * goes inactive at some date, it can be replaced
      */

--- a/resources/stubs/installer/config.stub
+++ b/resources/stubs/installer/config.stub
@@ -23,13 +23,7 @@ return [
 
     // Overrides config/phpvms.php
     'phpvms' => [
-        /**
-         * The ISO "Currency Code" to use, the list is in config/money.php
-         *
-         * Note, do not change this after you've set it, unless you don't
-         * care that the currencies aren't "exchanged" into the new format
-         */
-        'currency' => 'USD',
+
     ],
 
     //

--- a/resources/views/admin/aircraft/expenses.blade.php
+++ b/resources/views/admin/aircraft/expenses.blade.php
@@ -14,7 +14,7 @@
     @if(count($aircraft->expenses) > 0)
       <thead>
       <th>Name</th>
-      <th>Cost&nbsp;<span class="small">{{ currency(config('phpvms.currency')) }}</span></th>
+      <th>Cost&nbsp;<span class="small">{{ currency(setting('units.currency')) }}</span></th>
       <th>Type</th>
       <th></th>
       </thead>

--- a/resources/views/admin/airports/expenses.blade.php
+++ b/resources/views/admin/airports/expenses.blade.php
@@ -11,7 +11,7 @@
     @if(count($airport->expenses))
       <thead>
       <th>Name</th>
-      <th>Cost&nbsp;<span class="small">{{ currency(config('phpvms.currency')) }}</span></th>
+      <th>Cost&nbsp;<span class="small">{{ currency(setting('units.currency')) }}</span></th>
       <th>Type</th>
       <th></th>
       </thead>

--- a/resources/views/admin/pireps/transactions.blade.php
+++ b/resources/views/admin/pireps/transactions.blade.php
@@ -7,12 +7,12 @@
           <td>{{ $entry->memo }}</td>
           <td>
             @if($entry->credit)
-              {{ money($entry->credit, config('phpvms.currency')) }}
+              {{ money($entry->credit, setting('units.currency')) }}
             @endif
           </td>
           <td>
             @if($entry->debit)
-              {{ money($entry->debit, config('phpvms.currency')) }}
+              {{ money($entry->debit, setting('units.currency')) }}
             @endif
           </td>
         </tr>

--- a/resources/views/admin/settings/table.blade.php
+++ b/resources/views/admin/settings/table.blade.php
@@ -37,6 +37,12 @@
                           list_to_assoc($themes),
                           $setting->value,
                           ['class' => 'select2', 'style' => 'width: 100%; text-align: left;']) }}
+                  @elseif($setting->id === 'units_currency')
+                    {{ Form::select(
+                          $setting->id,
+                          $currencies,
+                          $setting->value,
+                          ['class' => 'select2', 'style' => 'width: 100%; text-align: left;']) }}
                   @else
                     {{ Form::select(
                             $setting->id,

--- a/resources/views/admin/subfleets/expenses.blade.php
+++ b/resources/views/admin/subfleets/expenses.blade.php
@@ -10,7 +10,7 @@
     @if(count($subfleet->expenses))
       <thead>
       <th>Name</th>
-      <th>Cost&nbsp;<span class="small">{{ currency(config('phpvms.currency')) }}</span></th>
+      <th>Cost&nbsp;<span class="small">{{ currency(setting('units.currency', 'USD')) }}</span></th>
       <th>Type</th>
       <th></th>
       </thead>

--- a/tests/FinanceTest.php
+++ b/tests/FinanceTest.php
@@ -689,7 +689,7 @@ class FinanceTest extends TestCase
         $journalRepo = app(JournalRepository::class);
 
         [$user, $pirep, $fares] = $this->createFullPirep();
-        $user->airline->initJournal(config('phpvms.currency'));
+        $user->airline->initJournal(setting('units.currency', 'USD'));
 
         // Override the fares
         $fare_counts = [];
@@ -744,7 +744,7 @@ class FinanceTest extends TestCase
         ]);
 
         [$user, $pirep, $fares] = $this->createFullPirep();
-        $user->airline->initJournal(config('phpvms.currency'));
+        $user->airline->initJournal(setting('units.currency', 'USD'));
 
         // Override the fares
         $fare_counts = [];


### PR DESCRIPTION
Move the currency setting from `config()` to `setting()`. That way the change can also be accounted for in journals and transactions.

Closes #671