### PR TITLE
Fix PilotHoursAwards

### DIFF
--- a/modules/Awards/Awards/PilotHoursAwards.php
+++ b/modules/Awards/Awards/PilotHoursAwards.php
@@ -42,7 +42,7 @@ class PilotHoursAwards extends Award
      */
     public function check($flight_minutes = null): bool
     {
-        if (!is_int($flight_minutes)) {
+        if (!is_numeric($flight_minutes)) {
             Log::error('PilotHourAwards: Flight time "'.$flight_minutes.'" is not a valid flight time');
             return false;
         }


### PR DESCRIPTION
!is_int was causing the check always return false even when user enters a proper value like 6000 or 30000 in admin/award settings.

We should use !is_numeric instead to see if it is a valid numeric value.