### PR TITLE
Refactor fares inheritance #905

### DIFF
--- a/app/Http/Resources/Fare.php
+++ b/app/Http/Resources/Fare.php
@@ -3,7 +3,6 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
-use App\Services\FareService;
 
 /**
  * @mixin \App\Models\Fare

--- a/app/Http/Resources/Fare.php
+++ b/app/Http/Resources/Fare.php
@@ -12,17 +12,13 @@ class Fare extends Resource
 {
     public function toArray($request)
     {
-        /** @var FareService $fareSvc */
-        $fareSvc = app(FareService::class);
-        $fare = $fareSvc->getFares($this);
-
         return [
-            'id'       => $fare->id,
-            'code'     => $fare->code,
-            'name'     => $fare->name,
-            'capacity' => $fare->capacity,
-            'cost'     => $fare->cost,
-            'price'    => $fare->price,
+            'id'       => $this->id,
+            'code'     => $this->code,
+            'name'     => $this->name,
+            'capacity' => $this->capacity,
+            'cost'     => $this->cost,
+            'price'    => $this->price,
             'type'     => $this->type,
             'notes'    => $this->notes,
             'active'   => $this->active,

--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -58,7 +58,6 @@ class Flight extends Resource
 
         $res['airline'] = new Airline($this->airline);
         $res['subfleets'] = Subfleet::collection($this->whenLoaded('subfleets'));
-        $res['fares'] = Fare::collection($this->whenLoaded('fares'));
         $res['fields'] = $this->setFields();
 
         // Simbrief info

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -25,6 +25,10 @@ use Illuminate\Support\Collection;
  * @property int        distance
  * @property int        flight_time
  * @property string     route
+ * @property string     dpt_time
+ * @property string     arr_time
+ * @property string     flight_type
+ * @property string     notes
  * @property int        level
  * @property float      load_factor
  * @property float      load_factor_variance

--- a/app/Services/BidService.php
+++ b/app/Services/BidService.php
@@ -13,11 +13,15 @@ use Illuminate\Support\Facades\Log;
 
 class BidService extends Service
 {
+    /** @var FareService */
+    private $fareSvc;
+
     /** @var FlightService */
     private $flightSvc;
 
-    public function __construct(FlightService $flightSvc)
+    public function __construct(FareService $fareSvc, FlightService $flightSvc)
     {
+        $this->fareSvc = $fareSvc;
         $this->flightSvc = $flightSvc;
     }
 
@@ -26,7 +30,7 @@ class BidService extends Service
      *
      * @param $bid_id
      *
-     * @return \App\Models\Bid|\Illuminate\Database\Eloquent\Model|object|null
+     * @return \App\Models\Bid|\Illuminate\Database\Eloquent\Model|tests/ImporterTest.php:521object|null
      */
     public function getBid($bid_id)
     {
@@ -55,6 +59,7 @@ class BidService extends Service
 
         foreach ($bids as $bid) {
             $bid->flight = $this->flightSvc->filterSubfleets($user, $bid->flight);
+            $bid->flight = $this->fareSvc->getReconciledFaresForFlight($bid->flight);
         }
 
         return $bids;

--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -9,17 +9,17 @@ use App\Models\Pirep;
 use App\Models\PirepFare;
 use App\Models\Subfleet;
 use App\Support\Math;
-use Illuminate\Database\Eloquent\Relations\Pivot;
-use InvalidArgumentException;
 use function count;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
 
 class FareService extends Service
 {
     /**
      * @param Collection[Fare] $subfleet_fares The fare for a subfleet
-     * @param Collection[Fare] $flight_fares The fares on a flight
+     * @param Collection[Fare] $flight_fares   The fares on a flight
      *
      * @return Collection[Fare] Collection of Fare
      */
@@ -37,7 +37,7 @@ class FareService extends Service
          * flight, no matter how rare that might be
          */
         if ($subfleet_fares === null || count($subfleet_fares) === 0) {
-            return $flight_fares->map(function($fare, $_) {
+            return $flight_fares->map(function ($fare, $_) {
                 return $this->getFareWithPivot($fare, $fare->pivot);
             });
         }

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -476,6 +476,7 @@ class ImporterTest extends TestCase
         $this->assertCount(1, $status['errors']);
 
         // See if it imported
+        /** @var Flight $flight */
         $flight = Flight::where([
             'airline_id'    => $airline->id,
             'flight_number' => '1972',
@@ -514,7 +515,7 @@ class ImporterTest extends TestCase
         $this->assertEquals('C41', $dep_gate['value']);
 
         // Check the fare class
-        $fares = $this->fareSvc->getForFlight($flight);
+        $fares = $this->fareSvc->getFareWithOverrides(null, $flight->fares);
         $this->assertCount(3, $fares);
 
         $first = $fares->where('code', 'Y')->first();


### PR DESCRIPTION
Refactor the fares inheritance so it reads as `flight->(subfleet)->fare`, instead of just `flight->fare`.

Closes #905 