### PR TITLE
PIREP fares refactoring #903

### DIFF
--- a/app/Database/migrations/2020_10_28_081536_modify_pirep_fares.php
+++ b/app/Database/migrations/2020_10_28_081536_modify_pirep_fares.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyPirepFares extends Migration
+{
+    /**
+     * Modify the PIREP fares table so that we can save all of the fares for that particular PIREP
+     * Basically copy all of those fields over, and then use this table directly, instead of the
+     * relationship to the fares table
+     *
+     * @return void
+     */
+    public function up()
+    {
+        /*
+         * Add the columns we need from the fares table so then this is now "fixed" in time
+         */
+        Schema::table('pirep_fares', function (Blueprint $table) {
+            $table->unsignedInteger('fare_id')->change()->nullable()->default(0);
+
+            $table->string('code', 50)->unique();
+            $table->string('name', 50);
+            $table->unsignedDecimal('price')->nullable()->default(0.00);
+            $table->unsignedDecimal('cost')->nullable()->default(0.00);
+            $table->unsignedInteger('capacity')->nullable()->default(0);
+        });
+
+        /**
+         * Now iterate through the existing table and copy/update everything
+         * Some fares might already have been removed deleted so just insert some null/errored
+         * values for those
+         */
+    }
+
+    public function down()
+    {
+    }
+}

--- a/app/Database/migrations/2020_10_28_081536_modify_pirep_fares.php
+++ b/app/Database/migrations/2020_10_28_081536_modify_pirep_fares.php
@@ -2,6 +2,7 @@
 
 use App\Contracts\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class ModifyPirepFares extends Migration
@@ -21,8 +22,11 @@ class ModifyPirepFares extends Migration
         Schema::table('pirep_fares', function (Blueprint $table) {
             $table->unsignedInteger('fare_id')->change()->nullable()->default(0);
 
-            $table->string('code', 50)->unique();
+            $table->string('code', 50);
             $table->string('name', 50);
+
+            // count is already there
+
             $table->unsignedDecimal('price')->nullable()->default(0.00);
             $table->unsignedDecimal('cost')->nullable()->default(0.00);
             $table->unsignedInteger('capacity')->nullable()->default(0);
@@ -33,6 +37,13 @@ class ModifyPirepFares extends Migration
          * Some fares might already have been removed deleted so just insert some null/errored
          * values for those
          */
+        $parent_fares = [];
+        $fares = DB::table('pirep_fares')->get();
+        foreach ($fares as $fare) {
+            if (empty($parent_fares[$fare->fare_id])) {
+                $parent_fares[$fare->fare_id] = DB::table('fares')->where('id', $fare->fare_id)->first();
+            }
+        }
     }
 
     public function down()

--- a/app/Models/PirepFare.php
+++ b/app/Models/PirepFare.php
@@ -4,6 +4,14 @@ namespace App\Models;
 
 use App\Contracts\Model;
 
+/**
+ * @property int     code
+ * @property string  name
+ * @property float   cost
+ * @property float   price
+ * @property int     capacity
+ * @property int     count
+ */
 class PirepFare extends Model
 {
     public $table = 'pirep_fares';
@@ -11,25 +19,24 @@ class PirepFare extends Model
 
     protected $fillable = [
         'pirep_id',
-        'fare_id',
+        'code',
+        'name',
         'count',
+        'price',
+        'cost',
+        'capacity',
     ];
 
     protected $casts = [
-        'count' => 'integer',
+        'count'    => 'integer',
+        'price'    => 'float',
+        'cost'     => 'float',
+        'capacity' => 'integer',
     ];
 
     public static $rules = [
         'count' => 'required',
     ];
-
-    /**
-     * Relationships
-     */
-    public function fare()
-    {
-        return $this->belongsTo(Fare::class, 'fare_id');
-    }
 
     public function pirep()
     {


### PR DESCRIPTION
Create copy of the fares that are submitted at the time the PIREP is submitted, disconnecting them from the fares table, where fares might be deleted/modified/removed and maybe change, depending on the inheritence. This should fix any errors that are happening because a fare is changed/removed.

- [ ] Migrate the fares data from the PIREP into the current table (account for inheritence)
- [ ] Update the insertion code to remove the relationship (leave old `fare_id` in there for reference)
- [ ] PIREP finance changes
- [ ] Look at other finance data that might need to be preserved
- [ ] Unit test updates (shouldn't need too many changes)

Closes #903 

