### PR TITLE
Failsafe for SimBrief random pax generation

### DIFF
--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -109,6 +109,9 @@ class SimBriefController
 
         $loadmax = $lfactor + $lfactorv;
         $loadmax = $loadmax > 100 ? 100 : $loadmax;
+        // Failsafe for admins not defining load values for their flights
+        // and also leave the general settings empty, set loadmax to 100
+        if ($loadmax === 0) { $loadmax = 100; }
 
         // Show the main simbrief form
         return view('flights.simbrief_form', [

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -111,7 +111,9 @@ class SimBriefController
         $loadmax = $loadmax > 100 ? 100 : $loadmax;
         // Failsafe for admins not defining load values for their flights
         // and also leave the general settings empty, set loadmax to 100
-        if ($loadmax === 0) { $loadmax = 100; }
+        if ($loadmax === 0) {
+            $loadmax = 100;
+        }
 
         // Show the main simbrief form
         return view('flights.simbrief_form', [


### PR DESCRIPTION
PR fixes the problem for 0 load generation where va admins do not set load factor and variance values for their flights and also leave the general settings empty. In such cases, both loadmin and loadmax was returning 0 , resulting zero load.

Thanks @macofallico for figuring this out.