### PR TITLE
SimBrief Planning System Update

### DIFF
--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -142,10 +142,10 @@ class SimBriefController
     {
         $sb_pack = SimBrief::find($request->id);
         if ($sb_pack) {
-            if (!$sb_pack->pirep_id) { 
+            if (!$sb_pack->pirep_id) {
                 $sb_pack->delete();
             } else {
-                $sb_pack->flight_id = NULL;
+                $sb_pack->flight_id = null;
                 $sb_pack->save();
             }
         }

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -3,22 +3,34 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Exceptions\AssetNotFound;
+use App\Models\Aircraft;
+use App\Models\Enums\FlightType;
 use App\Models\SimBrief;
 use App\Repositories\FlightRepository;
+use App\Services\FareService;
 use App\Services\SimBriefService;
+use App\Services\UserService;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class SimBriefController
 {
+    private $fareSvc;
     private $flightRepo;
     private $simBriefSvc;
+    private $userSvc;
 
-    public function __construct(FlightRepository $flightRepo, SimBriefService $simBriefSvc)
-    {
+    public function __construct(
+        FareService $fareSvc,
+        FlightRepository $flightRepo,
+        SimBriefService $simBriefSvc,
+        UserService $userSvc
+    ) {
+        $this->fareSvc = $fareSvc;
         $this->flightRepo = $flightRepo;
         $this->simBriefSvc = $simBriefSvc;
+        $this->userSvc = $userSvc;
     }
 
     /**
@@ -32,11 +44,21 @@ class SimBriefController
      */
     public function generate(Request $request)
     {
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+
         $flight_id = $request->input('flight_id');
-        $flight = $this->flightRepo->find($flight_id);
+        $aircraft_id = $request->input('aircraft_id');
+        $flight = $this->flightRepo->with(['subfleets'])->find($flight_id);
+        $flight = $this->fareSvc->getReconciledFaresForFlight($flight);
+
         if (!$flight) {
             flash()->error('Unknown flight');
             return redirect(route('frontend.flights.index'));
+        }
+
+        if (!$aircraft_id) {
+            flash()->error('Aircraft not selected ! Please select an Aircraft to Proceed ...');
         }
 
         $apiKey = setting('simbrief.api_key');
@@ -45,7 +67,6 @@ class SimBriefController
             return redirect(route('frontend.flights.index'));
         }
 
-        $user = Auth::user();
         $simbrief = SimBrief::select('id')->where([
             'flight_id' => $flight_id,
             'user_id'   => $user->id,
@@ -55,8 +76,27 @@ class SimBriefController
             return redirect(route('frontend.simbrief.briefing', [$simbrief->id]));
         }
 
+        $aircraft = Aircraft::select('registration', 'name', 'icao', 'iata', 'subfleet_id')
+            ->where('id', $aircraft_id)
+            ->get();
+
+        if ($flight->subfleets->count() > 0) {
+            $subfleets = $flight->subfleets;
+        } else {
+            $subfleets = $this->userSvc->getAllowableSubfleets($user);
+        }
+
+        if ($flight->flight_type === FlightType::CHARTER_PAX_ONLY) {
+            $pax_weight = 197;
+        } else {
+            $pax_weight = 208;
+        }
+
         return view('flights.simbrief_form', [
-            'flight' => $flight,
+            'flight'     => $flight,
+            'aircraft'   => $aircraft,
+            'subfleets'  => $subfleets,
+            'pax_weight' => $pax_weight, // TODO: Replace with a setting
         ]);
     }
 
@@ -75,8 +115,18 @@ class SimBriefController
             return redirect(route('frontend.flights.index'));
         }
 
+        $str = $simbrief->xml->aircraft->equip;
+        $wc = stripos($str, '-');
+        $tr = stripos($str, '/');
+        $wakecat = substr($str, 0, $wc);
+        $equipment = substr($str, $wc + 1, $tr - 2);
+        $transponder = substr($str, $tr + 1);
+
         return view('flights.simbrief_briefing', [
-            'simbrief' => $simbrief,
+            'simbrief'    => $simbrief,
+            'wakecat'     => $wakecat,
+            'equipment'   => $equipment,
+            'transponder' => $transponder,
         ]);
     }
 
@@ -92,10 +142,10 @@ class SimBriefController
     {
         $sb_pack = SimBrief::find($request->id);
         if ($sb_pack) {
-            if (!$sb_pack->pirep_id) {
+            if (!$sb_pack->pirep_id) { 
                 $sb_pack->delete();
             } else {
-                $sb_pack->flight_id = null;
+                $sb_pack->flight_id = NULL;
                 $sb_pack->save();
             }
         }

--- a/app/Providers/DirectiveServiceProvider.php
+++ b/app/Providers/DirectiveServiceProvider.php
@@ -19,5 +19,9 @@ class DirectiveServiceProvider extends ServiceProvider
         Blade::directive('minutestohours', function ($expr) {
             return "<?php echo \App\Support\Units\Time::minutesToHours($expr); ?>";
         });
+
+        Blade::directive('secstohhmm', function ($expr) {
+            return "<?php echo secstohhmm($expr); ?>";
+        });
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -355,6 +355,19 @@ if (!function_exists('show_datetime_format')) {
     }
 }
 
+if (!function_exists('secstohhmm')) {
+    /**
+     * Convert seconds to hhmm format
+     *
+     * @param $seconds
+     */
+    function secstohhmm($seconds) {
+        $seconds = round($seconds);
+        $hhmm = sprintf('%02d%02d', ($seconds/ 3600),($seconds/ 60 % 60));
+        echo $hhmm ;
+    }
+}
+
 if (!function_exists('_fmt')) {
     /**
      * Replace strings

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -361,10 +361,11 @@ if (!function_exists('secstohhmm')) {
      *
      * @param $seconds
      */
-    function secstohhmm($seconds) {
+    function secstohhmm($seconds)
+    {
         $seconds = round($seconds);
-        $hhmm = sprintf('%02d%02d', ($seconds/ 3600),($seconds/ 60 % 60));
-        echo $hhmm ;
+        $hhmm = sprintf('%02d%02d', ($seconds / 3600), ($seconds / 60 % 60));
+        echo $hhmm;
     }
 }
 

--- a/resources/views/layouts/default/flights/simbrief_briefing.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_briefing.blade.php
@@ -15,9 +15,9 @@
       @endif
     </div>
     <div class="col-sm-3">
-        <a class="btn btn-primary pull-right btn-lg"
-           style="margin-top: -10px;margin-bottom: 5px"
-           href="{{ url(route('frontend.simbrief.remove', [$simbrief->id])) }}">Generate New OFP</a>
+      <a class="btn btn-primary pull-right btn-lg"
+         style="margin-top: -10px;margin-bottom: 5px"
+         href="{{ url(route('frontend.simbrief.remove', [$simbrief->id])) }}">Generate New OFP</a>
     </div>
   </div>
 
@@ -134,24 +134,30 @@
               <div class="row">
                 <div class="col-12">
                   <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Departure METAR</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->orig_metar }}</p>
+                    <p
+                      class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->orig_metar }}</p>
                   </div>
                   <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Departure TAF</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->orig_taf }}</p>
+                    <p
+                      class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->orig_taf }}</p>
                   </div>
                   <hr/>
                   <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Destination METAR</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->dest_metar }}</p>
+                    <p
+                      class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->dest_metar }}</p>
                   </div>
                   <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Destination TAF</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->dest_taf }}</p>
+                    <p
+                      class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->dest_taf }}</p>
                   </div>
-				  <hr/>
-				  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Alternate METAR</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->altn_metar }}</p>
+                  <hr/>
+                  <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Alternate METAR</p>
+                    <p
+                      class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->altn_metar }}</p>
                   </div>
                   <div><p class="small text-uppercase pb-sm-0 mb-sm-1">Alternate TAF</p>
-                    <p class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->altn_taf }}</p>
+                    <p
+                      class="border border-dark rounded p-1 small text-monospace">{{ $simbrief->xml->weather->altn_taf }}</p>
                   </div>
                 </div>
               </div>
@@ -181,66 +187,64 @@
               </div>
             </div>
           </div>
-          
+
           <div class="form-container">
             <h6><i class="fas fa-info-circle"></i>&nbsp;Prefile ATC Flight Plan</h6>
             <div class="form-container-body">
               <div class="row">
                 <div class="col-4" align="center">
-				          @php
-					        $str = $simbrief->xml->aircraft->equip ;
-					        $wc = stripos($str,"-");
-					        $tr = stripos($str,"/");
-					        $wakecat = substr($str,0,$wc);
-					        $equipment = substr($str,$wc+1,$tr-2);
-					        $transponder = substr($str,$tr+1);
-							    function secstohhmm($seconds) {
-                      			$seconds = round($seconds);
-                      			$hhmm = sprintf('%02d%02d', ($seconds/ 3600),($seconds/ 60 % 60));
-                      			echo $hhmm ;
-                    		}
-				          @endphp
-				    <form action="https://fpl.ivao.aero/api/fp/load" method="POST" target="_blank">
-            		  <input type="hidden" name="CALLSIGN" value="{{ $simbrief->xml->atc->callsign }}" />
-            		  <input type="hidden" name="RULES" value="I" />
-           			  <input type="hidden" name="FLIGHTTYPE" value="N" />
-            		  <input type="hidden" name="NUMBER" value="1" />
-            		  <input type="hidden" name="ACTYPE" value="{{ $simbrief->xml->aircraft->icaocode }}" />
-            		  <input type="hidden" name="WAKECAT" value="{{ $wakecat }}" />
-            		  <input type="hidden" name="EQUIPMENT" value="{{ $equipment }}" />
-            		  <input type="hidden" name="TRANSPONDER" value="{{ $transponder }}" />
-           			  <input type="hidden" name="DEPICAO" value="{{ $simbrief->xml->origin->icao_code}}" />
-            		  <input type="hidden" name="DEPTIME" value="{{ date('Hi', $simbrief->xml->times->est_out->__toString())."" }}" />
-            		  <input type="hidden" name="SPEEDTYPE" value="{{ $simbrief->xml->atc->initial_spd_unit }}" />
-            		  <input type="hidden" name="SPEED" value="{{ $simbrief->xml->atc->initial_spd }}" />
-            		  <input type="hidden" name="LEVELTYPE" value="{{ $simbrief->xml->atc->initial_alt_unit }}" />
-            		  <input type="hidden" name="LEVEL" value="{{ $simbrief->xml->atc->initial_alt }}" />
-            		  <input type="hidden" name="ROUTE" value="{{ $simbrief->xml->general->route_ifps }}" />
-            		  <input type="hidden" name="DESTICAO" value="{{ $simbrief->xml->destination->icao_code }}" />
-            		  <input type="hidden" name="EET" value="@php secstohhmm($simbrief->xml->times->est_time_enroute) @endphp" />
-            		  <input type="hidden" name="ALTICAO" value="{{ $simbrief->xml->alternate->icao_code}}" />
-            		  <input type="hidden" name="ALTICAO2" value="{{ $simbrief->xml->alternate2->icao_code}}" />
-            		  <input type="hidden" name="OTHER" value="{{ $simbrief->xml->atc->section18 }}" />
-            		  <input type="hidden" name="ENDURANCE" value="@php secstohhmm($simbrief->xml->times->endurance) @endphp" />
-            		  <input type="hidden" name="POB" value="{{ $simbrief->xml->weights->pax_count }}" />
-            		  <input id="ivao_prefile" type="submit" class="btn btn-primary" value="File ATC on IVAO" />
-				    </form>	
-             </div>
-             <div class="col-4" align="center">
-				      <form action="https://my.vatsim.net/pilots/flightplan" method="GET" target="_blank">
-					        <input type="hidden" name="raw" value="{{ $simbrief->xml->atc->flightplan_text }}">
-					        <input type="hidden" name="fuel_time" value="@php secstohhmm($simbrief->xml->times->endurance) @endphp">
-					        <input type="hidden" name="speed" value="{{ $simbrief->xml->atc->initial_spd }}">
-					        <input type="hidden" name="altitude" value="{{ $simbrief->xml->atc->initial_alt }}">
-					        <input id="vatsim_prefile" type="submit" class="btn btn-primary" value="File ATC on VATSIM"/>
-				        </form>
+                  @php
+                    $str = $simbrief->xml->aircraft->equip ;
+                    $wc = stripos($str,"-");
+                    $tr = stripos($str,"/");
+                    $wakecat = substr($str,0,$wc);
+                    $equipment = substr($str,$wc+1,$tr-2);
+                    $transponder = substr($str,$tr+1);
+                  @endphp
+                  <form action="https://fpl.ivao.aero/api/fp/load" method="POST" target="_blank">
+                    <input type="hidden" name="CALLSIGN" value="{{ $simbrief->xml->atc->callsign }}"/>
+                    <input type="hidden" name="RULES" value="I"/>
+                    <input type="hidden" name="FLIGHTTYPE" value="N"/>
+                    <input type="hidden" name="NUMBER" value="1"/>
+                    <input type="hidden" name="ACTYPE" value="{{ $simbrief->xml->aircraft->icaocode }}"/>
+                    <input type="hidden" name="WAKECAT" value="{{ $wakecat }}"/>
+                    <input type="hidden" name="EQUIPMENT" value="{{ $equipment }}"/>
+                    <input type="hidden" name="TRANSPONDER" value="{{ $transponder }}"/>
+                    <input type="hidden" name="DEPICAO" value="{{ $simbrief->xml->origin->icao_code}}"/>
+                    <input type="hidden" name="DEPTIME"
+                           value="{{ date('Hi', $simbrief->xml->times->est_out->__toString())."" }}"/>
+                    <input type="hidden" name="SPEEDTYPE" value="{{ $simbrief->xml->atc->initial_spd_unit }}"/>
+                    <input type="hidden" name="SPEED" value="{{ $simbrief->xml->atc->initial_spd }}"/>
+                    <input type="hidden" name="LEVELTYPE" value="{{ $simbrief->xml->atc->initial_alt_unit }}"/>
+                    <input type="hidden" name="LEVEL" value="{{ $simbrief->xml->atc->initial_alt }}"/>
+                    <input type="hidden" name="ROUTE" value="{{ $simbrief->xml->general->route_ifps }}"/>
+                    <input type="hidden" name="DESTICAO" value="{{ $simbrief->xml->destination->icao_code }}"/>
+                    <input type="hidden" name="EET" value="@secstohhmm($simbrief->xml->times->est_time_enroute)"/>
+                    <input type="hidden" name="ALTICAO" value="{{ $simbrief->xml->alternate->icao_code}}"/>
+                    <input type="hidden" name="ALTICAO2" value="{{ $simbrief->xml->alternate2->icao_code}}"/>
+                    <input type="hidden" name="OTHER" value="{{ $simbrief->xml->atc->section18 }}"/>
+                    <input type="hidden" name="ENDURANCE" value="@secstohhmm($simbrief->xml->times->endurance)"/>
+                    <input type="hidden" name="POB" value="{{ $simbrief->xml->weights->pax_count }}"/>
+                    <input id="ivao_prefile" type="submit" class="btn btn-primary" value="File ATC on IVAO"/>
+                  </form>
+                </div>
+                <div class="col-4" align="center">
+                  <form action="https://my.vatsim.net/pilots/flightplan" method="GET" target="_blank">
+                    <input type="hidden" name="raw" value="{{ $simbrief->xml->atc->flightplan_text }}">
+                    <input type="hidden" name="fuel_time" value="@secstohhmm($simbrief->xml->times->endurance)">
+                    <input type="hidden" name="speed" value="{{ $simbrief->xml->atc->initial_spd }}">
+                    <input type="hidden" name="altitude" value="{{ $simbrief->xml->atc->initial_alt }}">
+                    <input id="vatsim_prefile" type="submit" class="btn btn-primary" value="File ATC on VATSIM"/>
+                  </form>
+                </div>
+                <div class="col-4" align="center">
+                  <a
+                    href="http://skyvector.com/?chart=304&amp;fpl={{ $simbrief->xml->origin->icao_code}} {{ $simbrief->xml->general->route }} {{ $simbrief->xml->destination->icao_code}}"
+                    target="_blank" class="btn btn-info">View Route At SkyVector</a>
+                </div>
+              </div>
             </div>
-			<div class="col-4" align="center">
-				<a href="http://skyvector.com/?chart=304&amp;fpl={{ $simbrief->xml->origin->icao_code}} {{ $simbrief->xml->general->route }} {{ $simbrief->xml->destination->icao_code}}" target="_blank" class="btn btn-info">View Route At SkyVector</a>
-			</div>
-             </div>
-           </div>
-          </div>          
+          </div>
           <div class="form-container">
             <h6><i class="fas fa-info-circle"></i>
               &nbsp;OFP

--- a/resources/views/layouts/default/flights/simbrief_briefing.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_briefing.blade.php
@@ -193,14 +193,6 @@
             <div class="form-container-body">
               <div class="row">
                 <div class="col-4" align="center">
-                  @php
-                    $str = $simbrief->xml->aircraft->equip ;
-                    $wc = stripos($str,"-");
-                    $tr = stripos($str,"/");
-                    $wakecat = substr($str,0,$wc);
-                    $equipment = substr($str,$wc+1,$tr-2);
-                    $transponder = substr($str,$tr+1);
-                  @endphp
                   <form action="https://fpl.ivao.aero/api/fp/load" method="POST" target="_blank">
                     <input type="hidden" name="CALLSIGN" value="{{ $simbrief->xml->atc->callsign }}"/>
                     <input type="hidden" name="RULES" value="I"/>
@@ -211,8 +203,7 @@
                     <input type="hidden" name="EQUIPMENT" value="{{ $equipment }}"/>
                     <input type="hidden" name="TRANSPONDER" value="{{ $transponder }}"/>
                     <input type="hidden" name="DEPICAO" value="{{ $simbrief->xml->origin->icao_code}}"/>
-                    <input type="hidden" name="DEPTIME"
-                           value="{{ date('Hi', $simbrief->xml->times->est_out->__toString())."" }}"/>
+                    <input type="hidden" name="DEPTIME" value="{{ date('Hi', $simbrief->xml->times->est_out->__toString()) }}"/>
                     <input type="hidden" name="SPEEDTYPE" value="{{ $simbrief->xml->atc->initial_spd_unit }}"/>
                     <input type="hidden" name="SPEED" value="{{ $simbrief->xml->atc->initial_spd }}"/>
                     <input type="hidden" name="LEVELTYPE" value="{{ $simbrief->xml->atc->initial_alt_unit }}"/>

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -1,269 +1,436 @@
 @extends('app')
-@section('title', 'Generate OFP')
+@section('title', 'SimBrief Flight Planning')
 
 @section('content')
+
+@if(empty(request()->get('aircraft_id')))
+<div class="row">
+  <div class="col-md-12">
+    <h2>Aircraft Selection</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+		  <select id="aircraftselection" class="form-control select2" onchange="checkacselection()">
+			<option value="ZZZZZ">Please Select An Aircraft</option>
+				@foreach($subfleets as $subfleet)
+					@foreach($subfleet->aircraft as $ac)
+						<option value="{{ $ac->id }}">[ {{ $ac->icao }} ] {{ $ac->registration }}</option>
+					@endforeach
+				@endforeach
+		  </select>
+  </div>
+  <div class="col-md-6">
+    <a id="mylink" style="visibility: hidden" href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}" class="btn btn-primary">Proceed To Flight Planning</a>
+  </div>
+</div>
+@else
+
+  @php
+    $loadmin = $flight->load_factor - $flight->load_factor_variance ;
+    $loadmax = $flight->load_factor + $flight->load_factor_variance ;
+    if($loadmin < 1) { $loadmin = 1 ; }
+    if($loadmax > 100) { $loadmax = 100 ; }
+  @endphp
+
+  @foreach($aircraft as $acdetails)
+    @php
+      $simbrieftype = $acdetails->icao ;
+      $subflid = $acdetails->subfleet_id ;
+      if($acdetails->icao == 'A20N') { $simbrieftype = 'A320' ; }
+      if($acdetails->icao == 'A21N') { $simbrieftype = 'A321' ; }
+      if($acdetails->icao == 'B77L') { $simbrieftype = 'B77F' ; }
+      if($acdetails->icao == 'B773') { $simbrieftype = 'B77W' ; }
+      if($acdetails->icao == 'E35L') { $simbrieftype = 'E135' ; }
+    @endphp
+  @endforeach
+
   <form id="sbapiform">
     <div class="row">
-      <div class="col-md-12">
-        <h2>Create Flight Briefing</h2>
-        <div class="row">
-          <div class="col-8">
-            <div class="form-container">
-              <h6><i class="fas fa-info-circle"></i>
-                &nbsp;@lang('pireps.flightinformations')
-              </h6>
-              <div class="form-container-body">
-                <div class="row">
-                  <div class="col-sm-4">
-                    <label for="orig">Departure Airport</label>
-                    <input id="orig"
-                           name="orig"
-                           type="text"
-                           class="form-control"
-                           placeholder="ZZZZ"
-                           maxlength="4"
-                           value="{{ $flight->dpt_airport_id }}"/>
+      <div class="card">
+        <div class="col-md-12">
+          <h2>Create Flight Briefing Package</h2>
+          <div class="row">
+            <div class="col-8">
+              <div class="form-container">
+                <div class="form-container-body">
+                  <h6><i class="fas fa-info-circle"></i>&nbsp;Aircraft Details</h6>
+                  <div class="row">
+                    <div class="col-sm-4">
+                      <label for="type">Type</label>
+                      <input type="text" class="form-control" value="{{ $acdetails->icao }}" maxlength="4" disabled/>
+                      <input type="hidden" id="type" name="type" class="form-control" value="{{ $simbrieftype }}" maxlength="4"/>
+                    </div>
+                    <div class="col-sm-4">
+                      <label for="reg">Registration</label>
+                      <input type="text" class="form-control" value="{{ $acdetails->registration }}" maxlength="6" disabled/>
+                      <input type="hidden" id="reg" name="reg" value="{{ $acdetails->registration }}"/>
+                    </div>
                   </div>
+                  <br>
+                </div>
 
-                  <div class="col-sm-4">
-                    <label for="dest">Arrival Airport</label>
-                    <input id="dest"
-                           name="dest"
-                           type="text"
-                           class="form-control"
-                           placeholder=""
-                           maxlength="4"
-                           value="{{ $flight->arr_airport_id }}"/>
+                <div class="form-container-body">
+                  <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('pireps.flightinformations') for
+                    <b>{{ $flight->airline->icao }} {{ $flight->flight_number }}</b></h6>
+                  <div class="row">
+                    <div class="col-sm-4">
+                      <label for="dorig">Departure Airport</label>
+                      <input id="dorig" type="text" class="form-control" maxlength="4"
+                             value="{{ $flight->dpt_airport_id }}" disabled/>
+                      <input id="orig" name="orig" type="hidden" maxlength="4" value="{{ $flight->dpt_airport_id }}"/>
+                    </div>
+                    <div class="col-sm-4">
+                      <label for="ddest">Arrival Airport</label>
+                      <input id="ddest" type="text" class="form-control" maxlength="4"
+                             value="{{ $flight->arr_airport_id }}" disabled/>
+                      <input id="dest" name="dest" type="hidden" maxlength="4" value="{{ $flight->arr_airport_id }}"/>
+                    </div>
+                    <div class="col-sm-4">
+                      <label for="altn">Alternate Airport</label>
+                      <input id="altn" name="altn" type="text" class="form-control" maxlength="4"
+                             value="{{ $flight->alt_airport_id ?? 'AUTO' }}"/>
+                    </div>
                   </div>
+                  <br>
+                  <div class="row">
+                    <div class="col-sm-8">
+                      <label for="route">Preferred Company Route</label>
+                      <input id="route" name="route" type="text" class="form-control" placeholder="" maxlength="1000"
+                             value="{{ $flight->route }}"/>
+                    </div>
+                    <div class="col-sm-4">
+                      <label for="fl">Preferred Flight Level</label>
+                      <input id="fl" name="fl" type="text" class="form-control" placeholder="" maxlength="5" value="{{ $flight->level }}"/>
+                    </div>
+                  </div>
+                  <br>
+                  <div class="row">
+                    <div class="col-sm-4">
+                      <label for="std">Scheduled Departure Time (UTC)</label>
+                      <input id="std" type="text" class="form-control" placeholder="" maxlength="4"
+                             value="{{ $flight->dpt_time }}" disabled/>
+                    </div>
+                    <div class="col-sm-4">
+                      <label for="etd">Estimated Departure Time (UTC)</label>
+                      <input id="etd" type="text" class="form-control" placeholder="" maxlength="4" disabled/>
+                    </div>
+                    <div class="col-sm-4">
+                      <label for="dof">Date Of Flight (UTC)</label>
+                      <input id="dof" type="text" class="form-control" placeholder="" maxlength="4" disabled/>
+                    </div>
+                  </div>
+                  <br>
+                </div>
 
-                  <div class="col-sm-4">
-                    <label for="type">Aircraft</label>
-                    <select id="type" name="type" class="custom-select select2">
-                      <option value="A306" title="A306">A306 - A300F4-600</option>
-                      <option value="A310" title="A310 / CF6-80C2A2">A310 - A310-304</option>
-                      <option value="A318" title="A318 / CFM56-5B9/P">A318 - A318-100</option>
-                      <option value="A319" title="A319 / CFM56-5B6/2P">A319 - A319-100</option>
-                      <option value="A320" title="A320 / CFM56-5B4/P">A320 - A320-200</option>
-                      <option value="A321" title="A321 / CFM56-5B3/P">A321 - A321-200</option>
-                      <option value="A332" title="A332 / CF6-80E1A4">A332 - A330-200</option>
-                      <option value="A333" title="A333 / RR Trent 772B">A333 - A330-300</option>
-                      <option value="A342" title="A342 / CFM56-5C2">A342 - A340-200</option>
-                      <option value="A343" title="A343 / CFM56-5C4">A343 - A340-300</option>
-                      <option value="A345" title="A345 / RB211 Trent 556-61">A345 - A340-500</option>
-                      <option value="A346" title="A346 / RB211 Trent 556-61">A346 - A340-600</option>
-                      <option value="A359" title="A359 / TRENT XWB-84">A359 - A350-900</option>
-                      <option value="A35K" title="A35K / TRENT XWB-97">A35K - A350-1000</option>
-                      <option value="A388" title="A388">A388 - A380-800</option>
-                      <option value="AT72" title="AT72">AT72 - ATR72-500</option>
-                      <option value="B190" title="B190 / PT6A-67D">B190 - B1900D</option>
-                      <option value="B350" title="B350">B350 - KINGAIR</option>
-                      <option value="B463" title="B463">B463 - BAE-146</option>
-                      <option value="B703" title="B703">B703 - B707-320B</option>
-                      <option value="B712" title="B712 / BR715-C1-30">B712 - B717-200</option>
-                      <option value="B722" title="B722">B722 - B727-200</option>
-                      <option value="B732" title="B732 / JT8D-15A">B732 - B737-200</option>
-                      <option value="B733" title="B733 / CFM56-3C-1">B733 - B737-300</option>
-                      <option value="B734" title="B734">B734 - B737-400</option>
-                      <option value="B735" title="B735">B735 - B737-500</option>
-                      <option value="B736" title="B736 / CFM56-7B22">B736 - B737-600</option>
-                      <option value="BBJ1" title="B737 / CFM56-7B27">BBJ1 - B737 BBJ</option>
-                      <option value="B737" title="B737 / CFM56-7B24">B737 - B737-700</option>
-                      <option value="BBJ2" title="B738 / CFM56-7B27">BBJ2 - B737 BBJ2</option>
-                      <option value="B738" title="B738 / CFM56-7B26">B738 - B737-800</option>
-                      <option value="BBJ3" title="B739 / CFM56-7B27">BBJ3 - B737 BBJ3</option>
-                      <option value="B739" title="B739 / CFM56-7B26">B739 - B737-900</option>
-                      <option value="B742" title="B742 / JT9D-7F">B742 - B747-200B</option>
-                      <option value="B744" title="B744 / RB211-524G/H">B744 - B747-400</option>
-                      <option value="B74F" title="B744 / RB211-524G/H">B74F - B747-400F</option>
-                      <option value="B748" title="B748 / GENX-2B67">B748 - B747-8</option>
-                      <option value="B48F" title="B748 / GENX-2B67">B48F - B747-8F</option>
-                      <option value="B752" title="B752 / PW2037">B752 - B757-200</option>
-                      <option value="B75F" title="B752 / PW2037">B75F - B757-200PF</option>
-                      <option value="B753" title="B753 / PW2037">B753 - B757-300</option>
-                      <option value="B762" title="B762 / CF6-80C2-B2">B762 - B767-200ER</option>
-                      <option value="B763" title="B763 / CF6-80C2B6F">B763 - B767-300ER</option>
-                      <option value="B76F" title="B763 / CF6-80C2B6F">B76F - B767-300F</option>
-                      <option value="B764" title="B764">B764 - B767-400ER</option>
-                      <option value="B772" title="B772 / GE90-94B">B772 - B777-200ER</option>
-                      <option value="B77L" title="B77L / GE90-110B1">B77L - B777-200LR</option>
-                      <option value="B77F" title="B77L / GE90-110B1">B77F - B777-F</option>
-                      <option value="B77W" title="B77W / GE90-115BL2">B77W - B777-300ER</option>
-                      <option value="B788" title="B788 / GENX-1B70">B788 - B787-8</option>
-                      <option value="B789" title="B789 / GENX-1B74">B789 - B787-9</option>
-                      <option value="B78X" title="B78X / GENX-1B76">B78X - B787-10</option>
-                      <option value="BE20" title="BE20">BE20 - KINGAIR</option>
-                      <option value="C172" title="C172 / IO-360-L2A">C172 - CESSNA 172R</option>
-                      <option value="C208" title="C208">C208 - CESSNA 208</option>
-                      <option value="C25A" title="C25A / FJ44-2C">C25A - CITATION CJ2</option>
-                      <option value="C404" title="C404">C404 - C404 TITAN</option>
-                      <option value="C510" title="C510">C510 - C510 MUSTANG</option>
-                      <option value="C550" title="C550">C550 - CITATION</option>
-                      <option value="C56X" title="C56X / PW545A">C56X - CITATION 560XL</option>
-                      <option value="C750" title="C750">C750 - CITATION X</option>
-                      <option value="CL30" title="CL30 / HTF7350">CL30 - CHALLENGER</option>
-                      <option value="CRJ2" title="CRJ2 / CF34-3B1">CRJ2 - CRJ-200</option>
-                      <option value="CRJ7" title="CRJ7 / CF34-8C1">CRJ7 - CRJ-700</option>
-                      <option value="CRJ9" title="CRJ9 / CF34-8C5">CRJ9 - CRJ-900</option>
-                      <option value="CRJX" title="CRJX / CF34-8C5A1">CRJX - CRJ-1000</option>
-                      <option value="DC10" title="DC10">DC10 - DC-10-30</option>
-                      <option value="DC6" title="DC6 / R2800-CB16">DC6&nbsp; - DC-6</option>
-                      <option value="DC85" title="DC85 / JT3D-3B">DC85 - DC-8-55</option>
-                      <option value="DH8A" title="DH8A / PW120A">DH8A - DHC8-102</option>
-                      <option value="DH8B" title="DH8B / PW123C">DH8B - DHC8-200</option>
-                      <option value="DH8C" title="DH8C / PW123B">DH8C - DHC8-311</option>
-                      <option value="DH8D" title="DH8D / PW150A">DH8D - DHC8-402</option>
-                      <option value="DHC2" title="DHC2">DHC2 - BEAVER</option>
-                      <option value="DHC6" title="DHC6">DHC6 - TWIN OTTER</option>
-                      <option value="E13L" title="E135">E13L - EMB-135BJ</option>
-                      <option value="E135" title="E135 / AE3007-A1/3">E135 - EMB-135LR</option>
-                      <option value="E140" title="E135 / AE3007-A1/3">E140 - ERJ-140LR</option>
-                      <option value="E145" title="E145 / AE3007-A1">E145 - EMB-145LR</option>
-                      <option value="E170" title="E170 / CF34-8E5">E170 - EMB-170</option>
-                      <option value="E175" title="E170 / CF34-8E5">E175 - EMB-175</option>
-                      <option value="E190" title="E190 / CF34-10E6">E190 - EMB-190</option>
-                      <option value="E195" title="E190 / CF34-10E7">E195 - EMB-195</option>
-                      <option value="E50P" title="E50P / PW617F1-E">E50P - PHENOM 100</option>
-                      <option value="E55P" title="E55P / PW535E">E55P - PHENOM 300</option>
-                      <option value="EA50" title="EA50 / PW610F">EA50 - ECLIPSE 550</option>
-                      <option value="F50" title="F50">F50&nbsp; - FOKKER F50</option>
-                      <option value="FA50" title="FA50 / TFE 731-40">FA50 - FALCON 50EX</option>
-                      <option value="GLF4" title="GLF4">GLF4 - GULFSTREAM</option>
-                      <option value="H25B" title="H25B">H25B - HAWKER 800A</option>
-                      <option value="JS41" title="JS41">JS41 - BAE JS-41</option>
-                      <option value="L101" title="L101 / RB211-524B">L101 - L1011-500</option>
-                      <option value="LJ25" title="LJ25 / CJ-610-8A">LJ25 - LEARJET 25</option>
-                      <option value="LJ45" title="LJ45">LJ45 - LEARJET 45</option>
-                      <option value="MD11" title="MD11 / CF6-80C2D1F">MD11 - MD-11</option>
-                      <option value="MD1F" title="MD11 / CF6-80C2D1F">MD1F - MD-11F</option>
-                      <option value="MD82" title="MD82 / JT8D-217">MD82 - DC-9-82</option>
-                      <option value="MD83" title="MD83 / JT8D-219">MD83 - DC-9-83</option>
-                      <option value="MD88" title="MD88 / JT8D-219">MD88 - MD-88</option>
-                      <option value="MD90" title="MD90">MD90 - MD-90-30</option>
-                      <option value="PC12" title="PC12 / PT6A-66D">PC12 - PILATUS PC12</option>
-                      <option value="RJ1H" title="RJ1H">RJ1H - AVRO RJ100</option>
-                      <option value="RJ70" title="RJ70">RJ70 - AVRO RJ70</option>
-                      <option value="RJ85" title="RJ85">RJ85 - AVRO RJ85</option>
-                      <option value="SF34" title="SF34 / GE CT7-9B">SF34 - SAAB 340B</option>
-                      <option value="SF50" title="SF50 / FJ33-5A">SF50 - VISION JET</option>
-                      <option value="SW4" title="SW4 / TPE-331">SW4&nbsp; - METROLINER</option>
-                      <option value="T154" title="T154">T154 - TU-154B2</option>
-                      <option value="TBM9" title="TBM9 / PT6A-66D">TBM9 - TBM 900</option>
-                    </select>
+                <div class="form-container-body">
+                  @foreach($subfleets as $subfleet)
+                    @if($subfleet->id == $subflid)
+                      <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Load Information For
+                        <b>{{ $subfleet->name }} ; {{ $acdetails->registration }}</b></h6>
+                      {{-- Generate Load Figures --}}
+                      <div class="row">
+                        @php $loadarray = [] ; @endphp
+                        @foreach($subfleet->fares as $fare)
+                          @if($fare->capacity > 0)
+                            @php
+                              $randomloadperfare = ceil(($fare->capacity * (rand($loadmin, $loadmax))) /100);
+                              $loadarray[] = ['SeatType' => $fare->code];
+                              $loadarray[] = ['SeatLoad' => $randomloadperfare];
+                            @endphp
+                            <div class="col-sm-4">
+                              <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} Load [
+                                Max: {{ number_format($fare->capacity) }} ]</label>
+                              <input id="LoadFare{{ $fare->id }}" type="text" class="form-control"
+                                     value="{{ number_format($randomloadperfare) }} @if($randomloadperfare > '900') {{ setting('units.weight') }} @endif"
+                                     disabled/>
+                            </div>
+                          @endif
+                        @endforeach
+                        @php
+                          $loadcollection = collect($loadarray) ;
+                          $totalgenload = $loadcollection->sum('SeatLoad') ;
+                        @endphp
+                      </div>
+
+                      @if($totalgenload > 0 && $totalgenload < 900)
+                        <input type="hidden" name="acdata" value="{'paxwgt':{{ $pax_weight }}}">
+                        <br>
+                        <div class="row">
+                          <div class="col-sm-4">
+                            @if(setting('units.weight') === 'kg')
+                              @php $estimatedpayload = number_format(round(($pax_weight * $totalgenload) / 2.2)) ; @endphp
+                            @else
+                              @php $estimatedpayload = number_format(round($pax_weight * $totalgenload)) ; @endphp
+                            @endif
+                            <label for="EstimatedLoad">Estimated Payload For {{ $totalgenload }} Pax</label>
+                            <input id="EstimatedLoad" type="text" class="form-control"
+                                   value="{{ $estimatedpayload }} {{ setting('units.weight') }}" disabled/>
+                          </div>
+                        </div>
+                        <input type="hidden" id="pax" name="pax" class="form-control" value="{{ $totalgenload }}"/>
+                      @elseif($totalgenload > 900)
+                        <input type='hidden' id="pax" name='pax' value='0' maxlength='3'>
+                        <input type='hidden' id="cargo" name='cargo' value="{{ $totalgenload }}" maxlength='7'>
+                      @endif
+                    @endif
+                  @endforeach
+                </div>
+              </div>
+            </div>
+            @if($totalgenload > 0)
+              @php
+                $loaddisttxt =  "Load Distribution ";
+                $loaddist = implode(' ', array_map(
+                            function ($v, $k) {
+                                if(is_array($v)){
+                                    return implode('&'.' '.':', $v);
+                                }else{
+                                    return $k.':'.$v;
+                                }
+                          },
+                          $loadarray,	array_keys($loadarray)
+                      ));
+              @endphp
+              <input type="hidden" name="manualrmk" value="{{ $loaddisttxt }}{{ $loaddist }}">
+            @endif
+            <input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
+            <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
+            <input type="hidden" id="steh" name="steh" maxlength="2">
+            <input type="hidden" id="stem" name="stem" maxlength="2">
+            <input type="hidden" id="date" name="date" maxlength="9">
+            <input type="hidden" id="deph" name="deph" maxlength="2">
+            <input type="hidden" id="depm" name="depm" maxlength="2">
+            <input type="hidden" name="selcal" value="BK-FS">
+            <input type="hidden" name="planformat" value="lido">
+            <input type="hidden" name="omit_sids" value="0">
+            <input type="hidden" name="omit_stars" value="0">
+            <input type="hidden" name="cruise" value="CI">
+            <input type="hidden" name="civalue" value="AUTO">
+
+            <div class="col-4">
+              <div class="form-container">
+                <div class="form-container-body">
+                  <h6><i class="fas fa-info-circle"></i>&nbsp;Planning Options</h6>
+                  <table class="table table-hover table-striped">
+                    <tr>
+                      <td>Cont Fuel:</td>
+                      <td>
+                        <select name="contpct" class="form-control">
+                          <option value="auto">AUTO</option>
+                          <option value="0">0 PCT</option>
+                          <option value="0.02">2 PCT</option>
+                          <option value="0.03">3 PCT</option>
+                          <option value="0.05" selected>5 PCT</option>
+                          <option value="0.1">10 PCT</option>
+                          <option value="0.15">15 PCT</option>
+                          <option value="0.2">20 PCT</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Reserve Fuel:</td>
+                      <td>
+                        <select name="resvrule" class="form-control">
+                          <option value="auto">AUTO</option>
+                          <option value="0">0 MIN</option>
+                          <option value="15">15 MIN</option>
+                          <option value="30" selected>30 MIN</option>
+                          <option value="45">45 MIN</option>
+                          <option value="60">60 MIN</option>
+                          <option value="75">75 MIN</option>
+                          <option value="90">90 MIN</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>SID/STAR Type:</td>
+                      <td>
+                        <select name="find_sidstar" class="form-control">
+                          <option value="C">Conventional</option>
+                          <option value="R" selected>RNAV</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Plan Stepclimbs:</td>
+                      <td>
+                        <select id="stepclimbs" name="stepclimbs" class="form-control" onchange="DisableFL()">
+                          <option value="0" selected>Disabled</option>
+                          <option value="1">Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>ETOPS Planning:</td>
+                      <td>
+                        <select name="etops" class="form-control">
+                          <option value="0" selected>Disabled</option>
+                          <option value="1">Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+                <br>
+                <div class="form-container-body">
+                  <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('stisla.briefingoptions')</h6>
+                  <table class="table table-hover table-striped">
+                    <tr>
+                      <td>Units:</td>
+                      <td>
+                        <select id="kgslbs" name="units" class="form-control">
+                          @if(setting('units.weight') === 'kg')
+                            <option value="KGS" selected>KGS</option>
+                            <option value="LBS">LBS</option>
+                          @else
+                            <option value="KGS">KGS</option>
+                            <option value="LBS" selected>LBS</option>
+                          @endif
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Detailed Navlog:</td>
+                      <td>
+                        <select name="navlog" class="form-control">
+                          <option value="0">Disabled</option>
+                          <option value="1" selected>Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Runway Analysis:</td>
+                      <td>
+                        <select name="tlr" class="form-control">
+                          <option value="0">Disabled</option>
+                          <option value="1" selected>Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Include NOTAMS:</td>
+                      <td>
+                        <select name="notams" class="form-control">
+                          <option value="0">Disabled</option>
+                          <option value="1" selected>Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>FIR NOTAMS:</td>
+                      <td>
+                        <select name="firnot" class="form-control">
+                          <option value="0" selected>Disabled</option>
+                          <option value="1">Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Flight Maps:</td>
+                      <td>
+                        <select name="maps" class="form-control">
+                          <option value="detail" selected>Detailed</option>
+                          <option value="simple">Simple</option>
+                          <option value="none">None</option>
+                        </select>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+                <br>
+                <div class="form-container-body">
+                  <div class="float-right">
+                    <div class="form-group">
+                      <input type="button"
+                             onclick="simbriefsubmit('{{ $flight->id }}', '{{ url(route('frontend.simbrief.briefing', [''])) }}');"
+                             class="btn btn-primary" value="Generate">
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <div class="col-4">
-            <div class="form-container">
-              <h6><i class="fas fa-info-circle"></i>
-                &nbsp;Briefing Options
-              </h6>
-              <table class="table table-hover table-striped">
-                <tr>
-                  <td>Units:</td>
-                  <td><select name="units">
-                      <option value="KGS">KGS</option>
-                      <option value="LBS" selected>LBS</option>
-                    </select></td>
-                </tr>
-                <tr>
-                  <td>Cont Fuel:</td>
-                  <td><select name="contpct">
-                      <option value="auto" selected>AUTO</option>
-                      <option value="0">0 PCT</option>
-                      <option value="0.02">2 PCT</option>
-                      <option value="0.03">3 PCT</option>
-                      <option value="0.05">5 PCT</option>
-                      <option value="0.1">10 PCT</option>
-                      <option value="0.15">15 PCT</option>
-                      <option value="0.2">20 PCT</option>
-                    </select></td>
-                </tr>
-                <tr>
-                  <td>Reserve Fuel:</td>
-                  <td><select name="resvrule">
-                      <option value="auto">AUTO</option>
-                      <option value="0">0 MIN</option>
-                      <option value="15">15 MIN</option>
-                      <option value="30">30 MIN</option>
-                      <option value="45" selected>45 MIN</option>
-                      <option value="60">60 MIN</option>
-                      <option value="75">75 MIN</option>
-                      <option value="90">90 MIN</option>
-                    </select></td>
-                </tr>
-                <tr>
-                  <td>Detailed Navlog:</td>
-                  <td><input type="hidden" name="navlog" value="0"><input type="checkbox" name="navlog" value="1"
-                                                                          checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>ETOPS Planning:</td>
-                  <td><input type="hidden" name="etops" value="0"><input type="checkbox" name="etops" value="1"></td>
-                </tr>
-                <tr>
-                  <td>Plan Stepclimbs:</td>
-                  <td><input type="hidden" name="stepclimbs" value="0"><input type="checkbox" name="stepclimbs"
-                                                                              value="1"
-                                                                              checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Runway Analysis:</td>
-                  <td><input type="hidden" name="tlr" value="0"><input type="checkbox" name="tlr" value="1" checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Include NOTAMS:</td>
-                  <td><input type="hidden" name="notams" value="0"><input type="checkbox" name="notams" value="1"
-                                                                          checked>
-                  </td>
-                </tr>
-                <tr>
-                  <td>FIR NOTAMS:</td>
-                  <td><input type="hidden" name="firnot" value="0"><input type="checkbox" name="firnot" value="1"></td>
-                </tr>
-                <tr>
-                  <td>Flight Maps:</td>
-                  <td><select name="maps">
-                      <option value="detail">Detailed</option>
-                      <option value="simple">Simple</option>
-                      <option value="none">None</option>
-                    </select></td>
-                </tr>
-              </table>
-            </div>
-          </div>
-        </div>
-
-        <input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
-        <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
-        <input type="hidden" name="date" value="01JAN14">
-        <input type="hidden" name="deph" value="12">
-        <input type="hidden" name="depm" value="30">
-        <input type="hidden" name="steh" value="2">
-        <input type="hidden" name="stem" value="15">
-        {{--<input type="hidden" name="reg" value="N123SB">
-        <input type="hidden" name="selcal" value="GR-FS">--}}
-        <input type="hidden" name="planformat" value="lido">
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-12">
-        <div class="float-right">
-          <div class="form-group">
-            <input type="button"
-                   onclick="simbriefsubmit('{{ $flight->id }}', '{{ url(route('frontend.simbrief.briefing', [''])) }}');"
-                   class="btn btn-outline-primary"
-                   value="Generate">
-          </div>
         </div>
       </div>
     </div>
   </form>
+@endif
 @endsection
 @section('scripts')
   <script src="{{public_asset('/assets/global/js/simbrief.apiv1.js')}}"></script>
+  <script type="text/javascript">
+    // ******
+    // Disable Submitting a fixed flight level for Stepclimb option to work
+    // Script is related to Plan Step Climbs selection
+    function DisableFL() {
+      let climb = document.getElementById("stepclimbs").value;
+      if (climb === "0") {
+        document.getElementById("fl").disabled = false
+      }
+
+      if (climb === "1") {
+        document.getElementById("fl").disabled = true
+      }
+    }
+  </script>
+  <script type="text/javascript">
+    // ******
+    // Get current UTC time, add 45 minutes to it and format according to Simbrief API
+    // Script also rounds the minutes to nearest 5 to avoid a Departure time like 1538 ;)
+    // If you need to reduce the margin of 45 mins, change value below
+    let d = new Date();
+    const months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+    d.setMinutes(d.getMinutes() + 45); // Change the value here
+    let deph = ("0" + d.getUTCHours(d)).slice(-2);
+    let depm = d.getUTCMinutes(d);
+    if (depm < 55) {
+      depm = Math.ceil(depm / 5) * 5;
+    }
+
+    if (depm > 55) {
+      depm = Math.floor(depm / 5) * 5;
+    }
+
+    depm = ("0" + depm).slice(-2);
+    dept = deph + depm;
+    let dof = ("0" + d.getUTCDate()).slice(-2) + months[d.getUTCMonth()] + d.getUTCFullYear();
+
+    document.getElementById("dof").setAttribute('value', dof);
+    document.getElementById("etd").setAttribute('value', dept);
+    document.getElementById("date").setAttribute('value', dof); // Sent to Simbrief
+    document.getElementById("deph").setAttribute('value', deph); // Sent to SimBrief
+    document.getElementById("depm").setAttribute('value', depm); // Sent to SimBrief
+  </script>
+  <script type="text/javascript">
+    // ******
+    // Calculate the Scheduled Enroute Time for Simbrief API
+    // Your PHPVMS flight_time value must be from BLOCK to BLOCK
+    // Including departure and arrival taxi times
+    // If this value is not correctly calculated and configured
+    // Simbrief CI (Cost Index) calculation will not provide realistic results
+    let num = {{ $flight->flight_time }};
+    let hours = (num / 60);
+    let rhours = Math.floor(hours);
+    let minutes = (hours - rhours) * 60;
+    let rminutes = Math.round(minutes);
+    document.getElementById("steh").setAttribute('value', rhours.toString()); // Sent to Simbrief
+    document.getElementById("stem").setAttribute('value', rminutes.toString()); // Sent to Simbrief
+  </script>
+  <script type="text/javascript">
+		// *** Simple Aircraft Selection With Dropdown Change
+		// *** Also keep Generate button hidden until a valid AC selection
+		const $oldlink = document.getElementById("mylink").href ;
+		function checkacselection() {
+			if (document.getElementById("aircraftselection").value == "ZZZZZ") {
+					document.getElementById('mylink').style.visibility = 'hidden';
+				}else{
+					document.getElementById('mylink').style.visibility = 'visible';
+				}
+			var $selectedac = document.getElementById("aircraftselection").value ;
+			var $newlink = "&aircraft_id=".concat($selectedac) ;
+			document.getElementById("mylink").href = $oldlink.concat($newlink) ;	
+		}
+	</script>
 @endsection

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -3,354 +3,364 @@
 
 @section('content')
 
-@if(empty(request()->get('aircraft_id')))
-<div class="row">
-  <div class="col-md-12">
-    <h2>Aircraft Selection</h2>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-		  <select id="aircraftselection" class="form-control select2" onchange="checkacselection()">
-			<option value="ZZZZZ">Please Select An Aircraft</option>
-				@foreach($subfleets as $subfleet)
-					@foreach($subfleet->aircraft as $ac)
-						<option value="{{ $ac->id }}">[ {{ $ac->icao }} ] {{ $ac->registration }}</option>
-					@endforeach
-				@endforeach
-		  </select>
-  </div>
-  <div class="col-md-6">
-    <a id="mylink" style="visibility: hidden" href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}" class="btn btn-primary">Proceed To Flight Planning</a>
-  </div>
-</div>
-@else
-
-  @php
-    $loadmin = $flight->load_factor - $flight->load_factor_variance ;
-    $loadmax = $flight->load_factor + $flight->load_factor_variance ;
-    if($loadmin < 1) { $loadmin = 1 ; }
-    if($loadmax > 100) { $loadmax = 100 ; }
-  @endphp
-
-  @foreach($aircraft as $acdetails)
-    @php
-      $simbrieftype = $acdetails->icao ;
-      $subflid = $acdetails->subfleet_id ;
-      if($acdetails->icao === 'A20N') { $simbrieftype = 'A320' ; }
-      if($acdetails->icao === 'A21N') { $simbrieftype = 'A321' ; }
-      if($acdetails->icao === 'B77L') { $simbrieftype = 'B77F' ; }
-      if($acdetails->icao === 'B773') { $simbrieftype = 'B77W' ; }
-      if($acdetails->icao === 'E35L') { $simbrieftype = 'E135' ; }
-    @endphp
-  @endforeach
-
-  <form id="sbapiform">
+  @if(empty(request()->get('aircraft_id')))
     <div class="row">
-      <div class="card">
-        <div class="col-md-12">
-          <h2>Create Flight Briefing Package</h2>
-          <div class="row">
-            <div class="col-8">
-              <div class="form-container">
-                <div class="form-container-body">
-                  <h6><i class="fas fa-info-circle"></i>&nbsp;Aircraft Details</h6>
-                  <div class="row">
-                    <div class="col-sm-4">
-                      <label for="type">Type</label>
-                      <input type="text" class="form-control" value="{{ $acdetails->icao }}" maxlength="4" disabled/>
-                      <input type="hidden" id="type" name="type" class="form-control" value="{{ $simbrieftype }}" maxlength="4"/>
-                    </div>
-                    <div class="col-sm-4">
-                      <label for="reg">Registration</label>
-                      <input type="text" class="form-control" value="{{ $acdetails->registration }}" maxlength="6" disabled/>
-                      <input type="hidden" id="reg" name="reg" value="{{ $acdetails->registration }}"/>
-                    </div>
-                  </div>
-                  <br>
-                </div>
+      <div class="col-md-12">
+        <h2>Aircraft Selection</h2>
+      </div>
+    </div>
 
-                <div class="form-container-body">
-                  <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('pireps.flightinformations') for
-                    <b>{{ $flight->airline->icao }} {{ $flight->flight_number }}</b></h6>
-                  <div class="row">
-                    <div class="col-sm-4">
-                      <label for="dorig">Departure Airport</label>
-                      <input id="dorig" type="text" class="form-control" maxlength="4"
-                             value="{{ $flight->dpt_airport_id }}" disabled/>
-                      <input id="orig" name="orig" type="hidden" maxlength="4" value="{{ $flight->dpt_airport_id }}"/>
-                    </div>
-                    <div class="col-sm-4">
-                      <label for="ddest">Arrival Airport</label>
-                      <input id="ddest" type="text" class="form-control" maxlength="4"
-                             value="{{ $flight->arr_airport_id }}" disabled/>
-                      <input id="dest" name="dest" type="hidden" maxlength="4" value="{{ $flight->arr_airport_id }}"/>
-                    </div>
-                    <div class="col-sm-4">
-                      <label for="altn">Alternate Airport</label>
-                      <input id="altn" name="altn" type="text" class="form-control" maxlength="4"
-                             value="{{ $flight->alt_airport_id ?? 'AUTO' }}"/>
-                    </div>
-                  </div>
-                  <br>
-                  <div class="row">
-                    <div class="col-sm-8">
-                      <label for="route">Preferred Company Route</label>
-                      <input id="route" name="route" type="text" class="form-control" placeholder="" maxlength="1000"
-                             value="{{ $flight->route }}"/>
-                    </div>
-                    <div class="col-sm-4">
-                      <label for="fl">Preferred Flight Level</label>
-                      <input id="fl" name="fl" type="text" class="form-control" placeholder="" maxlength="5" value="{{ $flight->level }}"/>
-                    </div>
-                  </div>
-                  <br>
-                  <div class="row">
-                    <div class="col-sm-4">
-                      <label for="std">Scheduled Departure Time (UTC)</label>
-                      <input id="std" type="text" class="form-control" placeholder="" maxlength="4"
-                             value="{{ $flight->dpt_time }}" disabled/>
-                    </div>
-                    <div class="col-sm-4">
-                      <label for="etd">Estimated Departure Time (UTC)</label>
-                      <input id="etd" type="text" class="form-control" placeholder="" maxlength="4" disabled/>
-                    </div>
-                    <div class="col-sm-4">
-                      <label for="dof">Date Of Flight (UTC)</label>
-                      <input id="dof" type="text" class="form-control" placeholder="" maxlength="4" disabled/>
-                    </div>
-                  </div>
-                  <br>
-                </div>
+    <div class="row">
+      <div class="col-md-6">
+        <select id="aircraftselection" class="form-control select2" onchange="checkacselection()">
+          <option value="ZZZZZ">Please Select An Aircraft</option>
+          @foreach($subfleets as $subfleet)
+            @foreach($subfleet->aircraft as $ac)
+              <option value="{{ $ac->id }}">[ {{ $ac->icao }} ] {{ $ac->registration }}</option>
+            @endforeach
+          @endforeach
+        </select>
+      </div>
+      <div class="col-md-6">
+        <a id="mylink" style="visibility: hidden"
+           href="{{ route('frontend.simbrief.generate') }}?flight_id={{ $flight->id }}" class="btn btn-primary">Proceed
+          To Flight Planning</a>
+      </div>
+    </div>
+  @else
 
-                <div class="form-container-body">
-                  @foreach($subfleets as $subfleet)
-                    @if($subfleet->id == $subflid)
-                      <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Load Information For
-                        <b>{{ $subfleet->name }} ; {{ $acdetails->registration }}</b></h6>
-                      {{-- Generate Load Figures --}}
-                      <div class="row">
-                      {{-- Create and send some data to the $loadarray for MANUALRMK generation --}}
-                        @php $loadarray = [] ; @endphp
-                        @foreach($subfleet->fares as $fare)
-                          @if($fare->capacity > 0)
-                            @php
-                              $randomloadperfare = ceil(($fare->capacity * (rand($loadmin, $loadmax))) /100);
-                              $loadarray[] = ['SeatType' => $fare->code];
-                              $loadarray[] = ['SeatLoad' => $randomloadperfare];
-                            @endphp
-                            <div class="col-sm-4">
-                              <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} Load [
-                                Max: {{ number_format($fare->capacity) }} ]</label>
-                              <input id="LoadFare{{ $fare->id }}" type="text" class="form-control"
-                                     value="{{ number_format($randomloadperfare) }} @if($randomloadperfare > '900') {{ setting('units.weight') }} @endif"
-                                     disabled/>
-                            </div>
-                          @endif
-                        @endforeach
-                        @php
-                          $loadcollection = collect($loadarray) ;
-                          $totalgenload = $loadcollection->sum('SeatLoad') ;
-                        @endphp
+    @php
+      $loadmin = $flight->load_factor - $flight->load_factor_variance;
+      $loadmax = $flight->load_factor + $flight->load_factor_variance;
+      if($loadmin < 1) { $loadmin = 1; }
+      if($loadmax > 100) { $loadmax = 100; }
+    @endphp
+
+    @foreach($aircraft as $acdetails)
+      @php
+        $simbrieftype = $acdetails->icao ;
+        $subflid = $acdetails->subfleet_id ;
+        if($acdetails->icao === 'A20N') { $simbrieftype = 'A320'; }
+        if($acdetails->icao === 'A21N') { $simbrieftype = 'A321'; }
+        if($acdetails->icao === 'B77L') { $simbrieftype = 'B77F'; }
+        if($acdetails->icao === 'B773') { $simbrieftype = 'B77W'; }
+        if($acdetails->icao === 'E35L') { $simbrieftype = 'E135'; }
+      @endphp
+    @endforeach
+
+    <form id="sbapiform">
+      <div class="row">
+        <div class="card">
+          <div class="col-md-12">
+            <h2>Create Flight Briefing Package</h2>
+            <div class="row">
+              <div class="col-8">
+                <div class="form-container">
+                  <div class="form-container-body">
+                    <h6><i class="fas fa-info-circle"></i>&nbsp;Aircraft Details</h6>
+                    <div class="row">
+                      <div class="col-sm-4">
+                        <label for="type">Type</label>
+                        <input type="text" class="form-control" value="{{ $acdetails->icao }}" maxlength="4" disabled/>
+                        <input type="hidden" id="type" name="type" class="form-control" value="{{ $simbrieftype }}"
+                               maxlength="4"/>
                       </div>
+                      <div class="col-sm-4">
+                        <label for="reg">Registration</label>
+                        <input type="text" class="form-control" value="{{ $acdetails->registration }}" maxlength="6"
+                               disabled/>
+                        <input type="hidden" id="reg" name="reg" value="{{ $acdetails->registration }}"/>
+                      </div>
+                    </div>
+                    <br>
+                  </div>
 
-                      @if($totalgenload > 0 && $totalgenload < 900)
-                        <input type="hidden" name="acdata" value="{'paxwgt':{{ $pax_weight }}}">
-                        <br>
+                  <div class="form-container-body">
+                    <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('pireps.flightinformations') for
+                      <b>{{ $flight->airline->icao }} {{ $flight->flight_number }}</b></h6>
+                    <div class="row">
+                      <div class="col-sm-4">
+                        <label for="dorig">Departure Airport</label>
+                        <input id="dorig" type="text" class="form-control" maxlength="4"
+                               value="{{ $flight->dpt_airport_id }}" disabled/>
+                        <input id="orig" name="orig" type="hidden" maxlength="4" value="{{ $flight->dpt_airport_id }}"/>
+                      </div>
+                      <div class="col-sm-4">
+                        <label for="ddest">Arrival Airport</label>
+                        <input id="ddest" type="text" class="form-control" maxlength="4"
+                               value="{{ $flight->arr_airport_id }}" disabled/>
+                        <input id="dest" name="dest" type="hidden" maxlength="4" value="{{ $flight->arr_airport_id }}"/>
+                      </div>
+                      <div class="col-sm-4">
+                        <label for="altn">Alternate Airport</label>
+                        <input id="altn" name="altn" type="text" class="form-control" maxlength="4"
+                               value="{{ $flight->alt_airport_id ?? 'AUTO' }}"/>
+                      </div>
+                    </div>
+                    <br>
+                    <div class="row">
+                      <div class="col-sm-8">
+                        <label for="route">Preferred Company Route</label>
+                        <input id="route" name="route" type="text" class="form-control" placeholder="" maxlength="1000"
+                               value="{{ $flight->route }}"/>
+                      </div>
+                      <div class="col-sm-4">
+                        <label for="fl">Preferred Flight Level</label>
+                        <input id="fl" name="fl" type="text" class="form-control" placeholder="" maxlength="5"
+                               value="{{ $flight->level }}"/>
+                      </div>
+                    </div>
+                    <br>
+                    <div class="row">
+                      <div class="col-sm-4">
+                        <label for="std">Scheduled Departure Time (UTC)</label>
+                        <input id="std" type="text" class="form-control" placeholder="" maxlength="4"
+                               value="{{ $flight->dpt_time }}" disabled/>
+                      </div>
+                      <div class="col-sm-4">
+                        <label for="etd">Estimated Departure Time (UTC)</label>
+                        <input id="etd" type="text" class="form-control" placeholder="" maxlength="4" disabled/>
+                      </div>
+                      <div class="col-sm-4">
+                        <label for="dof">Date Of Flight (UTC)</label>
+                        <input id="dof" type="text" class="form-control" placeholder="" maxlength="4" disabled/>
+                      </div>
+                    </div>
+                    <br>
+                  </div>
+
+                  <div class="form-container-body">
+                    @foreach($subfleets as $subfleet)
+                      @if($subfleet->id == $subflid)
+                        <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Load Information For
+                          <b>{{ $subfleet->name }} ; {{ $acdetails->registration }}</b></h6>
+                        {{-- Generate Load Figures --}}
                         <div class="row">
-                          <div class="col-sm-4">
-                            @if(setting('units.weight') === 'kg')
-                              @php $estimatedpayload = number_format(round(($pax_weight * $totalgenload) / 2.2)) ; @endphp
-                            @else
-                              @php $estimatedpayload = number_format(round($pax_weight * $totalgenload)) ; @endphp
+                          {{-- Create and send some data to the $loadarray for MANUALRMK generation --}}
+                          @php $loadarray = [] ; @endphp
+                          @foreach($subfleet->fares as $fare)
+                            @if($fare->capacity > 0)
+                              @php
+                                $randomloadperfare = ceil(($fare->capacity * (rand($loadmin, $loadmax))) /100);
+                                $loadarray[] = ['SeatType' => $fare->code];
+                                $loadarray[] = ['SeatLoad' => $randomloadperfare];
+                              @endphp
+                              <div class="col-sm-4">
+                                <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} Load [
+                                  Max: {{ number_format($fare->capacity) }} ]</label>
+                                <input id="LoadFare{{ $fare->id }}" type="text" class="form-control"
+                                       value="{{ number_format($randomloadperfare) }} @if($randomloadperfare > '900') {{ setting('units.weight') }} @endif"
+                                       disabled/>
+                              </div>
                             @endif
-                            <label for="EstimatedLoad">Estimated Payload For {{ $totalgenload }} Pax</label>
-                            <input id="EstimatedLoad" type="text" class="form-control"
-                                   value="{{ $estimatedpayload }} {{ setting('units.weight') }}" disabled/>
-                          </div>
+                          @endforeach
+                          @php
+                            $loadcollection = collect($loadarray) ;
+                            $totalgenload = $loadcollection->sum('SeatLoad') ;
+                          @endphp
                         </div>
-                        <input type="hidden" id="pax" name="pax" class="form-control" value="{{ $totalgenload }}"/>
-                      @elseif($totalgenload > 900)
-                        <input type='hidden' id="pax" name='pax' value='0' maxlength='3'>
-                        <input type='hidden' id="cargo" name='cargo' value="{{ $totalgenload }}" maxlength='7'>
+
+                        @if($totalgenload > 0 && $totalgenload < 900)
+                          <input type="hidden" name="acdata" value="{'paxwgt':{{ $pax_weight }}}">
+                          <br>
+                          <div class="row">
+                            <div class="col-sm-4">
+                              @if(setting('units.weight') === 'kg')
+                                @php $estimatedpayload = number_format(round(($pax_weight * $totalgenload) / 2.2)) ; @endphp
+                              @else
+                                @php $estimatedpayload = number_format(round($pax_weight * $totalgenload)) ; @endphp
+                              @endif
+                              <label for="EstimatedLoad">Estimated Payload For {{ $totalgenload }} Pax</label>
+                              <input id="EstimatedLoad" type="text" class="form-control"
+                                     value="{{ $estimatedpayload }} {{ setting('units.weight') }}" disabled/>
+                            </div>
+                          </div>
+                          <input type="hidden" id="pax" name="pax" class="form-control" value="{{ $totalgenload }}"/>
+                        @elseif($totalgenload > 900)
+                          <input type='hidden' id="pax" name='pax' value='0' maxlength='3'>
+                          <input type='hidden' id="cargo" name='cargo' value="{{ $totalgenload }}" maxlength='7'>
+                        @endif
                       @endif
-                    @endif
-                  @endforeach
+                    @endforeach
+                  </div>
                 </div>
               </div>
-            </div>
-            {{-- Here we generate the MANUALRMK which is sent to SimBrief and displayed in the generated ofp as Dispatch Remarks. --}}
-            {{-- $loadarray is created and filled with data during random load generation, it holds each fare's code and the generated load --}}
-            {{-- then we are imploding that array to get the fare codes and load counts --}}
-            {{-- Returned string will be like Load Distribution Y 132 C 12 F 4 --}}
-            @if($totalgenload > 0)
-              @php
-                $loaddisttxt =  "Load Distribution ";
-                $loaddist = implode(' ', array_map(
-                            function ($v, $k) {
-                                if(is_array($v)){
-                                    return implode('&'.' '.':', $v);
-                                }else{
-                                    return $k.':'.$v;
-                                }
-                          },
-                          $loadarray,	array_keys($loadarray)
-                      ));
-              @endphp
-              <input type="hidden" name="manualrmk" value="{{ $loaddisttxt }}{{ $loaddist }}">
-            @endif
-            <input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
-            <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
-            <input type="hidden" id="steh" name="steh" maxlength="2">
-            <input type="hidden" id="stem" name="stem" maxlength="2">
-            <input type="hidden" id="date" name="date" maxlength="9">
-            <input type="hidden" id="deph" name="deph" maxlength="2">
-            <input type="hidden" id="depm" name="depm" maxlength="2">
-            <input type="hidden" name="selcal" value="BK-FS">
-            <input type="hidden" name="planformat" value="lido">
-            <input type="hidden" name="omit_sids" value="0">
-            <input type="hidden" name="omit_stars" value="0">
-            <input type="hidden" name="cruise" value="CI">
-            <input type="hidden" name="civalue" value="AUTO">
+              {{--
+              Here we generate the MANUALRMK which is sent to SimBrief and displayed in the generated
+              ofp as Dispatch Remarks. $loadarray is created and filled with data during random load
+              generation, it holds each fare's code and the generated load then we are imploding that
+              array to get the fare codes and load counts.
 
-            <div class="col-4">
-              <div class="form-container">
-                <div class="form-container-body">
-                  <h6><i class="fas fa-info-circle"></i>&nbsp;Planning Options</h6>
-                  <table class="table table-hover table-striped">
-                    <tr>
-                      <td>Cont Fuel:</td>
-                      <td>
-                        <select name="contpct" class="form-control">
-                          <option value="auto">AUTO</option>
-                          <option value="0">0 PCT</option>
-                          <option value="0.02">2 PCT</option>
-                          <option value="0.03">3 PCT</option>
-                          <option value="0.05" selected>5 PCT</option>
-                          <option value="0.1">10 PCT</option>
-                          <option value="0.15">15 PCT</option>
-                          <option value="0.2">20 PCT</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Reserve Fuel:</td>
-                      <td>
-                        <select name="resvrule" class="form-control">
-                          <option value="auto">AUTO</option>
-                          <option value="0">0 MIN</option>
-                          <option value="15">15 MIN</option>
-                          <option value="30" selected>30 MIN</option>
-                          <option value="45">45 MIN</option>
-                          <option value="60">60 MIN</option>
-                          <option value="75">75 MIN</option>
-                          <option value="90">90 MIN</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>SID/STAR Type:</td>
-                      <td>
-                        <select name="find_sidstar" class="form-control">
-                          <option value="C">Conventional</option>
-                          <option value="R" selected>RNAV</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Plan Stepclimbs:</td>
-                      <td>
-                        <select id="stepclimbs" name="stepclimbs" class="form-control" onchange="DisableFL()">
-                          <option value="0" selected>Disabled</option>
-                          <option value="1">Enabled</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>ETOPS Planning:</td>
-                      <td>
-                        <select name="etops" class="form-control">
-                          <option value="0" selected>Disabled</option>
-                          <option value="1">Enabled</option>
-                        </select>
-                      </td>
-                    </tr>
-                  </table>
-                </div>
-                <br>
-                <div class="form-container-body">
-                  <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('stisla.briefingoptions')</h6>
-                  <table class="table table-hover table-striped">
-                    <tr>
-                      <td>Units:</td>
-                      <td>
-                        <select id="kgslbs" name="units" class="form-control">
-                          @if(setting('units.weight') === 'kg')
-                            <option value="KGS" selected>KGS</option>
-                            <option value="LBS">LBS</option>
-                          @else
-                            <option value="KGS">KGS</option>
-                            <option value="LBS" selected>LBS</option>
-                          @endif
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Detailed Navlog:</td>
-                      <td>
-                        <select name="navlog" class="form-control">
-                          <option value="0">Disabled</option>
-                          <option value="1" selected>Enabled</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Runway Analysis:</td>
-                      <td>
-                        <select name="tlr" class="form-control">
-                          <option value="0">Disabled</option>
-                          <option value="1" selected>Enabled</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Include NOTAMS:</td>
-                      <td>
-                        <select name="notams" class="form-control">
-                          <option value="0">Disabled</option>
-                          <option value="1" selected>Enabled</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>FIR NOTAMS:</td>
-                      <td>
-                        <select name="firnot" class="form-control">
-                          <option value="0" selected>Disabled</option>
-                          <option value="1">Enabled</option>
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Flight Maps:</td>
-                      <td>
-                        <select name="maps" class="form-control">
-                          <option value="detail" selected>Detailed</option>
-                          <option value="simple">Simple</option>
-                          <option value="none">None</option>
-                        </select>
-                      </td>
-                    </tr>
-                  </table>
-                </div>
-                <br>
-                <div class="form-container-body">
-                  <div class="float-right">
-                    <div class="form-group">
-                      <input type="button"
-                             onclick="simbriefsubmit('{{ $flight->id }}', '{{ url(route('frontend.simbrief.briefing', [''])) }}');"
-                             class="btn btn-primary" value="Generate">
+              Returned string will be like Load Distribution Y 132 C 12 F 4
+              --}}
+              @if($totalgenload > 0)
+                @php
+                  $loaddisttxt =  "Load Distribution ";
+                  $loaddist = implode(' ', array_map(
+                              function ($v, $k) {
+                                  if(is_array($v)){
+                                      return implode('&'.' '.':', $v);
+                                  }else{
+                                      return $k.':'.$v;
+                                  }
+                            },
+                            $loadarray,	array_keys($loadarray)
+                        ));
+                @endphp
+                <input type="hidden" name="manualrmk" value="{{ $loaddisttxt }}{{ $loaddist }}">
+              @endif
+              <input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
+              <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
+              <input type="hidden" id="steh" name="steh" maxlength="2">
+              <input type="hidden" id="stem" name="stem" maxlength="2">
+              <input type="hidden" id="date" name="date" maxlength="9">
+              <input type="hidden" id="deph" name="deph" maxlength="2">
+              <input type="hidden" id="depm" name="depm" maxlength="2">
+              <input type="hidden" name="selcal" value="BK-FS">
+              <input type="hidden" name="planformat" value="lido">
+              <input type="hidden" name="omit_sids" value="0">
+              <input type="hidden" name="omit_stars" value="0">
+              <input type="hidden" name="cruise" value="CI">
+              <input type="hidden" name="civalue" value="AUTO">
+
+              <div class="col-4">
+                <div class="form-container">
+                  <div class="form-container-body">
+                    <h6><i class="fas fa-info-circle"></i>&nbsp;Planning Options</h6>
+                    <table class="table table-hover table-striped">
+                      <tr>
+                        <td>Cont Fuel:</td>
+                        <td>
+                          <select name="contpct" class="form-control">
+                            <option value="auto">AUTO</option>
+                            <option value="0">0 PCT</option>
+                            <option value="0.02">2 PCT</option>
+                            <option value="0.03">3 PCT</option>
+                            <option value="0.05" selected>5 PCT</option>
+                            <option value="0.1">10 PCT</option>
+                            <option value="0.15">15 PCT</option>
+                            <option value="0.2">20 PCT</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Reserve Fuel:</td>
+                        <td>
+                          <select name="resvrule" class="form-control">
+                            <option value="auto">AUTO</option>
+                            <option value="0">0 MIN</option>
+                            <option value="15">15 MIN</option>
+                            <option value="30" selected>30 MIN</option>
+                            <option value="45">45 MIN</option>
+                            <option value="60">60 MIN</option>
+                            <option value="75">75 MIN</option>
+                            <option value="90">90 MIN</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>SID/STAR Type:</td>
+                        <td>
+                          <select name="find_sidstar" class="form-control">
+                            <option value="C">Conventional</option>
+                            <option value="R" selected>RNAV</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Plan Stepclimbs:</td>
+                        <td>
+                          <select id="stepclimbs" name="stepclimbs" class="form-control" onchange="DisableFL()">
+                            <option value="0" selected>Disabled</option>
+                            <option value="1">Enabled</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>ETOPS Planning:</td>
+                        <td>
+                          <select name="etops" class="form-control">
+                            <option value="0" selected>Disabled</option>
+                            <option value="1">Enabled</option>
+                          </select>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                  <br>
+                  <div class="form-container-body">
+                    <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('stisla.briefingoptions')</h6>
+                    <table class="table table-hover table-striped">
+                      <tr>
+                        <td>Units:</td>
+                        <td>
+                          <select id="kgslbs" name="units" class="form-control">
+                            @if(setting('units.weight') === 'kg')
+                              <option value="KGS" selected>KGS</option>
+                              <option value="LBS">LBS</option>
+                            @else
+                              <option value="KGS">KGS</option>
+                              <option value="LBS" selected>LBS</option>
+                            @endif
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Detailed Navlog:</td>
+                        <td>
+                          <select name="navlog" class="form-control">
+                            <option value="0">Disabled</option>
+                            <option value="1" selected>Enabled</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Runway Analysis:</td>
+                        <td>
+                          <select name="tlr" class="form-control">
+                            <option value="0">Disabled</option>
+                            <option value="1" selected>Enabled</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Include NOTAMS:</td>
+                        <td>
+                          <select name="notams" class="form-control">
+                            <option value="0">Disabled</option>
+                            <option value="1" selected>Enabled</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>FIR NOTAMS:</td>
+                        <td>
+                          <select name="firnot" class="form-control">
+                            <option value="0" selected>Disabled</option>
+                            <option value="1">Enabled</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Flight Maps:</td>
+                        <td>
+                          <select name="maps" class="form-control">
+                            <option value="detail" selected>Detailed</option>
+                            <option value="simple">Simple</option>
+                            <option value="none">None</option>
+                          </select>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                  <br>
+                  <div class="form-container-body">
+                    <div class="float-right">
+                      <div class="form-group">
+                        <input type="button"
+                               onclick="simbriefsubmit('{{ $flight->id }}', '{{ url(route('frontend.simbrief.briefing', [''])) }}');"
+                               class="btn btn-primary" value="Generate">
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -359,9 +369,8 @@
           </div>
         </div>
       </div>
-    </div>
-  </form>
-@endif
+    </form>
+  @endif
 @endsection
 @section('scripts')
   <script src="{{public_asset('/assets/global/js/simbrief.apiv1.js')}}"></script>
@@ -424,18 +433,19 @@
     document.getElementById("stem").setAttribute('value', rminutes.toString()); // Sent to Simbrief
   </script>
   <script type="text/javascript">
-		// *** Simple Aircraft Selection With Dropdown Change
-		// *** Also keep Generate button hidden until a valid AC selection
-		const $oldlink = document.getElementById("mylink").href ;
-		function checkacselection() {
-			if (document.getElementById("aircraftselection").value == "ZZZZZ") {
-					document.getElementById('mylink').style.visibility = 'hidden';
-				}else{
-					document.getElementById('mylink').style.visibility = 'visible';
-				}
-			var $selectedac = document.getElementById("aircraftselection").value ;
-			var $newlink = "&aircraft_id=".concat($selectedac) ;
-			document.getElementById("mylink").href = $oldlink.concat($newlink) ;	
-		}
-	</script>
+    // *** Simple Aircraft Selection With Dropdown Change
+    // *** Also keep Generate button hidden until a valid AC selection
+    const $oldlink = document.getElementById("mylink").href;
+
+    function checkacselection() {
+      if (document.getElementById("aircraftselection").value === "ZZZZZ") {
+        document.getElementById('mylink').style.visibility = 'hidden';
+      } else {
+        document.getElementById('mylink').style.visibility = 'visible';
+      }
+      var $selectedac = document.getElementById("aircraftselection").value;
+      var $newlink = "&aircraft_id=".concat($selectedac);
+      document.getElementById("mylink").href = $oldlink.concat($newlink);
+    }
+  </script>
 @endsection

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -38,11 +38,11 @@
     @php
       $simbrieftype = $acdetails->icao ;
       $subflid = $acdetails->subfleet_id ;
-      if($acdetails->icao == 'A20N') { $simbrieftype = 'A320' ; }
-      if($acdetails->icao == 'A21N') { $simbrieftype = 'A321' ; }
-      if($acdetails->icao == 'B77L') { $simbrieftype = 'B77F' ; }
-      if($acdetails->icao == 'B773') { $simbrieftype = 'B77W' ; }
-      if($acdetails->icao == 'E35L') { $simbrieftype = 'E135' ; }
+      if($acdetails->icao === 'A20N') { $simbrieftype = 'A320' ; }
+      if($acdetails->icao === 'A21N') { $simbrieftype = 'A321' ; }
+      if($acdetails->icao === 'B77L') { $simbrieftype = 'B77F' ; }
+      if($acdetails->icao === 'B773') { $simbrieftype = 'B77W' ; }
+      if($acdetails->icao === 'E35L') { $simbrieftype = 'E135' ; }
     @endphp
   @endforeach
 
@@ -131,6 +131,7 @@
                         <b>{{ $subfleet->name }} ; {{ $acdetails->registration }}</b></h6>
                       {{-- Generate Load Figures --}}
                       <div class="row">
+                      {{-- Create and send some data to the $loadarray for MANUALRMK generation --}}
                         @php $loadarray = [] ; @endphp
                         @foreach($subfleet->fares as $fare)
                           @if($fare->capacity > 0)
@@ -179,6 +180,10 @@
                 </div>
               </div>
             </div>
+            {{-- Here we generate the MANUALRMK which is sent to SimBrief and displayed in the generated ofp as Dispatch Remarks. --}}
+            {{-- $loadarray is created and filled with data during random load generation, it holds each fare's code and the generated load --}}
+            {{-- then we are imploding that array to get the fare codes and load counts --}}
+            {{-- Returned string will be like Load Distribution Y 132 C 12 F 4 --}}
             @if($totalgenload > 0)
               @php
                 $loaddisttxt =  "Load Distribution ";


### PR DESCRIPTION
Replaces outdated old pr.

Same improvements apply to both SimBrief Controller and flights / simbrief_form.blade

### 

- Uses the aircraft_id to get all necessary details to calculate random load according to load factor and variances. (Min and Max protections applied, load factor will never go above 100 and below 1)
- All possible values are sent to simbrief for more precise and customized flight plan generation
- Gets current utc time and adds 45mins to it for ETD and Date generation
- Different pax weights are used for Charter and Scheduled flights (also sent to SimBrief)
- Calculated random load figures are sent to SimBrief OFP as Dispatch Remark too
- Automatic SID/STAR type selection added to planning options (RNAV or Conventional)
- Step Climb logic applied (as per SimBrief documentation, if Step Climbs are enabled no flight level info is needed)
- Gets user weight settings (KG/LBS) and uses it on both calculations and SimBrief Briefing Options section