### PR TITLE
Fix pilot leave calculation #1022

### DIFF
--- a/app/Cron/Nightly/PilotLeave.php
+++ b/app/Cron/Nightly/PilotLeave.php
@@ -4,10 +4,7 @@ namespace App\Cron\Nightly;
 
 use App\Contracts\Listener;
 use App\Events\CronNightly;
-use App\Models\Enums\UserState;
-use App\Models\User;
 use App\Services\UserService;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 
 /**

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -109,6 +109,7 @@ class SimBriefController
 
         $loadmax = $lfactor + $lfactorv;
         $loadmax = $loadmax > 100 ? 100 : $loadmax;
+
         // Failsafe for admins not defining load values for their flights
         // and also leave the general settings empty, set loadmax to 100
         if ($loadmax === 0) {

--- a/app/Models/PirepFare.php
+++ b/app/Models/PirepFare.php
@@ -4,6 +4,14 @@ namespace App\Models;
 
 use App\Contracts\Model;
 
+/**
+ * @property int    id
+ * @property string pirep_id
+ * @property int    fare_id
+ * @property int    count
+ * @property Pirep  pirep
+ * @property Fare   fare
+ */
 class PirepFare extends Model
 {
     public $table = 'pirep_fares';

--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -286,9 +286,7 @@ class FareService extends Service
      */
     public function getForPirep(Pirep $pirep)
     {
-        $found_fares = PirepFare::where('pirep_id', $pirep->id)->get();
-
-        return $found_fares;
+        return PirepFare::where('pirep_id', $pirep->id)->get();
     }
 
     /**
@@ -312,6 +310,8 @@ class FareService extends Service
         foreach ($fares as $fare) {
             $fare['pirep_id'] = $pirep->id;
             // other fields: ['fare_id', 'count']
+
+            Log::info('Saving fare pirep='.$pirep->id.', fare='.$fare['count']);
 
             $field = new PirepFare($fare);
             $field->save();

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -3,7 +3,9 @@
 namespace Tests;
 
 use App\Models\Aircraft;
+use App\Models\Enums\UserState;
 use App\Models\Flight;
+use App\Models\Pirep;
 use App\Models\Subfleet;
 use App\Models\User;
 use Exception;
@@ -21,34 +23,37 @@ trait TestData
     {
         $subfleet = $this->createSubfleetWithAircraft(1);
         $rank = $this->createRank(2, [$subfleet['subfleet']->id]);
-        $user = factory(User::class)->create(array_merge([
+
+        return factory(User::class)->create(array_merge([
             'flight_time' => 1000,
             'rank_id'     => $rank->id,
+            'state'       => UserState::ACTIVE,
         ], $attrs));
-
-        return $user;
     }
 
     /**
      * Create a new PIREP with a proper subfleet/rank/user and an
      * aircraft that the user is allowed to fly
      *
+     * @param array $user_attrs  Additional attributes for the user
+     * @param array $pirep_attrs Additional attributes for the PIREP
+     *
+     * @throws \Exception
+     *
      * @return \App\Models\Pirep
      */
-    protected function createPirep()
+    protected function createPirep(array $user_attrs = [], array $pirep_attrs = [])
     {
         $subfleet = $this->createSubfleetWithAircraft(2);
         $rank = $this->createRank(10, [$subfleet['subfleet']->id]);
-        $this->user = factory(\App\Models\User::class)->create([
+        $this->user = factory(\App\Models\User::class)->create(array_merge([
             'rank_id' => $rank->id,
-        ]);
+        ], $user_attrs));
 
         // Return a Pirep model
-        $pirep = factory(\App\Models\Pirep::class)->make([
+        return factory(Pirep::class)->make(array_merge([
             'aircraft_id' => $subfleet['aircraft']->random()->id,
-        ]);
-
-        return $pirep;
+        ], $pirep_attrs));
     }
 
     /**


### PR DESCRIPTION
Changed user leave so it uses the last PIREP ID or the created date/time of the user. Added tests.

Closes #1022