### PR TITLE
Update CSV export fields separator to compatibility

### DIFF
--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -27,6 +27,7 @@ class ExportService extends Service
     {
         $writer = Writer::createFromPath($path, 'w+');
         CharsetConverter::addTo($writer, 'utf-8', 'utf-8');
+        $writer->setDelimiter(';');
 
         return $writer;
     }


### PR DESCRIPTION
In Europe the decimal separator are "," but produce differets issues if you try to export fieds that have number with decimal places.

In addition "Microsoft Excel" use semicolon(;) how default separtor between fileds in a standar UTF8 files.

The RFC4180 https://tools.ietf.org/html/rfc4180 don't limit the character used to separate this fields, show i think that it's better use this.

This solve #844 