### PR TITLE
Fix For Acars Config Download Button Not Working Bug #919

### DIFF
--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -52,7 +52,7 @@ class ProfileController extends Controller
     {
         // Is the ACARS module enabled?
         $acars_enabled = false;
-        $acars = Module::find('VMSACARS');
+        $acars = Module::find('VMSAcars');
         if ($acars) {
             $acars_enabled = $acars->isEnabled();
         }
@@ -95,6 +95,7 @@ class ProfileController extends Controller
             'user'       => $user,
             'userFields' => $userFields,
             'airports'   => $airports,
+            'acars'      => $this->acarsEnabled(),
         ]);
     }
 

--- a/resources/views/layouts/default/profile/index.blade.php
+++ b/resources/views/layouts/default/profile/index.blade.php
@@ -133,11 +133,11 @@
         <div class="text-right">
           @if (isset($acars) && $acars === true)
           <a href="{{ route('frontend.profile.acars') }}" class="btn btn-primary"
-             onclick="alert('Save to \'My Documents/phpVMS\'')">ACARS Config</a>
+             onclick="alert('Copy or Save to \'My Documents/phpVMS\'')">ACARS Config</a>
           &nbsp;
           @endif
           <a href="{{ route('frontend.profile.regen_apikey') }}" class="btn btn-warning"
-             onclick="return confirm({{ __('Are you sure? This will reset your API key.') }})">@lang('profile.newapikey')</a>
+             onclick="return confirm('Are you sure ? This will reset your API key !')">@lang('profile.newapikey')</a>
           &nbsp;
           <a href="{{ route('frontend.profile.edit', [$user->id]) }}"
              class="btn btn-primary">@lang('common.edit')</a>

--- a/resources/views/layouts/default/profile/index.blade.php
+++ b/resources/views/layouts/default/profile/index.blade.php
@@ -137,7 +137,7 @@
           &nbsp;
           @endif
           <a href="{{ route('frontend.profile.regen_apikey') }}" class="btn btn-warning"
-             onclick="return confirm('Are you sure ? This will reset your API key !')">@lang('profile.newapikey')</a>
+             onclick="return confirm('Are you sure? This will reset your API key!')">@lang('profile.newapikey')</a>
           &nbsp;
           <a href="{{ route('frontend.profile.edit', [$user->id]) }}"
              class="btn btn-primary">@lang('common.edit')</a>


### PR DESCRIPTION
PR fixes the Acars Config Download button not showing up at user profile bug #919 

Also fixes the problem where Generate New Api Key button not following user selections and generating a new key even if user clicks cancel.

![acars_button](https://user-images.githubusercontent.com/74361521/105763804-3d523500-5f67-11eb-8d36-0538ab64c309.png)
