### PR TITLE
Use theme in error handlers #715

### DIFF
--- a/app/Http/Middleware/SetActiveTheme.php
+++ b/app/Http/Middleware/SetActiveTheme.php
@@ -13,23 +13,42 @@ use Illuminate\Support\Facades\Log;
  */
 class SetActiveTheme implements Middleware
 {
+    private static $skip = [
+        'admin',
+        'admin/*',
+        'api',
+        'api/*',
+        'importer',
+        'importer/*',
+        'install',
+        'install/*',
+        'update',
+        'update/*',
+    ];
+
+    /**
+     * Handle the request
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
     public function handle(Request $request, Closure $next)
     {
-        $skip = [
-            'admin',
-            'admin/*',
-            'api',
-            'api/*',
-            'importer',
-            'importer/*',
-            'install',
-            'install/*',
-            'update',
-            'update/*',
-        ];
+        $this->setTheme($request);
+        return $next($request);
+    }
 
-        if ($request->is($skip)) {
-            return $next($request);
+    /**
+     * Set the theme for the current middleware
+     *
+     * @param \Illuminate\Http\Request $request
+     */
+    public function setTheme(Request $request)
+    {
+        if ($request->is(self::$skip)) {
+            return;
         }
 
         try {
@@ -42,7 +61,5 @@ class SetActiveTheme implements Middleware
         if (!empty($theme)) {
             Theme::set($theme);
         }
-
-        return $next($request);
     }
 }


### PR DESCRIPTION
Explicitly set the theme in the error handler, seems something changed in the behavior between Laravel 6 -> 7.  Refactor the middleware a bit so we can reuse that logic

closes #715 