### PR TITLE
Fix allowing to install while using table prefix

### DIFF
--- a/app/Database/migrations/2020_03_28_174238_airline_remove_nullable.php
+++ b/app/Database/migrations/2020_03_28_174238_airline_remove_nullable.php
@@ -9,7 +9,7 @@ class AirlineRemoveNullable extends Migration
     public function up()
     {
         Schema::table('airlines', function (Blueprint $table) {
-            $table->dropUnique('airlines_iata_unique');
+            $table->dropUnique(['iata']);
         });
     }
 


### PR DESCRIPTION
This is fix for my issue #934.

Originally the Unique index is passed to dropUnique as a string, not taking the prefix in account. We should use array instead to allow Laravel to do its job and convert our passed value to prefix_table_column_unique name).