### PR TITLE
Update Metar.php

### DIFF
--- a/app/Support/Metar.php
+++ b/app/Support/Metar.php
@@ -523,6 +523,8 @@ class Metar implements \ArrayAccess
 
         // Finally determine if it's VFR or IFR conditions
         // https://www.aviationweather.gov/cva/help
+        // https://www.skybrary.aero/index.php/Visual_Meteorological_Conditions_(VMC)
+        // This may be changed to ICAO standards as VMC and IMC
         $this->result['category'] = 'VFR';
 
         if (array_key_exists('cavok', $this->result) && $this->result['cavok']) {
@@ -531,7 +533,7 @@ class Metar implements \ArrayAccess
             /* @noinspection NestedPositiveIfStatementsInspection */
             if (array_key_exists('cloud_height', $this->result) && $this->result['cloud_height'] !== null) {
                 if ($this->result['cloud_height']['ft'] > 3000
-                    && (empty($this->result['visibility']) || $this->result['visibility']['nmi'] > 5)) {
+                    && (empty($this->result['visibility']) || $this->result['visibility']['km'] > 5)) {
                     $this->result['category'] = 'VFR';
                 } else {
                     $this->result['category'] = 'IFR';
@@ -1231,9 +1233,10 @@ class Metar implements \ArrayAccess
         $pressure = (int) $found[2];
         if ($found[1] === 'A') {
             $pressure /= 100;
+            $this->set_result_value('barometer', $this->createPressure($pressure, 'inHg'));
+        } else {
+            $this->set_result_value('barometer', $this->createPressure($pressure, 'hPa'));
         }
-
-        $this->set_result_value('barometer', $this->createPressure($pressure, 'hPa'));
 
         $this->method++;
         return true;

--- a/tests/MetarTest.php
+++ b/tests/MetarTest.php
@@ -77,7 +77,7 @@ class MetarTest extends TestCase
         $this->assertEquals(24.8, $parsed['dew_point']['f']);
 
         $this->assertEquals(33, $parsed['humidity']);
-        $this->assertEquals(29.58, $parsed['barometer']['hPa']);
+        $this->assertEquals(29.58, $parsed['barometer']['inHg']);
 
         $this->assertEquals('AO2 PK WND 27045/2128 PRESRR SLP018 T01221044', $parsed['remarks']);
     }


### PR DESCRIPTION
The reported pressure was always being assigned as hPa thus resulting display and conversion errors when the reported pressure was inHg.

Also the VFR/IFR (VMC/IMC) determination was using minimum 5 nmi and 3000 ft cloud base, it must be 5 km and 3000 ft.

With this state, this PR should fix issue #948 and partly fixes issue #963