### PR TITLE
Personal Stats Widget

### DIFF
--- a/app/Widgets/PersonalStats.php
+++ b/app/Widgets/PersonalStats.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Widgets;
+
+use Carbon;
+use App\Models\Pirep;
+use App\Contracts\Widget;
+use Illuminate\Support\Facades\DB;
+
+/** Show some nice stats of current user **/
+class PersonalStats extends Widget
+{
+
+	protected $config = ['disp' => null, 'user' => null, 'period' => null, 'type' => 'avglanding',];
+
+	public function user() {
+    	return $this->belongsTo(User::class);
+	}
+	
+    public function run() {
+
+		$user = $this->config['user'] ;
+		$selection = $this->config['type'] ;
+		$period = $this->config['period'] ;
+
+		if ($user) {
+			$userid = $this->config['user'] ;
+		} else {
+			$userid = user()->id ;
+		}
+
+		if ($selection == 'avglanding') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->avg('landing_rate') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->avg('landing_rate') ;
+			}			
+			$PersonalStats = round($PersonalStats) ;
+			$PersonalStats = $PersonalStats . ' ft/min' ;
+
+		} elseif ($selection == 'avgscore') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->avg('score') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->avg('score') ;
+			}
+			$PersonalStats = round($PersonalStats) ;
+
+		} elseif ($selection == 'avgdistance') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->avg('distance') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->avg('distance') ;
+			}
+			$PersonalStats = number_format(round($PersonalStats)) ;
+			$PersonalStats = $PersonalStats . ' Nm' ;
+
+		} elseif ($selection == 'totdistance') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->sum('distance') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->sum('distance') ;
+			}
+			$PersonalStats = number_format(round($PersonalStats)) ;
+			$PersonalStats = $PersonalStats . ' Nm' ;
+
+		} elseif ($selection == 'avgtime') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->avg('flight_time') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->avg('flight_time') ;
+			}
+
+		} elseif ($selection == 'tottime') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->sum('flight_time') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->sum('flight_time') ;
+			}
+
+		} elseif ($selection == 'avgfuel') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->avg('fuel_used') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->avg('fuel_used') ;
+			}
+			if(setting('units.weight') === 'kg') {
+				$PersonalStats = number_format(round($PersonalStats / 2.205)) ;
+				$PersonalStats = $PersonalStats . ' Kgs' ;
+			} else {
+				$PersonalStats = number_format(round($PersonalStats)) ;
+				$PersonalStats = $PersonalStats . ' Lbs' ;
+			}
+			
+		} elseif ($selection == 'totfuel') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->sum('fuel_used') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->sum('fuel_used') ;
+			}
+			if(setting('units.weight') === 'kg') {
+				$PersonalStats = number_format(round($PersonalStats / 2.205)) ;
+				$PersonalStats = $PersonalStats . ' Kgs' ;
+			} else {
+				$PersonalStats = number_format(round($PersonalStats)) ;
+				$PersonalStats = $PersonalStats . ' Lbs' ;
+			}
+
+		} elseif ($selection == 'totflight') {
+			if ($period) {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')
+								->where('submitted_at','>=',Carbon::now()->subdays($this->config['period']))->count('score') ;
+			} else {
+				$PersonalStats = Pirep::where('user_id', ".$userid.")->where('state', '2')->where('source', '1')->count('score') ;
+			}
+			$PersonalStats = number_format($PersonalStats) ;
+
+		}
+
+		return view('widgets.personalstats', ['pstat'  => $PersonalStats, 'type' => $selection, 'disp' => $this->config['disp'], 'period' => $this->config['period'],]);
+    }
+}

--- a/resources/views/layouts/default/widgets/personalstats.blade.php
+++ b/resources/views/layouts/default/widgets/personalstats.blade.php
@@ -1,0 +1,47 @@
+{{-- DEFINE YOUR TEXT HERE ---}}
+@php
+    $last = 'Last' ;
+    $days = 'Days' ;
+    $noreports = 'No Reports' ;
+    $statname = 'Personal Stats Widget' ;
+    if($type == 'avglanding') { $statname = 'Average Landing Rate' ; }
+    if($type == 'avgscore') { $statname = 'Average Score' ; }
+    if($type == 'avgdistance') { $statname = 'Average Distance' ; }
+    if($type == 'totdistance') { $statname = 'Total Distance' ; }
+    if($type == 'avgtime') { $statname = 'Average Flight Time' ; }
+    if($type == 'tottime') { $statname = 'Total Flight Time' ; }
+    if($type == 'avgfuel') { $statname = 'Average Fuel Burn' ; }
+    if($type == 'totfuel') { $statname = 'Total Fuel Burn' ; }
+@endphp
+@if($disp == 'full')
+<div class="card">
+    <div class="card-body">
+        <div class="statistic-details">
+            <div class="statistic-details-item">
+                <div class="detail-value">
+                @if($pstat <> 0)
+                    @if($type == 'avgtime' || $type == 'tottime')
+                        @minutestotime($pstat)
+                    @else
+                        {{ $pstat }}
+                    @endif
+                @else
+                    {{ $noreports }}
+                @endif           
+                </div>
+                <div class="detail-name">{{ $statname }} @if($period)({{ $last }} {{ $period }} {{ $days }})@endif</div>
+            </div>
+        </div>
+    </div>
+</div>
+@else
+    @if($pstat <> 0)
+        @if($type == 'avgtime' || $type == 'tottime')
+            @minutestotime($pstat)
+        @else
+            {{ $pstat }}
+        @endif
+    @else
+        {{ $noreports }}
+    @endif  
+@endif


### PR DESCRIPTION
Displays some nice stats based on Pirep Model and requires vmsAcars (or any compatible acars solution) , can be improved/edited to display manual pireps too with reduced capacity.

***** Options : PersonalStats

user can be any user's id or not used at all
period can be any number of days (except 0 of course) or not used at all
disp can be full or not used at all
type can be avglanding, avgscore, avgtime, tottime, avgdistance, totdistance, avgfuel, totfuel, totflight

If no user is defined, widget will get current user's data for calculations. This may be used for dashboard or any personal pages where the viewer will be able to see his results. If stats are needed on the user profile page then 'user' option is required.
('user' => $user->id is enough to get proper results at profile page)

If no period is defined then all accepted acars reports will be used for calculations, else the results for the last n days provided 
('period' => 7 will give last 7 days)

If a full card is required with the results and info text then 'disp' => full must be used while while calling the widget. It should be compatible with the default template (and any others too) but if needed personalstats.blade may be edited.

I personally use the plain text results on my dashboard and 'disp' => full in user profile pages.

Designed it for personal use, but if they are good enough we can have them in the main pack too.