### PR TITLE
Oxymoron/doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://travis-ci.org/nabeelio/phpvms.svg)](https://travis-ci.org/nabeelio/phpvms) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d668bebb0a3c46bda381af16ce3d9450)](https://www.codacy.com/app/nabeelio/phpvms?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nabeelio/phpvms&amp;utm_campaign=Badge_Grade) [![Latest Stable Version](https://poser.pugx.org/nabeel/phpvms/v/stable)](https://packagist.org/packages/nabeel/phpvms) ![StyleCI](https://github.styleci.io/repos/93688482/shield?branch=dev) [![License](https://poser.pugx.org/nabeel/phpvms/license)](https://packagist.org/packages/nabeel/phpvms)
 
-The next phpvms version built on the laravel framework. work in progress. The latest documentation, with installation instructions is available 
-                                                                          [on the phpVMS documentation](http://docs.phpvms.net/) page.
+The next phpvms version built on the laravel framework. work in progress. The latest documentation, with installation instructions is available [on the phpVMS documentation](https://docs.phpvms.net/) page.
 
 # installation
 
@@ -24,14 +23,14 @@ A full distribution, with all of the composer dependencies, is available at this
 - Database:
   - MySQL 5.5+ (or MySQL variant, including MariaDB and Percona)
 
-[View more details on requirements](http://docs.phpvms.net/setup/requirements)
+[View more details on requirements](https://docs.phpvms.net/requirements)
 
 ## Installer
 
 1. Upload to your server
 1. Visit the site, and follow the link to the installer
 
-[View installation details](http://docs.phpvms.net/setup/installation)
+[View installation details](https://docs.phpvms.net/installation/installation)
 
 # development environment
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# phpvms <sup>7</sup>
+# phpVMS <sup>7</sup>
 
 [![Build Status](https://travis-ci.org/nabeelio/phpvms.svg)](https://travis-ci.org/nabeelio/phpvms) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d668bebb0a3c46bda381af16ce3d9450)](https://www.codacy.com/app/nabeelio/phpvms?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nabeelio/phpvms&amp;utm_campaign=Badge_Grade) [![Latest Stable Version](https://poser.pugx.org/nabeel/phpvms/v/stable)](https://packagist.org/packages/nabeel/phpvms) ![StyleCI](https://github.styleci.io/repos/93688482/shield?branch=dev) [![License](https://poser.pugx.org/nabeel/phpvms/license)](https://packagist.org/packages/nabeel/phpvms)
 
 The next phpvms version built on the laravel framework. work in progress. The latest documentation, with installation instructions is available [on the phpVMS documentation](https://docs.phpvms.net/) page.
 
-# installation
+## Installation
 
 A full distribution, with all of the composer dependencies, is available at this 
 [GitHub Releases](https://github.com/nabeelio/phpvms/releases) link. 
 
-
-
-## Requirements
+### Requirements
 
 - PHP 7.3+, extensions:
   - cURL
@@ -25,14 +23,14 @@ A full distribution, with all of the composer dependencies, is available at this
 
 [View more details on requirements](https://docs.phpvms.net/requirements)
 
-## Installer
+### Installer
 
 1. Upload to your server
 1. Visit the site, and follow the link to the installer
 
 [View installation details](https://docs.phpvms.net/installation/installation)
 
-# development environment
+## Development Environment
 
 A full development environment can be brought up using Docker:
 
@@ -49,7 +47,7 @@ Then go to `http://localhost`. If you're using dnsmasq, the `app` container is l
 127.0.0.1   phpvms.test
 ```
 
-## Building JS/CSS assets
+### Building JS/CSS assets
 
 Yarn is required, run:
 


### PR DESCRIPTION
Some of the documentation links were broken and lead to the infamous 404 error. I've updated the links to what I believe is correct. However, I'm not sure about the installation link. Let me know if you would like for me to change it to something else.

Also, there was some weird whitespace thing going on with the first paragraph? I just removed it, I didn't see any value in having it there. Probably was injected by some sort of WYSIWYG editor or something.

Also, I modified the ATX headings to follow the style of markdown seen in most popular GitHub repositories. If that doesn't jive with you, I can remove that commit from this PR. But I think it flows better.