### PR TITLE
Flight/Subfleet fares not returning in API #899

### DIFF
--- a/app/Console/Commands/CreateDatabase.php
+++ b/app/Console/Commands/CreateDatabase.php
@@ -92,8 +92,9 @@ class CreateDatabase extends Command
         }
 
         if ($this->option('reset') === true) {
-            $cmd = ['rm', '-rf', config($dbkey.'database')];
-            $this->runCommand($cmd);
+            if (file_exists($dbPath)) {
+                unlink(config($dbkey.'database'));
+            }
         }
 
         if (!file_exists($dbPath)) {

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -54,9 +54,13 @@ class FlightController extends Controller
      */
     public function get($id)
     {
+        /** @var \App\Models\User $user */
         $user = Auth::user();
+
+        /** @var \App\Models\Flight $flight */
         $flight = $this->flightRepo->with([
             'airline',
+            'fares',
             'subfleets',
             'subfleets.aircraft',
             'subfleets.fares',
@@ -66,7 +70,7 @@ class FlightController extends Controller
             },
         ])->find($id);
 
-        $this->flightSvc->filterSubfleets(Auth::user(), $flight);
+        $flight = $this->flightSvc->filterSubfleets($user, $flight);
 
         return new FlightResource($flight);
     }
@@ -109,6 +113,7 @@ class FlightController extends Controller
             $flights = $this->flightRepo
                 ->with([
                     'airline',
+                    'fares',
                     'subfleets',
                     'subfleets.aircraft',
                     'subfleets.fares',
@@ -124,7 +129,7 @@ class FlightController extends Controller
 
         // TODO: Remove any flights here that a user doesn't have permissions to
         foreach ($flights as $flight) {
-            $this->flightSvc->filterSubfleets(Auth::user(), $flight);
+            $this->flightSvc->filterSubfleets($user, $flight);
         }
 
         return FlightResource::collection($flights);

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -61,7 +61,8 @@ class UserController extends Controller
      */
     protected function getUserId(Request $request)
     {
-        if ($request->get('id') === null) {
+        $id = $request->get('id');
+        if ($id === null || $id === 'me') {
             return Auth::user()->id;
         }
 

--- a/app/Http/Resources/Fare.php
+++ b/app/Http/Resources/Fare.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
+use App\Services\FareService;
 
 /**
  * @mixin \App\Models\Fare
@@ -11,13 +12,17 @@ class Fare extends Resource
 {
     public function toArray($request)
     {
+        /** @var FareService $fareSvc */
+        $fareSvc = app(FareService::class);
+        $fare = $fareSvc->getFares($this);
+
         return [
-            'id'       => $this->id,
-            'code'     => $this->code,
-            'name'     => $this->name,
-            'price'    => $this->price,
-            'cost'     => $this->cost,
-            'capacity' => $this->capacity,
+            'id'       => $fare->id,
+            'code'     => $fare->code,
+            'name'     => $fare->name,
+            'capacity' => $fare->capacity,
+            'cost'     => $fare->cost,
+            'price'    => $fare->price,
             'type'     => $this->type,
             'notes'    => $this->notes,
             'active'   => $this->active,

--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -58,6 +58,7 @@ class Flight extends Resource
 
         $res['airline'] = new Airline($this->airline);
         $res['subfleets'] = Subfleet::collection($this->whenLoaded('subfleets'));
+        $res['fares'] = Fare::collection($this->whenLoaded('fares'));
         $res['fields'] = $this->setFields();
 
         // Simbrief info

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -580,6 +580,7 @@ class RouteServiceProvider extends ServiceProvider
                 Route::post('user/bids', 'UserController@bids');
                 Route::delete('user/bids', 'UserController@bids');
 
+                Route::get('users/me', 'UserController@index');
                 Route::get('users/{id}', 'UserController@get');
                 Route::get('users/{id}/fleet', 'UserController@fleet');
                 Route::get('users/{id}/pireps', 'UserController@pireps');

--- a/app/Services/BidService.php
+++ b/app/Services/BidService.php
@@ -45,6 +45,7 @@ class BidService extends Service
     {
         $bids = Bid::with([
             'flight',
+            'flight.fares',
             'flight.simbrief',
             'flight.subfleets',
             'flight.subfleets.aircraft',

--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -60,13 +60,13 @@ class FareService extends Service
     }
 
     /**
-     * Get fares
+     * Get a fare with the proper prices/costs populated in the pivot
      *
      * @param $fare
      *
      * @return mixed
      */
-    protected function getFares($fare)
+    public function getFares($fare)
     {
         $pivot = $fare->pivot;
         if (filled($pivot->price)) {

--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -16,6 +16,7 @@ use App\Support\Units\Time;
 class FlightService extends Service
 {
     private $airportSvc;
+    private $fareSvc;
     private $flightRepo;
     private $navDataRepo;
     private $userSvc;
@@ -24,17 +25,20 @@ class FlightService extends Service
      * FlightService constructor.
      *
      * @param AirportService    $airportSvc
+     * @param FareService       $fareSvc
      * @param FlightRepository  $flightRepo
      * @param NavdataRepository $navdataRepo
      * @param UserService       $userSvc
      */
     public function __construct(
         AirportService $airportSvc,
+        FareService $fareSvc,
         FlightRepository $flightRepo,
         NavdataRepository $navdataRepo,
         UserService $userSvc
     ) {
         $this->airportSvc = $airportSvc;
+        $this->fareSvc = $fareSvc;
         $this->flightRepo = $flightRepo;
         $this->navDataRepo = $navdataRepo;
         $this->userSvc = $userSvc;

--- a/tests/FinanceTest.php
+++ b/tests/FinanceTest.php
@@ -16,6 +16,7 @@ use App\Models\Subfleet;
 use App\Models\User;
 use App\Repositories\ExpenseRepository;
 use App\Repositories\JournalRepository;
+use App\Services\BidService;
 use App\Services\FareService;
 use App\Services\Finance\PirepFinanceService;
 use App\Services\FleetService;
@@ -276,6 +277,49 @@ class FinanceTest extends TestCase
         $this->assertCount(1, $body['subfleets']);
         $this->assertEquals(50, $body['fares'][0]['price']);
         $this->assertEquals($fare->capacity, $body['fares'][0]['capacity']);
+    }
+
+    public function testFlightFaresOverAPIOnUserBids()
+    {
+        $this->updateSetting('pireps.only_aircraft_at_dpt_airport', false);
+        $this->updateSetting('pireps.restrict_aircraft_to_rank', false);
+
+        /** @var BidService $bidSvc */
+        $bidSvc = app(BidService::class);
+
+        $this->user = factory(User::class)->create();
+
+        /** @var Flight $flight */
+        $flight = factory(Flight::class)->create();
+
+        /** @var Subfleet $subfleet */
+        $subfleet = factory(Subfleet::class)->create();
+        $this->fleetSvc->addSubfleetToFlight($subfleet, $flight);
+
+        /** @var Fare $fare */
+        $fare = factory(Fare::class)->create();
+
+        $this->fareSvc->setForFlight($flight, $fare);
+        $flight_fares = $this->fareSvc->getForFlight($flight);
+
+        $this->assertCount(1, $flight_fares);
+        $this->assertEquals($fare->price, $flight_fares->get(0)->price);
+        $this->assertEquals($fare->capacity, $flight_fares->get(0)->capacity);
+
+        //
+        // set an override now (but on the flight)
+        //
+        $this->fareSvc->setForFlight($flight, $fare, ['price' => 50]);
+        $bid = $bidSvc->addBid($flight, $this->user);
+
+        $req = $this->get('/api/user/bids');
+        $req->assertStatus(200);
+
+        $body = $req->json()['data'];
+        $this->assertEquals($flight->id, $body[0]['flight_id']);
+        $this->assertCount(1, $body[0]['flight']['subfleets']);
+        $this->assertEquals(50, $body[0]['flight']['fares'][0]['price']);
+        $this->assertEquals($fare->capacity, $body[0]['flight']['fares'][0]['capacity']);
     }
 
     public function testSubfleetFaresOverAPI()

--- a/tests/FlightTest.php
+++ b/tests/FlightTest.php
@@ -34,50 +34,6 @@ class FlightTest extends TestCase
     }
 
     /**
-     * Add a single flight
-     *
-     * @param       $user
-     * @param array $flight_properties
-     *
-     * @return mixed
-     */
-    public function addFlight($user, $flight_properties = [])
-    {
-        $opts = array_merge([
-            'airline_id' => $user->airline_id,
-        ], $flight_properties);
-
-        $flight = factory(Flight::class)->create($opts);
-
-        $flight->subfleets()->syncWithoutDetaching([
-            factory(Subfleet::class)->create([
-                'airline_id' => $user->airline_id,
-            ])->id,
-        ]);
-
-        return $flight;
-    }
-
-    /**
-     * Add a given number of flights for a subfleet
-     *
-     * @param $subfleet
-     * @param $num_flights
-     *
-     * @return \App\Models\Flight[]
-     */
-    public function addFlightsForSubfleet($subfleet, $num_flights)
-    {
-        return factory(Flight::class, $num_flights)->create([
-            'airline_id' => $subfleet->airline->id,
-        ])->each(function (Flight $f) use ($subfleet) {
-            $f->subfleets()->syncWithoutDetaching([
-                $subfleet->id,
-            ]);
-        });
-    }
-
-    /**
      * Test adding a flight and also if there are duplicates
      */
     public function testDuplicateFlight()
@@ -468,7 +424,11 @@ class FlightTest extends TestCase
     public function testFlightSearchApiDistance()
     {
         $total_flights = 10;
+
+        /** @var \App\Models\User user */
         $this->user = factory(User::class)->create();
+
+        /** @var \App\Models\Flight $flights */
         $flights = factory(Flight::class, $total_flights)->create([
             'airline_id' => $this->user->airline_id,
         ]);

--- a/tests/SubfleetTest.php
+++ b/tests/SubfleetTest.php
@@ -3,8 +3,6 @@
 namespace Tests;
 
 use App\Models\Fare;
-use App\Models\Subfleet;
-use App\Models\User;
 use App\Services\FareService;
 
 class SubfleetTest extends TestCase

--- a/tests/SubfleetTest.php
+++ b/tests/SubfleetTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use App\Models\Fare;
 use App\Models\Subfleet;
+use App\Models\User;
 use App\Services\FareService;
 
 class SubfleetTest extends TestCase
@@ -19,9 +20,15 @@ class SubfleetTest extends TestCase
 
     public function testSubfleetFaresNoOverride()
     {
+        /** @var FareService $fare_svc */
         $fare_svc = app(FareService::class);
 
-        $subfleet = factory(Subfleet::class)->create();
+        $subfleet_aircraft = $this->createSubfleetWithAircraft(1);
+
+        /** @var \App\Models\Subfleet $subfleet */
+        $subfleet = $subfleet_aircraft['subfleet'];
+
+        /** @var \App\Models\Fare $fare */
         $fare = factory(Fare::class)->create();
 
         $fare_svc->setForSubfleet($subfleet, $fare);
@@ -52,9 +59,13 @@ class SubfleetTest extends TestCase
 
     public function testSubfleetFaresOverride()
     {
+        /** @var FareService $fare_svc */
         $fare_svc = app(FareService::class);
 
+        /** @var Subfleet $subfleet */
         $subfleet = factory(Subfleet::class)->create();
+
+        /** @var \App\Models\Fare $fare */
         $fare = factory(Fare::class)->create();
 
         $fare_svc->setForSubfleet($subfleet, $fare, [

--- a/tests/SubfleetTest.php
+++ b/tests/SubfleetTest.php
@@ -56,44 +56,4 @@ class SubfleetTest extends TestCase
         $fare_svc->delFareFromSubfleet($subfleet, $fare);
         $this->assertCount(0, $fare_svc->getForSubfleet($subfleet));
     }
-
-    public function testSubfleetFaresOverride()
-    {
-        /** @var FareService $fare_svc */
-        $fare_svc = app(FareService::class);
-
-        /** @var Subfleet $subfleet */
-        $subfleet = factory(Subfleet::class)->create();
-
-        /** @var \App\Models\Fare $fare */
-        $fare = factory(Fare::class)->create();
-
-        $fare_svc->setForSubfleet($subfleet, $fare, [
-            'price' => 50, 'capacity' => 400,
-        ]);
-
-        $ac_fares = $fare_svc->getForSubfleet($subfleet);
-
-        $this->assertCount(1, $ac_fares);
-        $this->assertEquals(50, $ac_fares[0]->price);
-        $this->assertEquals(400, $ac_fares[0]->capacity);
-
-        //
-        // update the override to a different amount and make sure it updates
-        //
-
-        $fare_svc->setForSubfleet($subfleet, $fare, [
-            'price' => 150, 'capacity' => 50,
-        ]);
-
-        $ac_fares = $fare_svc->getForSubfleet($subfleet);
-
-        $this->assertCount(1, $ac_fares);
-        $this->assertEquals(150, $ac_fares[0]->price);
-        $this->assertEquals(50, $ac_fares[0]->capacity);
-
-        // delete
-        $fare_svc->delFareFromSubfleet($subfleet, $fare);
-        $this->assertCount(0, $fare_svc->getForSubfleet($subfleet));
-    }
 }

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -75,7 +75,6 @@ trait TestData
         return $rank;
     }
 
-
     /**
      * Add a single flight
      *


### PR DESCRIPTION
- Adds new `fares` section in the flight response which should be used if there are overriding fares on the flight itself

Closes #899