### PR TITLE
New Config Option For Weather Widget

### DIFF
--- a/app/Widgets/Weather.php
+++ b/app/Widgets/Weather.php
@@ -11,7 +11,8 @@ use App\Services\AirportService;
 class Weather extends Widget
 {
     protected $config = [
-        'icao' => null,
+        'icao'     => null,
+        'raw_only' => false,
     ];
 
     /**


### PR DESCRIPTION
Added **raw_only** to the config options for being able to display full decoded weather or just raw metar/taf or both (depends on the blade design)