### PR TITLE
Update Simbrief Briefing Display

### DIFF
--- a/resources/views/layouts/default/flights/simbrief_briefing.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_briefing.blade.php
@@ -124,22 +124,29 @@
           </div>
 
           <div class="form-container">
-            <h6><i class="fas fa-info-circle"></i>
-              &nbsp;Weather
-            </h6>
+            <h6><i class="fas fa-info-circle"></i>&nbsp;Weather</h6>
             <div class="form-container-body">
               <div class="row">
                 <div class="col-12">
                   <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Departure METAR</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">
-                      {{ $simbrief->xml->weather->orig_metar }}</p>
+                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->orig_metar }}</p>
                   </div>
-
+                  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Departure TAF</p>
+                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->orig_taf }}</p>
+                  </div>
                   <hr/>
-
-                  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Arrival METAR</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">
-                      {{  $simbrief->xml->weather->dest_metar }}</p>
+                  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Destination METAR</p>
+                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->dest_metar }}</p>
+                  </div>
+                  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Destination TAF</p>
+                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->dest_taf }}</p>
+                  </div>
+				          <hr/>
+				          <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Alternate METAR</p>
+                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->altn_metar }}</p>
+                  </div>
+                  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Alternate TAF</p>
+                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->altn_taf }}</p>
                   </div>
                 </div>
               </div>
@@ -169,12 +176,64 @@
               </div>
             </div>
           </div>
+          
+          <div class="form-container">
+            <h6><i class="fas fa-info-circle"></i>&nbsp;Prefile ATC Flight Plan</h6>
+            <div class="form-container-body">
+              <div class="row">
+                <div class="col-6" align="center">
+				          @php
+					          $str = $simbrief->xml->aircraft->equip ;
+					          $wc = stripos($str,"-");
+					          $tr = stripos($str,"/");
+					          $wakecat = substr($str,0,$wc);
+					          $equipment = substr($str,$wc+1,$tr-2);
+					          $transponder = substr($str,$tr+1);
+				          @endphp
+				        <form action="https://fpl.ivao.aero/api/fp/load" method="POST" target="_blank">
+            		  <input type="hidden" name="CALLSIGN" value="{{ $simbrief->xml->atc->callsign }}" />
+            		  <input type="hidden" name="RULES" value="I" />
+           			  <input type="hidden" name="FLIGHTTYPE" value="N" />
+            		  <input type="hidden" name="NUMBER" value="1" />
+            		  <input type="hidden" name="ACTYPE" value="{{ $simbrief->xml->aircraft->icaocode }}" />
+            		  <input type="hidden" name="WAKECAT" value="{{ $wakecat }}" />
+            		  <input type="hidden" name="EQUIPMENT" value="{{ $equipment }}" />
+            		  <input type="hidden" name="TRANSPONDER" value="{{ $transponder }}" />
+           			  <input type="hidden" name="DEPICAO" value="{{ $simbrief->xml->origin->icao_code}}" />
+            		  <input type="hidden" name="DEPTIME" value="{{ date('Hi', $simbrief->xml->times->est_out->__toString())."" }}" />
+            		  <input type="hidden" name="SPEEDTYPE" value="{{ $simbrief->xml->atc->initial_spd_unit }}" />
+            		  <input type="hidden" name="SPEED" value="{{ $simbrief->xml->atc->initial_spd }}" />
+            		  <input type="hidden" name="LEVELTYPE" value="{{ $simbrief->xml->atc->initial_alt_unit }}" />
+            		  <input type="hidden" name="LEVEL" value="{{ $simbrief->xml->atc->initial_alt }}" />
+            		  <input type="hidden" name="ROUTE" value="{{ $simbrief->xml->general->route_ifps }}" />
+            		  <input type="hidden" name="DESTICAO" value="{{ $simbrief->xml->destination->icao_code }}" />
+            		  <input type="hidden" name="EET" value="@minutestotime($simbrief->xml->times->est_time_enroute / 60)" />
+            		  <input type="hidden" name="ALTICAO" value="{{ $simbrief->xml->alternate->icao_code}}" />
+            		  <input type="hidden" name="ALTICAO2" value="{{ $simbrief->xml->alternate2->icao_code}}" />
+            		  <input type="hidden" name="OTHER" value="{{ $simbrief->xml->atc->section18 }}" />
+            		  <input type="hidden" name="ENDURANCE" value="@minutestotime($simbrief->xml->times->endurance / 60)" />
+            		  <input type="hidden" name="POB" value="{{ $simbrief->xml->weights->pax_count }}" />
+            		  <input id="ivao_prefile" type="submit" class="btn btn-primary" value="File ATC on IVAO" />
+				        </form>	
+             </div>
+             <div class="col-6" align="center">
+				      <form action="https://my.vatsim.net/pilots/flightplan" method="GET" target="_blank">
+					        <input type="hidden" name="raw" value="{{ $simbrief->xml->atc->flightplan_text }}">
+					        <input type="hidden" name="fuel_time" value="@minutestotime($simbrief->xml->times->endurance / 60)">
+					        <input type="hidden" name="speed" value="{{ $simbrief->xml->atc->initial_spd }}">
+					        <input type="hidden" name="altitude" value="{{ $simbrief->xml->atc->initial_alt }}">
+					        <input id="vatsim_prefile" type="submit" class="btn btn-primary" value="File ATC on VATSIM"/>
+				        </form>
+              </div>				
+             </div>
+           </div>
+          </div>          
           <div class="form-container">
             <h6><i class="fas fa-info-circle"></i>
               &nbsp;OFP
             </h6>
             <div class="form-container-body border border-dark">
-              <div class="overflow-auto" style="height: 600px;">
+              <div class="overflow-auto" style="height: 750px;">
                 {!! $simbrief->xml->text->plan_html !!}
               </div>
             </div>


### PR DESCRIPTION
1. Added ATC Prefile options for IVAO and VATSIM
2. Added TAF reports for Origin, Destination and Alternate airports. 
   * Technically TAF reports are required for flights more than 1 hour, so we need to see them on the briefing page too
3. Adjusted the height of OFP div to match the visual style with the WX section changes