### PR TITLE
Update DownloadController.php

### DIFF
--- a/app/Http/Controllers/Frontend/DownloadController.php
+++ b/app/Http/Controllers/Frontend/DownloadController.php
@@ -41,8 +41,14 @@ class DownloadController extends Controller
 
             $category = explode('\\', $class);
             $category = end($category);
-
-            $group_name = $category.' - '.$obj->name;
+            
+			if ($category == 'Aircraft') {
+				$group_name = $category.' > '.$obj->icao.' '.$obj->registration;
+			} elseif ($category == 'Airport') {
+				$group_name = $category.' > '.$obj->icao.' : '.$obj->name.' ('.$obj->country.')';
+			} else {
+				$group_name = $category.' > '.$obj->name;
+			}
             $regrouped_files[$group_name] = $files;
         }
 


### PR DESCRIPTION
Changed the group name according to its category , aircrafts will show icao type and registration , airports will be displayed with their icao codes names and countries. Rest will be showed with their names (exp airlines)

This will result a much better look on the downloads page for end users while looking for a specific type's files (like a repaint for a B738).

![download_controller](https://user-images.githubusercontent.com/74361521/102639410-120b4780-416a-11eb-9447-7352434917ed.png)
