### PR TITLE
Fix METAR invalid parameter #738

### DIFF
--- a/app/Services/Metar/AviationWeather.php
+++ b/app/Services/Metar/AviationWeather.php
@@ -14,9 +14,7 @@ use Illuminate\Support\Facades\Log;
 class AviationWeather extends Metar
 {
     private const METAR_URL =
-        'https://www.aviationweather.gov/adds/dataserver_current/httpparam?'
-        .'dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=3'
-        .'&mostRecent=true&fields=raw_text&stationString=';
+        'https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=3&mostRecent=true&stationString=';
 
     private $httpClient;
 

--- a/tests/MetarTest.php
+++ b/tests/MetarTest.php
@@ -173,6 +173,14 @@ class MetarTest extends TestCase
         $this->assertInstanceOf(Metar::class, $airportSvc->getMetar('kjfk'));
     }
 
+    public function testHttpCallSuccessFullResponse()
+    {
+        $this->mockXmlResponse('aviationweather/kphx.xml');
+        $airportSvc = app(AirportService::class);
+
+        $this->assertInstanceOf(Metar::class, $airportSvc->getMetar('kphx'));
+    }
+
     public function testHttpCallEmpty()
     {
         $this->mockXmlResponse('aviationweather/empty.xml');

--- a/tests/data/aviationweather/kphx.xml
+++ b/tests/data/aviationweather/kphx.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XML-Schema-instance" version="1.2" xsi:noNamespaceSchemaLocation="http://aviationweather.gov/adds/schema/metar1_2.xsd">
+  <request_index>30141982</request_index>
+  <data_source name="metars" />
+  <request type="retrieve" />
+  <errors />
+  <warnings />
+  <time_taken_ms>4</time_taken_ms>
+  <data num_results="1">
+    <METAR>
+      <raw_text>KPHX 021651Z 33009KT 10SM FEW160 FEW210 SCT250 36/08 A2991 RMK AO2 SLP105 T03560078</raw_text>
+      <station_id>KPHX</station_id>
+      <observation_time>2020-06-02T16:51:00Z</observation_time>
+      <latitude>33.43</latitude>
+      <longitude>-112.02</longitude>
+      <temp_c>35.6</temp_c>
+      <dewpoint_c>7.8</dewpoint_c>
+      <wind_dir_degrees>330</wind_dir_degrees>
+      <wind_speed_kt>9</wind_speed_kt>
+      <visibility_statute_mi>10.0</visibility_statute_mi>
+      <altim_in_hg>29.911417</altim_in_hg>
+      <sea_level_pressure_mb>1010.5</sea_level_pressure_mb>
+      <quality_control_flags>
+        <auto_station>TRUE</auto_station>
+      </quality_control_flags>
+      <sky_condition sky_cover="FEW" cloud_base_ft_agl="16000" />
+      <sky_condition sky_cover="FEW" cloud_base_ft_agl="21000" />
+      <sky_condition sky_cover="SCT" cloud_base_ft_agl="25000" />
+      <flight_category>VFR</flight_category>
+      <metar_type>METAR</metar_type>
+      <elevation_m>336.0</elevation_m>
+    </METAR>
+  </data>
+</response>


### PR DESCRIPTION
Fix METAR dropping the `fields=raw_text` parameter.