### PR TITLE
Installer: Use absolute paths for permissions check #693

### DIFF
--- a/modules/Installer/Config/config.php
+++ b/modules/Installer/Config/config.php
@@ -26,16 +26,16 @@ return [
 
     // Make sure these are writable
     'permissions' => [
-        'bootstrap/cache',
-        'public/uploads',
-        'storage',
-        'storage/app/public',
-        'storage/app/public/avatars',
-        'storage/app/public/uploads',
-        'storage/framework',
-        'storage/framework/cache',
-        'storage/framework/sessions',
-        'storage/framework/views',
-        'storage/logs',
+        base_path('bootstrap/cache'),
+        public_path('uploads'),
+        storage_path(),
+        storage_path('app/public'),
+        storage_path('app/public/avatars'),
+        storage_path('app/public/uploads'),
+        storage_path('framework'),
+        storage_path('framework/cache'),
+        storage_path('framework/sessions'),
+        storage_path('framework/views'),
+        storage_path('logs'),
     ],
 ];

--- a/modules/Installer/Resources/views/install/index-start.blade.php
+++ b/modules/Installer/Resources/views/install/index-start.blade.php
@@ -2,7 +2,6 @@
 @section('title', 'Install phpVMS')
 
 @section('content')
-  <h2>phpvms installer</h2>
   <p>Press continue to start</p>
   {{ Form::open(['route' => 'installer.step1', 'method' => 'post']) }}
   <p style="text-align: right">

--- a/modules/Installer/Services/RequirementsService.php
+++ b/modules/Installer/Services/RequirementsService.php
@@ -55,9 +55,8 @@ class RequirementsService extends Service
         clearstatcache();
 
         $directories = [];
-        foreach (config('installer.permissions') as $dir) {
+        foreach (config('installer.permissions') as $path) {
             $pass = true;
-            $path = base_path($dir);
 
             if (!file_exists($path)) {
                 $pass = false;
@@ -68,7 +67,7 @@ class RequirementsService extends Service
             }
 
             $directories[] = [
-                'dir'    => $dir,
+                'dir'    => $path,
                 'passed' => $pass,
             ];
         }


### PR DESCRIPTION
Remove the call to `base_path()` and the use absolute paths reported by Laravel when checking the permissions of those paths (in case `/public` has been moved)

closes #693 