### PR TITLE
Fixes for installer/modules race condition

### DIFF
--- a/app/Contracts/Migration.php
+++ b/app/Contracts/Migration.php
@@ -52,7 +52,6 @@ abstract class Migration extends \Illuminate\Database\Migrations\Migration
         }
     }
 
-
     /**
      * Seed a YAML file into the database
      *

--- a/app/Contracts/Migration.php
+++ b/app/Contracts/Migration.php
@@ -2,8 +2,10 @@
 
 namespace App\Contracts;
 
+use App\Models\Module;
 use App\Support\Database;
-use DB;
+use Exception;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
@@ -28,6 +30,30 @@ abstract class Migration extends \Illuminate\Database\Migrations\Migration
     }
 
     /**
+     * Add a module and enable it
+     *
+     * @param array $attrs
+     */
+    public function addModule(array $attrs)
+    {
+        $module = array_merge([
+            'enabled'    => true,
+            'created_at' => DB::raw('NOW()'),
+            'updated_at' => DB::raw('NOW()'),
+        ], $attrs);
+
+        try {
+            DB::table('modules')->insert($module);
+        } catch (Exception $e) {
+            // setting already exists, just ignore it
+            if ($e->getCode() === 23000) {
+                return;
+            }
+        }
+    }
+
+
+    /**
      * Seed a YAML file into the database
      *
      * @param string $file Full path to yml file to seed
@@ -37,7 +63,7 @@ abstract class Migration extends \Illuminate\Database\Migrations\Migration
         try {
             $path = base_path($file);
             Database::seed_from_yaml_file($path, false);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::error('Unable to load '.$file.' file');
             Log::error($e);
         }
@@ -54,7 +80,7 @@ abstract class Migration extends \Illuminate\Database\Migrations\Migration
         foreach ($rows as $row) {
             try {
                 DB::table($table)->insert($row);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 // setting already exists, just ignore it
                 if ($e->getCode() === 23000) {
                     continue;

--- a/app/Database/migrations/2020_09_30_081536_create_modules_table.php
+++ b/app/Database/migrations/2020_09_30_081536_create_modules_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
+use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -19,6 +19,12 @@ class CreateModulesTable extends Migration
             $table->boolean('enabled')->default(1);
             $table->timestamps();
         });
+
+        $this->addModule(['name' => 'Awards']);
+        $this->addModule(['name' => 'Sample']);
+        $this->addModule(['name' => 'VMSAcars']);
+        $this->addModule(['name' => 'Vacentral']);
+        $this->addModule(['name' => 'TestModule']);
     }
 
     /**

--- a/app/Database/seeds/DatabaseSeeder.php
+++ b/app/Database/seeds/DatabaseSeeder.php
@@ -1,15 +1,21 @@
 <?php
 
+use App\Services\Installer\MigrationService;
 use App\Services\Installer\SeederService;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    private $seederService;
+    /** @var MigrationService */
+    private $migrationSvc;
+
+    /** @var SeederService */
+    private $seederSvc;
 
     public function __construct()
     {
-        $this->seederService = app(SeederService::class);
+        $this->migrationSvc = app(MigrationService::class);
+        $this->seederSvc = app(SeederService::class);
     }
 
     /**
@@ -19,6 +25,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->seederService->syncAllSeeds();
+        // Make sure any migrations that need to be run are run/cleared out
+        if ($this->migrationSvc->migrationsAvailable()) {
+            $this->migrationSvc->runAllMigrations();
+        }
+
+        // Then sync all of the seeds
+        $this->seederSvc->syncAllSeeds();
     }
 }

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -3,9 +3,13 @@
 namespace App\Models;
 
 use App\Contracts\Model;
+use Carbon\Carbon;
 
 /**
- * Class ModuleManager
+ * @property string name
+ * @property bool   enabled
+ * @property Carbon created_at
+ * @property Carbon updated_at
  */
 class Module extends Model
 {

--- a/app/Services/Installer/DatabaseService.php
+++ b/app/Services/Installer/DatabaseService.php
@@ -47,6 +47,7 @@ class DatabaseService extends Service
         } catch (\PDOException $e) {
             throw $e;
         }
+
         return true;
     }
 

--- a/app/Services/Installer/MigrationService.php
+++ b/app/Services/Installer/MigrationService.php
@@ -61,7 +61,7 @@ class MigrationService extends Service
         $files = $migrator->getMigrationFiles(array_values($migration_dirs));
 
         foreach ($files as $filename => $filepath) {
-            if (in_array($filename, $runFiles)) {
+            if (in_array($filename, $runFiles, true)) {
                 continue;
             }
 

--- a/app/Services/Installer/MigrationService.php
+++ b/app/Services/Installer/MigrationService.php
@@ -52,9 +52,11 @@ class MigrationService extends Service
 
         $availMigrations = [];
         $runFiles = [];
+
         try {
             $runFiles = $migrator->getRepository()->getRan();
-        } catch (Exception $e) { } // Skip database run initialized
+        } catch (Exception $e) {
+        } // Skip database run initialized
 
         $files = $migrator->getMigrationFiles(array_values($migration_dirs));
 
@@ -94,6 +96,6 @@ class MigrationService extends Service
         $ret = $migrator->run($availMigrations);
         Log::info('Ran '.count($ret).' migrations');
 
-        return $output."\n".join("\n", $ret);
+        return $output."\n".implode("\n", $ret);
     }
 }

--- a/app/Services/Installer/SeederService.php
+++ b/app/Services/Installer/SeederService.php
@@ -56,10 +56,10 @@ class SeederService extends Service
      */
     public function syncAllSeeds(): void
     {
-        $this->syncAllYamlFileSeeds();
         $this->syncAllSettings();
         $this->syncAllPermissions();
         $this->syncAllModules();
+        $this->syncAllYamlFileSeeds();
     }
 
     /**

--- a/app/Services/ModuleService.php
+++ b/app/Services/ModuleService.php
@@ -125,8 +125,12 @@ class ModuleService extends Service
                 'name'    => $module_name,
                 'enabled' => 1,
             ]);
+
+            Artisan::call('module:migrate '.$module_name);
+
             return true;
         }
+
         return false;
     }
 
@@ -240,6 +244,11 @@ class ModuleService extends Service
         $module->update([
             'enabled' => $status,
         ]);
+
+        if ($status === true) {
+            Artisan::call('module:migrate '.$module->name);
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Something of a race condition happens when there are module migrations pending, but they're not picked up when the migration hasn't yet been loaded. This is an issue when there is seed data which depends on the migrations to run. So, before running the seeds, check for any pending migrations, but also in the installer, after running the initial migrations, check again for pending migrations, where the initial sets of modules that are running would have been loaded in.

cc @YashGovekar 