### PR TITLE
Update Metar Decoding (Text Correction Only)

### DIFF
--- a/app/Support/Metar.php
+++ b/app/Support/Metar.php
@@ -172,11 +172,11 @@ class Metar implements \ArrayAccess
         'NSW'  => 'no significant weather are observed',
         'NSC'  => 'no significant clouds are observed',
         'NCD'  => 'nil cloud detected',
-        'SKC'  => 'no significant changes expected',
+        'SKC'  => 'sky is clear',
         'CLR'  => 'clear skies',
         'NOBS' => 'no observation',
         //
-        'FEW' => 'a few',
+        'FEW' => 'few',
         'SCT' => 'scattered',
         'BKN' => 'broken sky',
         'OVC' => 'overcast sky',

--- a/tests/MetarTest.php
+++ b/tests/MetarTest.php
@@ -64,7 +64,7 @@ class MetarTest extends TestCase
 
         $this->assertCount(4, $parsed['clouds']);
         $this->assertEquals(
-            'A few at 1676 meters; scattered at 2896 meters; broken sky at 3353 meters; broken sky at 7010 meters',
+            'Few at 1676 meters; scattered at 2896 meters; broken sky at 3353 meters; broken sky at 7010 meters',
             $parsed['clouds_report']
         );
         $this->assertEquals(1676.4, $parsed['cloud_height']['m']);
@@ -147,8 +147,8 @@ class MetarTest extends TestCase
         $metar = Metar::parse($metar);
 
         $this->assertEquals(2, count($metar['clouds']));
-        $this->assertEquals('A few at 457 meters; a few at 7620 meters', $metar['clouds_report']);
-        $this->assertEquals('A few at 1500 feet; a few at 25000 feet', $metar['clouds_report_ft']);
+        $this->assertEquals('Few at 457 meters; few at 7620 meters', $metar['clouds_report']);
+        $this->assertEquals('Few at 1500 feet; few at 25000 feet', $metar['clouds_report_ft']);
     }
 
     /**


### PR DESCRIPTION
**SKC** means **Sky Clear** or _Clear Skies_. , it is not used as an acronym for No Significant Changes Expected (which is NOSIG)

Rest is ok