### PR TITLE
SimBrief : Generate New Briefing

### DIFF
--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -88,15 +88,14 @@ class SimBriefController
      *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-
     public function remove(Request $request)
     {
         $sb_pack = SimBrief::find($request->id);
-        if($sb_pack) {
-            if(!$sb_pack->pirep_id) { 
+        if ($sb_pack) {
+            if (!$sb_pack->pirep_id) {
                 $sb_pack->delete();
             } else {
-                $sb_pack->flight_id = NULL;
+                $sb_pack->flight_id = null;
                 $sb_pack->save();
             }
         }

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -81,6 +81,30 @@ class SimBriefController
     }
 
     /**
+     * Remove the flight_id from the SimBrief Briefing (to a create a new one)
+     * or if no pirep_id is attached to the briefing delete it completely
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
+     */
+
+    public function remove(Request $request)
+    {
+        $sb_pack = SimBrief::find($request->id);
+        if($sb_pack) {
+            if(!$sb_pack->pirep_id) { 
+                $sb_pack->delete();
+            } else {
+                $sb_pack->flight_id = NULL;
+                $sb_pack->save();
+            }
+        }
+
+        return redirect(route('frontend.flights.index'));
+    }
+
+    /**
      * Create a prefile of this PIREP with a given OFP. Then redirect the
      * user to the newly prefiled PIREP
      *

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -147,6 +147,7 @@ class RouteServiceProvider extends ServiceProvider
                 Route::get('simbrief/{id}', 'SimBriefController@briefing')->name('simbrief.briefing');
                 Route::get('simbrief/{id}/prefile', 'SimBriefController@prefile')->name('simbrief.prefile');
                 Route::get('simbrief/{id}/cancel', 'SimBriefController@cancel')->name('simbrief.cancel');
+                Route::get('simbrief/{id}/remove', 'SimBriefController@remove')->name('simbrief.remove');
             });
 
             Route::group([

--- a/resources/views/layouts/default/flights/simbrief_briefing.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_briefing.blade.php
@@ -3,7 +3,7 @@
 
 @section('content')
   <div class="row">
-    <div class="col-sm-9">
+    <div class="col-sm-6">
       <h2>{{ $simbrief->xml->general->icao_airline }}{{ $simbrief->xml->general->flight_number }}
         : {{ $simbrief->xml->origin->icao_code }} to {{ $simbrief->xml->destination->icao_code }}</h2>
     </div>
@@ -13,6 +13,11 @@
            style="margin-top: -10px;margin-bottom: 5px"
            href="{{ url(route('frontend.simbrief.prefile', [$simbrief->id])) }}">Prefile PIREP</a>
       @endif
+    </div>
+    <div class="col-sm-3">
+        <a class="btn btn-primary pull-right btn-lg"
+           style="margin-top: -10px;margin-bottom: 5px"
+           href="{{ url(route('frontend.simbrief.remove', [$simbrief->id])) }}">Generate New OFP</a>
     </div>
   </div>
 


### PR DESCRIPTION
With this we will be able to generate a new briefing with SB after creating one.

- RouteServiceProvider : Added the route for remove function
- SimBriefController : Added the function to remove the simbrief ofp from db (or just null the flight_id if a pirep_id is provided for that simbrief ofp) , finally redirecting the user to flights.index
- simbrief_briefing.blade : Added the button next to Prefile Pirep button