### PR TITLE
Update SimBrief Form

### DIFF
--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -198,8 +198,10 @@
 				@php
 					$FKMin = $flight->load_factor - $flight->load_factor_variance ;
 					$FKMax = $flight->load_factor + $flight->load_factor_variance ;
+				  	if($FKMax > 100) { $FKMax = 100 ;}
+				  	if($FKMin <= 0) { $FKMin = 1 ;}
 					$FKRandomLoad = rand($FKMin, $FKMax);
-				@endphp	
+				@endphp
 				@foreach($flight->subfleets as $SUB)
 					<div class="row">
 						<div class="col-sm-8">Configuration and Load Figures for <b>&nbsp;{{ $SUB->name }}&nbsp;</b> ;</div>
@@ -233,14 +235,14 @@
 		<input id="LoadSF{{ $SubFleetIDs->subfleet_id }}" type="hidden" name="{{ $SimBriefLoadType }}" class="form-control" value="{{ $CalcRandomLoad }}" disabled/>
   @endforeach			
 		<input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
-    <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
-    <input type="hidden" id="date" name="date" maxlength="9">
+    	<input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
+    	<input type="hidden" id="date" name="date" maxlength="9">
 		<input type="hidden" id="deph" name="deph" maxlength="2">
-    <input type="hidden" id="depm" name="depm" maxlength="2">
+    	<input type="hidden" id="depm" name="depm" maxlength="2">
 		<input type="hidden" id="steh" name="steh" maxlength="2">
 		<input type="hidden" id="stem" name="stem" maxlength="2">
-    <input type="hidden" name="selcal" value="BK-FS">
-    <input type="hidden" name="planformat" value="lido">
+    	<input type="hidden" name="selcal" value="BK-FS">
+    	<input type="hidden" name="planformat" value="lido">
 		<input type="hidden" name="omit_sids" value="0">
 		<input type="hidden" name="omit_stars" value="0">
 		<input type="hidden" name="cruise" value="CI">
@@ -446,20 +448,20 @@
 				var SubFleetsSB = "LoadSF".concat({{ $SubFleets->id }});
 				document.getElementById(SubFleetsSB).disabled = true;
 			@endforeach
-			var str = document.getElementById("AircraftSelect").value;
+		var str = document.getElementById("AircraftSelect").value;
   		var d1 = str.search(",");
-			var d2 = str.search("#");
+		var d2 = str.search("#");
   		var icao = str.slice(0, d1);
   		var registration = str.slice(d1+1,d2);
-			var subfleetid = str.slice(d2+1);
-			var SelectedSubFleetSB = "LoadSF".concat(subfleetid);
-				if (icao == "A20N") {icao = "A320"}; // Correction for A320 NEO
-				if (icao == "A21N") {icao = "A321"}; // Correction for A321 NEO
-				if (icao == "B77L") {icao = "B77F"}; // Correction for B777 Freighter
-				if (icao == "B773") {icao = "B77W"}; // Correction for B777-300
+		var subfleetid = str.slice(d2+1);
+		var SelectedSubFleetSB = "LoadSF".concat(subfleetid);
+			if (icao == "A20N") {icao = "A320"}; // Correction for A320 NEO
+			if (icao == "A21N") {icao = "A321"}; // Correction for A321 NEO
+			if (icao == "B77L") {icao = "B77F"}; // Correction for B777 Freighter
+			if (icao == "B773") {icao = "B77W"}; // Correction for B777-300
   		document.getElementById("type").value = icao;
   		document.getElementById("reg").value = registration;
-			document.getElementById(SelectedSubFleetSB).disabled = false;
+		document.getElementById(SelectedSubFleetSB).disabled = false;
 		}
 	</script>
 @endsection

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -2,42 +2,32 @@
 @section('title', 'Generate OFP')
 
 @section('content')
+  @php
+	$fareSvc = app(App\Services\FareService::class);
+	$flight = $fareSvc->getReconciledFaresForFlight($flight);		
+	@endphp
   <form id="sbapiform">
     <div class="row">
-      <div class="col-md-12">
-        <h2>Create Flight Briefing</h2>
+      <div class="col-md-12"><h2>Create Flight Briefing</h2>
         <div class="row">
           <div class="col-8">
-            <div class="form-container">
-              <h6><i class="fas fa-info-circle"></i>
-                &nbsp;@lang('pireps.flightinformations')
-              </h6>
+            <div class="form-container"><h6><i class="fas fa-info-circle"></i>&nbsp;@lang('pireps.flightinformations')</h6>
               <div class="form-container-body">
                 <div class="row">
                   <div class="col-sm-4">
-                    <label for="orig">Departure Airport</label>
-                    <input id="orig"
-                           name="orig"
-                           type="text"
-                           class="form-control"
-                           placeholder="ZZZZ"
-                           maxlength="4"
-                           value="{{ $flight->dpt_airport_id }}"/>
-                  </div>
-
-                  <div class="col-sm-4">
-                    <label for="dest">Arrival Airport</label>
-                    <input id="dest"
-                           name="dest"
-                           type="text"
-                           class="form-control"
-                           placeholder=""
-                           maxlength="4"
-                           value="{{ $flight->arr_airport_id }}"/>
-                  </div>
-
-                  <div class="col-sm-4">
-                    <label for="type">Aircraft</label>
+					        <label for="AircraftSelect">Aircraft Selection</label>
+						      <select name="AircraftSelect" class="form-control select2" id="AircraftSelect" onchange="SplitSelection()">
+						      <option value="ZZZZ,ZZZZZ" title="ZZZZ">Please Select An Aircraft</option>
+						      @foreach($flight->subfleets as $SFID)
+						      @php $AircraftList = App\Models\Aircraft::where('subfleet_id', $SFID->id)->orderBy('icao')->get(); @endphp
+   							    @foreach ($AircraftList as $AC)
+							        <option value="{{ $AC->icao }},{{ $AC->registration }}#{{ $AC->subfleet_id }}">[ {{ $AC->icao }} ] {{ $AC->registration }} @if($AC->registration <> $AC->name) '{{ $AC->name }}' @endif</option>
+							      @endforeach
+						     @endforeach
+						</select>
+	
+					<!-- Below value fields may be used to check SimBrief available types
+					<label for="type">Aircraft</label>
                     <select id="type" name="type" class="custom-select select2">
                       <option value="A306" title="A306">A306 - A300F4-600</option>
                       <option value="A310" title="A310 / CF6-80C2A2">A310 - A310-304</option>
@@ -106,7 +96,7 @@
                       <option value="CRJ9" title="CRJ9 / CF34-8C5">CRJ9 - CRJ-900</option>
                       <option value="CRJX" title="CRJX / CF34-8C5A1">CRJX - CRJ-1000</option>
                       <option value="DC10" title="DC10">DC10 - DC-10-30</option>
-                      <option value="DC6" title="DC6 / R2800-CB16">DC6&nbsp; - DC-6</option>
+                      <option value="DC6"  title="DC6 / R2800-CB16">DC6 - DC-6</option>
                       <option value="DC85" title="DC85 / JT3D-3B">DC85 - DC-8-55</option>
                       <option value="DH8A" title="DH8A / PW120A">DH8A - DHC8-102</option>
                       <option value="DH8B" title="DH8B / PW123C">DH8B - DHC8-200</option>
@@ -125,7 +115,7 @@
                       <option value="E50P" title="E50P / PW617F1-E">E50P - PHENOM 100</option>
                       <option value="E55P" title="E55P / PW535E">E55P - PHENOM 300</option>
                       <option value="EA50" title="EA50 / PW610F">EA50 - ECLIPSE 550</option>
-                      <option value="F50" title="F50">F50&nbsp; - FOKKER F50</option>
+                      <option value="F50"  title="F50">F50 - FOKKER F50</option>
                       <option value="FA50" title="FA50 / TFE 731-40">FA50 - FALCON 50EX</option>
                       <option value="GLF4" title="GLF4">GLF4 - GULFSTREAM</option>
                       <option value="H25B" title="H25B">H25B - HAWKER 800A</option>
@@ -145,109 +135,243 @@
                       <option value="RJ85" title="RJ85">RJ85 - AVRO RJ85</option>
                       <option value="SF34" title="SF34 / GE CT7-9B">SF34 - SAAB 340B</option>
                       <option value="SF50" title="SF50 / FJ33-5A">SF50 - VISION JET</option>
-                      <option value="SW4" title="SW4 / TPE-331">SW4&nbsp; - METROLINER</option>
+                      <option value="SW4"  title="SW4 / TPE-331">SW4 - METROLINER</option>
                       <option value="T154" title="T154">T154 - TU-154B2</option>
                       <option value="TBM9" title="TBM9 / PT6A-66D">TBM9 - TBM 900</option>
                     </select>
-                  </div>
-                </div>
+					    -->
               </div>
-            </div>
+				  <div class="col-sm-4">
+            <label for="type">ICAO Type</label>
+            <input id="type" name="type" type="text" class="form-control" placeholder="ZZZZ" maxlength="4" />
           </div>
-          <div class="col-4">
-            <div class="form-container">
-              <h6><i class="fas fa-info-circle"></i>
-                &nbsp;Briefing Options
-              </h6>
-              <table class="table table-hover table-striped">
-                <tr>
-                  <td>Units:</td>
-                  <td><select name="units">
-                      <option value="KGS">KGS</option>
-                      <option value="LBS" selected>LBS</option>
-                    </select></td>
-                </tr>
-                <tr>
-                  <td>Cont Fuel:</td>
-                  <td><select name="contpct">
-                      <option value="auto" selected>AUTO</option>
-                      <option value="0">0 PCT</option>
-                      <option value="0.02">2 PCT</option>
-                      <option value="0.03">3 PCT</option>
-                      <option value="0.05">5 PCT</option>
-                      <option value="0.1">10 PCT</option>
-                      <option value="0.15">15 PCT</option>
-                      <option value="0.2">20 PCT</option>
-                    </select></td>
-                </tr>
-                <tr>
-                  <td>Reserve Fuel:</td>
-                  <td><select name="resvrule">
-                      <option value="auto">AUTO</option>
-                      <option value="0">0 MIN</option>
-                      <option value="15">15 MIN</option>
-                      <option value="30">30 MIN</option>
-                      <option value="45" selected>45 MIN</option>
-                      <option value="60">60 MIN</option>
-                      <option value="75">75 MIN</option>
-                      <option value="90">90 MIN</option>
-                    </select></td>
-                </tr>
-                <tr>
-                  <td>Detailed Navlog:</td>
-                  <td><input type="hidden" name="navlog" value="0"><input type="checkbox" name="navlog" value="1"
-                                                                          checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>ETOPS Planning:</td>
-                  <td><input type="hidden" name="etops" value="0"><input type="checkbox" name="etops" value="1"></td>
-                </tr>
-                <tr>
-                  <td>Plan Stepclimbs:</td>
-                  <td><input type="hidden" name="stepclimbs" value="0"><input type="checkbox" name="stepclimbs"
-                                                                              value="1"
-                                                                              checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Runway Analysis:</td>
-                  <td><input type="hidden" name="tlr" value="0"><input type="checkbox" name="tlr" value="1" checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Include NOTAMS:</td>
-                  <td><input type="hidden" name="notams" value="0"><input type="checkbox" name="notams" value="1"
-                                                                          checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>FIR NOTAMS:</td>
-                  <td><input type="hidden" name="firnot" value="0"><input type="checkbox" name="firnot" value="1"></td>
-                </tr>
-                <tr>
-                  <td>Flight Maps:</td>
-                  <td><select name="maps">
-                      <option value="detail">Detailed</option>
-                      <option value="simple">Simple</option>
-                      <option value="none">None</option>
-                    </select></td>
-                </tr>
+					
+				  <div class="col-sm-4">
+            <label for="reg">Registration</label>
+            <input id="reg" name="reg" type="text" class="form-control" placeholder="ZZZZZ" maxlength="6" />
+          </div>
+        </div>
+				<div class="row"><br></div>
+				<div class="row">
+				  <div class="col-sm-4">
+            <label for="orig">Departure Airport</label>
+            <input id="orig" name="orig" type="text" class="form-control" maxlength="4" value="{{ $flight->dpt_airport_id }}" />
+          </div>
+          <div class="col-sm-4">
+            <label for="dest">Arrival Airport</label>
+            <input id="dest" name="dest" type="text" class="form-control" maxlength="4" value="{{ $flight->arr_airport_id }}" />
+          </div>
+					@php if($flight->alt_airport_id) { $ALTN = $flight->alt_airport_id ; } else { $ALTN = 'AUTO' ; } @endphp
+				  <div class="col-sm-4">
+            <label for="altn">Alternate Airport</label>
+            <input id="altn" name="altn" type="text" class="form-control" maxlength="4" value="{{ $ALTN }}"/>
+          </div>
+				</div>
+				<div class="row"><br></div>
+				<div class="row">
+					<div class="col-sm-8">
+					   <label for="route">Preferred Company Route</label>
+					   <input id="route" name="route" type="text" class="form-control" maxlength="1000" value="{{ $flight->route }}" />
+					</div>					
+					<div class="col-sm-4">
+					   <label for="fl">Preferred Flight Level</label>
+             <input id="fl" name="fl" type="text" class="form-control" maxlength="5" value="{{ $flight->level }}" />
+					</div>
+				</div>
+				<div class="row"><br></div>
+				<div class="row">
+					<div class="col-sm-4">
+						<label for="std">Scheduled Departure Time (UTC)</label>
+						<input id="std" type="text" class="form-control" maxlength="4" value="{{ $flight->dpt_time }}" disabled/>
+					</div>
+					<div class="col-sm-4">
+						<label for="etd">Estimated Departure Time (UTC)</label>
+						<input id="etd" type="text" class="form-control" maxlength="4" disabled/>
+					</div>
+					<div class="col-sm-4">
+						<label for="dof">Date Of Flight (UTC)</label>
+						<input id="dof" type="text" class="form-control" maxlength="4" disabled/>
+					</div>		
+				</div>
+				<hr>
+				<h6><i class="fas fa-info-circle"></i>&nbsp;Load Information For Assigned Fleet(s)</h6>
+				@php
+					$FKMin = $flight->load_factor - $flight->load_factor_variance ;
+					$FKMax = $flight->load_factor + $flight->load_factor_variance ;
+					$FKRandomLoad = rand($FKMin, $FKMax);
+				@endphp	
+				@foreach($flight->subfleets as $SUB)
+					<div class="row">
+						<div class="col-sm-8">Configuration and Load Figures for <b>&nbsp;{{ $SUB->name }}&nbsp;</b> ;</div>
+					</div>
+					<br>
+					<div class="row">
+					@foreach($SUB->fares as $SUBfares)
+						@if($SUBfares->capacity > 0)
+						@php $RandomLoadPerFare = round(($SUBfares->capacity * $FKRandomLoad) /100) @endphp
+						<div class="col-sm-4">
+              <label for="CapFare{{ $SUBfares->id }}">{{ $SUBfares->name }} Capacity</label><br>
+              <input id="CapFare{{ $SUBfares->id }}" type="text" value="{{ $SUBfares->capacity }}" disabled/>
+						<br>
+							<label for="LoadFare{{ $SUBfares->id }}">{{ $SUBfares->name }} Load</label><br>
+							<input id="LoadFare{{ $SUBfares->id }}" type="text" value="{{ $RandomLoadPerFare }}" disabled/>
+						</div>
+						@endif
+					@endforeach
+					</div>
+					<hr>
+				@endforeach
+				<div class="row"><div class="col-sm-12">Selected Aircraft's Total Pax/Cargo Load Will Be Used For Flight Planning</div></div>
+      </div>
+    </div>
+  </div>
+  @php $GetSubFleetIDs = DB::table('flight_subfleet')->where('flight_id', $flight->id)->select('id', 'subfleet_id')->get() @endphp
+	@foreach($GetSubFleetIDs as $SubFleetIDs)
+	  @php $GetMaxCap = DB::table('subfleet_fare')->where('subfleet_id', $SubFleetIDs->subfleet_id)->sum('capacity') @endphp
+		@php $CalcRandomLoad = ceil(($GetMaxCap * $FKRandomLoad) /100) @endphp
+		@php if($CalcRandomLoad > 900) { $SimBriefLoadType = "cargo" ; echo "<input type='hidden' name='pax' value='0' maxlength='3'>" ; } else { $SimBriefLoadType = "pax" ; } @endphp								
+		<input id="LoadSF{{ $SubFleetIDs->subfleet_id }}" type="hidden" name="{{ $SimBriefLoadType }}" class="form-control" value="{{ $CalcRandomLoad }}" disabled/>
+  @endforeach			
+		<input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
+    <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
+    <input type="hidden" id="date" name="date" maxlength="9">
+		<input type="hidden" id="deph" name="deph" maxlength="2">
+    <input type="hidden" id="depm" name="depm" maxlength="2">
+		<input type="hidden" id="steh" name="steh" maxlength="2">
+		<input type="hidden" id="stem" name="stem" maxlength="2">
+    <input type="hidden" name="selcal" value="BK-FS">
+    <input type="hidden" name="planformat" value="lido">
+		<input type="hidden" name="omit_sids" value="0">
+		<input type="hidden" name="omit_stars" value="0">
+		<input type="hidden" name="cruise" value="CI">
+		<input type="hidden" name="civalue" value="AUTO">
+			
+  <div class="col-4">
+	  <div class="form-container">
+      <h6><i class="fas fa-info-circle"></i>&nbsp;Planning Options</h6>	
+				<table class="table table-hover table-striped">
+        <tr>
+          <td>Cont Fuel:</td>
+        <td>
+         	<select name="contpct" class="form-control">
+           	<option value="auto">AUTO</option>
+            <option value="0">0 PCT</option>
+            <option value="0.02">2 PCT</option>
+            <option value="0.03">3 PCT</option>
+            <option value="0.05" selected>5 PCT</option>
+            <option value="0.1">10 PCT</option>
+            <option value="0.15">15 PCT</option>
+            <option value="0.2">20 PCT</option>
+        	</select>
+        </td>
+        </tr>
+        <tr>
+          <td>Reserve Fuel:</td>
+          <td>
+            <select name="resvrule" class="form-control">
+              <option value="auto">AUTO</option>
+              <option value="0">0 MIN</option>
+              <option value="15">15 MIN</option>
+              <option value="30" selected>30 MIN</option>
+              <option value="45">45 MIN</option>
+              <option value="60">60 MIN</option>
+              <option value="75">75 MIN</option>
+              <option value="90">90 MIN</option>
+             </select>
+           </td>
+          </tr>
+          <tr>
+            <td>SID/STAR Type:</td>
+          <td>
+					  <select name="find_sidstar" class="form-control">
+						  <option value="C">Conventinoal</option>
+							<option value="R" selected>RNAV</option>
+						</select>
+          </td>
+          </tr>
+          <tr>
+            <td>Plan Stepclimbs:</td>
+          <td>
+					  <select id="stepclimbs" name="stepclimbs" class="form-control" onchange="DisableFL()">
+							<option value="0" selected>Disabled</option>
+							<option value="1">Enabled</option>
+						</select>
+          </td>
+          </tr>				
+          <tr>
+            <td>ETOPS Planning:</td>
+          <td>
+						<select name="etops" class="form-control">
+							<option value="0" selected>Disabled</option>
+							<option value="1">Enabled</option>
+						</select>
+					</td>
+          </tr>							
+				</table>				
+			</div>
+			<br>
+      <div class="form-container">
+        <h6><i class="fas fa-info-circle"></i>&nbsp;Briefing Options</h6>
+          <table class="table table-hover table-striped">
+            <tr>
+              <td>Units:</td>
+            <td>
+              <select name="units" class="form-control">
+                <option value="KGS" selected>KGS</option>
+                <option value="LBS">LBS</option>
+               </select>
+            </td>
+            </tr>
+            <tr>
+              <td>Detailed Navlog:</td>
+             <td>
+					      <select name="navlog" class="form-control">
+						      <option value="0">Disabled</option>
+						      <option value="1" selected>Enabled</option>
+					      </select>
+             </td>
+             </tr>
+             <tr>
+                <td>Runway Analysis:</td>
+             <td>
+					      <select name="tlr" class="form-control">
+						      <option value="0">Disabled</option>
+						      <option value="1" selected>Enabled</option>
+					      </select>
+             </td>
+             </tr>
+             <tr>
+             <td>Include NOTAMS:</td>
+             <td>
+					      <select name="notams" class="form-control">
+						      <option value="0">Disabled</option>
+						      <option value="1" selected>Enabled</option>
+					      </select>
+              </td>
+              </tr>
+              <tr>
+                <td>FIR NOTAMS:</td>
+              <td>
+					      <select name="firnot" class="form-control">
+						        <option value="0" selected>Disabled</option>
+						        <option value="1">Enabled</option>
+					      </select>
+              </td>
+              </tr>
+              <tr>
+                <td>Flight Maps:</td>
+                <td>
+                  <select name="maps" class="form-control">
+                    <option value="detail" selected>Detailed</option>
+                    <option value="simple">Simple</option>
+                    <option value="none">None</option>
+                  </select>
+                </td>
+               </tr>
               </table>
             </div>
           </div>
         </div>
-
-        <input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
-        <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
-        <input type="hidden" name="date" value="01JAN14">
-        <input type="hidden" name="deph" value="12">
-        <input type="hidden" name="depm" value="30">
-        <input type="hidden" name="steh" value="2">
-        <input type="hidden" name="stem" value="15">
-        {{--<input type="hidden" name="reg" value="N123SB">
-        <input type="hidden" name="selcal" value="GR-FS">--}}
-        <input type="hidden" name="planformat" value="lido">
       </div>
     </div>
     <div class="row">
@@ -265,5 +389,77 @@
   </form>
 @endsection
 @section('scripts')
-  <script src="{{public_asset('/assets/global/js/simbrief.apiv1.js')}}"></script>
+	<script src="{{public_asset('/assets/global/js/simbrief.apiv1.js')}}"></script>
+	<script type="text/javascript">
+		// ******
+		// Disable Submitting a fixed flight level for Stepclimb option to work
+		// Script is related to Plan Step Climbs selection
+		function DisableFL() {
+ 			var climb = document.getElementById("stepclimbs").value;
+			if (climb == "0") {document.getElementById("fl").disabled = false};
+			if (climb == "1") {document.getElementById("fl").disabled = true};	
+			}
+	</script>
+	<script type="text/javascript">
+		// ******
+		// Get current UTC time, add 45 minutes to it and format according to Simbrief API
+		// Script also rounds the minutes to nearest 5 to avoid a Departure time like 1538 ;)
+		// If you need to reduce the margin of 45 mins, change value below
+		var d = new Date() ;
+		var months = ["JAN","FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC"] ;
+		d.setMinutes(d.getMinutes() + 45) ; // Change the value here
+		var deph = ("0" + d.getUTCHours(d)).slice(-2) ;
+		var depm = d.getUTCMinutes(d);
+		if(depm < 55) { depm = Math.ceil(depm/5)*5;}
+		if(depm > 55) { depm = Math.floor(depm/5)*5;}
+		depm = ("0" + depm).slice(-2) ;
+		dept = deph + depm ;
+		var dof = ("0" + d.getUTCDate()).slice(-2) + months[d.getUTCMonth()] + d.getUTCFullYear() ;
+		document.getElementById("dof").setAttribute('value',dof) ;
+		document.getElementById("etd").setAttribute('value',dept) ;
+		document.getElementById("date").setAttribute('value',dof) ; // Sent to Simbrief
+		document.getElementById("deph").setAttribute('value',deph) ; // Sent to SimBrief
+		document.getElementById("depm").setAttribute('value',depm) ; // Sent to SimBrief
+	</script>
+	<script type="text/javascript">
+		// ******
+		// Calculate the Scheduled Enroute Time for Simbrief API
+		// Your PHPVMS flight_time value must be from BLOCK to BLOCK
+		// Including departure and arrival taxi times
+		// If this value is not correctly calculated and configured
+		// Simbrief CI (Cost Index) calculation will not provide realistic results
+		var num = {{ $flight->flight_time }} ;
+		var hours = (num / 60);
+		var rhours = Math.floor(hours);
+		var minutes = (hours - rhours) * 60;
+		var rminutes = Math.round(minutes);
+		document.getElementById("steh").setAttribute('value',rhours) ; // Sent to Simbrief
+		document.getElementById("stem").setAttribute('value',rminutes) ; // Sent to Simbrief
+	</script>
+	<script type="text/javascript">
+		// ******
+		// Splits the Aircraft Selection value and sends the results to proper form fields
+		// Output values used for Simbrief integration and load calculations/selections
+		// Also includes some ICAO Type Corrections for SimBrief Aircraft Types
+		function SplitSelection() {
+			@foreach($flight->subfleets as $SubFleets)
+				var SubFleetsSB = "LoadSF".concat({{ $SubFleets->id }});
+				document.getElementById(SubFleetsSB).disabled = true;
+			@endforeach
+			var str = document.getElementById("AircraftSelect").value;
+  		var d1 = str.search(",");
+			var d2 = str.search("#");
+  		var icao = str.slice(0, d1);
+  		var registration = str.slice(d1+1,d2);
+			var subfleetid = str.slice(d2+1);
+			var SelectedSubFleetSB = "LoadSF".concat(subfleetid);
+				if (icao == "A20N") {icao = "A320"}; // Correction for A320 NEO
+				if (icao == "A21N") {icao = "A321"}; // Correction for A321 NEO
+				if (icao == "B77L") {icao = "B77F"}; // Correction for B777 Freighter
+				if (icao == "B773") {icao = "B77W"}; // Correction for B777-300
+  		document.getElementById("type").value = icao;
+  		document.getElementById("reg").value = registration;
+			document.getElementById(SelectedSubFleetSB).disabled = false;
+		}
+	</script>
 @endsection


### PR DESCRIPTION
* Added the ability to select the aircrafts assigned to the flight (via subfleets)
* Use selected aircraft (and subfleet) for random load generation according to Load Factor and Variance set for the flight (uses subfleet fares to get the capacities)
* Uses pre-defined route,alternate aerodrome and level for the flight
* Gets current UTC time, adds some margin to it (45mins - configurable via script), determines the date and passes that info to SimBrief for proper ATC FPL generation
* Gets scheduled flight time (mins) for the flight and converts it to proper format (hh mm) , passes it to SimBrief for proper Cost Index (CI) calculations
* Option for automatic SID/STAR selection (Conventional or RNAV)
* Correct flow for Plan Step Climbs applied, it is disabled by default. When enabled flight level will not be passed to SimBrief (according to SB system workflow)

* Compatible with Cargo and Passenger fleets (Cargo fleets will send the random Cargo load and 0 pax to SimBrief)
* Not Compatible with Multi Purpose Fleets (Both Cargo and Pax configured planes,think like 10tonnes of cargo and 50pax seats on a B738, they are rare but possible)

If the user leaves Fleet Fares empty and makes all capacity settings from the Flight Fares (which is not logical but possible) then random load calculation may generate unrealistic results. In the worst case 0 pax may be sent to SimBrief !

Load input is not possible at the moment 'cause manual input from the pilot will override airline/flight load factors, which will make the random load generation and load factor settings useless. Load section (and its logic) may be improved later for more flexible options.

* Uses 4 Javascript (2 for calculating times, 1 for Step Climb Dropdown, 1 for Aircraft and Subfleet Selection part)
* Uses some pure php code (mostly at aircraft configuration, capacity checking and load calculation area)

![deflook](https://user-images.githubusercontent.com/74361521/101183730-f29bf700-3660-11eb-8afd-16f3ac805a85.png)