### PR TITLE
Update FlightService.php

### DIFF
--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -137,6 +137,13 @@ class FlightService extends Service
     {
         /** @var \Illuminate\Support\Collection $subfleets */
         $subfleets = $flight->subfleets;
+
+        // If no subfleets assigned to a flight get users allowed subfleets
+        if ($subfleets === null || $subfleets->count() === 0) {
+            $subfleets = $this->userSvc->getAllowableSubfleets($user);
+        }
+
+        // If subfleets are still empty return the flight
         if ($subfleets === null || $subfleets->count() === 0) {
             return $flight;
         }


### PR DESCRIPTION
If no subfleets are assigned to a flight, vmsacars was not allowing the flight to be loaded and used 'cause the subfleets was returning null. With this pr, users will be able to use the aircrafts which they have access to by their ranks. ( Same logic was used in SimBrief Controller to populate the aircraft list for flight plan generation )