### PR TITLE
Advanced Fuel Calculations

### DIFF
--- a/app/Database/migrations/2021_02_23_150601_aircraft_add_fuelonboard.php
+++ b/app/Database/migrations/2021_02_23_150601_aircraft_add_fuelonboard.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a `fuel_onboard` column for recording what is left in tanks
+ */
+class AircraftAddFuelonboard extends Migration
+{
+    public function up()
+    {
+        Schema::table('aircraft', function (Blueprint $table) {
+            $table->unsignedDecimal('fuel_onboard')
+                ->nullable()
+                ->default(0.0)
+                ->after('zfw');
+        });
+    }
+}

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -305,3 +305,11 @@
   options: ''
   type: 'text'
   description: 'Discord public channel ID for broadcasat notifications'
+- key: pireps.advanced_fuel
+  name: 'Advanced Fuel Calculations'
+  group: pireps
+  value: false
+  options: ''
+  type: boolean
+  description: 'Enables remaining fuel amounts to be considered for fuel expenses'
+  

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -228,7 +228,7 @@
   options: ''
   type: boolean
   description: 'When a PIREP is accepted, remove the bid, if it exists'
-  - key: pireps.advanced_fuel
+- key: pireps.advanced_fuel
   name: 'Advanced Fuel Calculations'
   group: pireps
   value: false

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -228,6 +228,13 @@
   options: ''
   type: boolean
   description: 'When a PIREP is accepted, remove the bid, if it exists'
+  - key: pireps.advanced_fuel
+  name: 'Advanced Fuel Calculations'
+  group: pireps
+  value: false
+  options: ''
+  type: boolean
+  description: 'Enables remaining fuel amounts to be considered for fuel expenses'
 - key: pilots.id_length
   name: 'Pilot ID Length'
   group: pilots
@@ -305,11 +312,5 @@
   options: ''
   type: 'text'
   description: 'Discord public channel ID for broadcasat notifications'
-- key: pireps.advanced_fuel
-  name: 'Advanced Fuel Calculations'
-  group: pireps
-  value: false
-  options: ''
-  type: boolean
-  description: 'Enables remaining fuel amounts to be considered for fuel expenses'
+
   

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -312,5 +312,4 @@
   options: ''
   type: 'text'
   description: 'Discord public channel ID for broadcasat notifications'
-
   

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -152,12 +152,12 @@ class PirepFinanceService extends Service
     public function payFuelCosts(Pirep $pirep): void
     {
         $ap = $pirep->dpt_airport;
-        if (setting('pirep.advanced_fuel', true)) {
+        if (setting('pirep.advanced_fuel', false)) {
             $ac = $pirep->aircraft;
             // Reading second row by skip(1) to reach the previous accepted pirep. Current pirep is at the first row
             $prev_flight = Pirep::where('aircraft_id', $ac->id)->where('state', 2)->where('status', 'ONB')->orderby('submitted_at', 'desc')->skip(1)->first();
             if ($prev_flight) {
-                // If there is a pirep use its value to calculate the remaining fuel
+                // If there is a pirep use its values to calculate the remaining fuel
                 // and calculate the uplifted fuel amount for this pirep
                 $fuel_amount = $pirep->block_fuel - ($prev_flight->block_fuel - $prev_flight->fuel_used);
                 // Aircraft has more than enough fuel in its tanks, no uplift necessary

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -152,10 +152,27 @@ class PirepFinanceService extends Service
     public function payFuelCosts(Pirep $pirep): void
     {
         $ap = $pirep->dpt_airport;
-        $fuel_used = $pirep->fuel_used;
+        if (setting('pirep.advanced_fuel', true)) {
+          $ac = $pirep->aircraft;
+          // Reading second row by skip(1) to reach the previous accepted pirep. Current pirep is at the first row
+          $prev_flight = Pirep::where('aircraft_id', $ac->id)->where('state', 2)->where('status', 'ONB')->orderby('submitted_at', 'desc')->skip(1)->first();
+          if ($prev_flight) {
+            // If there is a pirep use its value to calculate the remaining fuel
+            // and calculate the uplifted fuel amount for this pirep
+            $fuel_amount = $pirep->block_fuel - ($prev_flight->block_fuel - $prev_flight->fuel_used);
+            // Aircraft has more than enough fuel in its tanks, no uplift necessary
+            if ($fuel_amount < 0) { $fuel_amount = 0; }
+          } else {
+            // No pirep found for aircraft, debit full block fuel
+            $fuel_amount = $pirep->block_fuel;
+          }
+        } else {
+          // Setting is false, switch back to basic calculation
+          $fuel_amount = $pirep->fuel_used;
+        }
 
-        $debit = Money::createFromAmount($fuel_used * $ap->fuel_jeta_cost);
-        Log::info('Finance: Fuel cost, (fuel='.$fuel_used.', cost='.$ap->fuel_jeta_cost.') D='
+        $debit = Money::createFromAmount($fuel_amount * $ap->fuel_jeta_cost);
+        Log::info('Finance: Fuel cost, (fuel='.$fuel_amount.', cost='.$ap->fuel_jeta_cost.') D='
             .$debit->getAmount());
 
         $this->financeSvc->debitFromJournal(

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -153,21 +153,21 @@ class PirepFinanceService extends Service
     {
         $ap = $pirep->dpt_airport;
         if (setting('pirep.advanced_fuel', true)) {
-          $ac = $pirep->aircraft;
-          // Reading second row by skip(1) to reach the previous accepted pirep. Current pirep is at the first row
-          $prev_flight = Pirep::where('aircraft_id', $ac->id)->where('state', 2)->where('status', 'ONB')->orderby('submitted_at', 'desc')->skip(1)->first();
-          if ($prev_flight) {
-              // If there is a pirep use its value to calculate the remaining fuel
-              // and calculate the uplifted fuel amount for this pirep
-              $fuel_amount = $pirep->block_fuel - ($prev_flight->block_fuel - $prev_flight->fuel_used);
-              // Aircraft has more than enough fuel in its tanks, no uplift necessary
-              if ($fuel_amount < 0) {
-                  $fuel_amount = 0;
-              }
-          } else {
-              // No pirep found for aircraft, debit full block fuel
-              $fuel_amount = $pirep->block_fuel;
-          }
+            $ac = $pirep->aircraft;
+            // Reading second row by skip(1) to reach the previous accepted pirep. Current pirep is at the first row
+            $prev_flight = Pirep::where('aircraft_id', $ac->id)->where('state', 2)->where('status', 'ONB')->orderby('submitted_at', 'desc')->skip(1)->first();
+            if ($prev_flight) {
+                // If there is a pirep use its value to calculate the remaining fuel
+                // and calculate the uplifted fuel amount for this pirep
+                $fuel_amount = $pirep->block_fuel - ($prev_flight->block_fuel - $prev_flight->fuel_used);
+                // Aircraft has more than enough fuel in its tanks, no uplift necessary
+                if ($fuel_amount < 0) {
+                    $fuel_amount = 0;
+                }
+            } else {
+                // No pirep found for aircraft, debit full block fuel
+                $fuel_amount = $pirep->block_fuel;
+            }
         } else {
             // Setting is false, switch back to basic calculation
             $fuel_amount = $pirep->fuel_used;

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -157,18 +157,20 @@ class PirepFinanceService extends Service
           // Reading second row by skip(1) to reach the previous accepted pirep. Current pirep is at the first row
           $prev_flight = Pirep::where('aircraft_id', $ac->id)->where('state', 2)->where('status', 'ONB')->orderby('submitted_at', 'desc')->skip(1)->first();
           if ($prev_flight) {
-            // If there is a pirep use its value to calculate the remaining fuel
-            // and calculate the uplifted fuel amount for this pirep
-            $fuel_amount = $pirep->block_fuel - ($prev_flight->block_fuel - $prev_flight->fuel_used);
-            // Aircraft has more than enough fuel in its tanks, no uplift necessary
-            if ($fuel_amount < 0) { $fuel_amount = 0; }
+              // If there is a pirep use its value to calculate the remaining fuel
+              // and calculate the uplifted fuel amount for this pirep
+              $fuel_amount = $pirep->block_fuel - ($prev_flight->block_fuel - $prev_flight->fuel_used);
+              // Aircraft has more than enough fuel in its tanks, no uplift necessary
+              if ($fuel_amount < 0) {
+                  $fuel_amount = 0;
+              }
           } else {
-            // No pirep found for aircraft, debit full block fuel
-            $fuel_amount = $pirep->block_fuel;
+              // No pirep found for aircraft, debit full block fuel
+              $fuel_amount = $pirep->block_fuel;
           }
         } else {
-          // Setting is false, switch back to basic calculation
-          $fuel_amount = $pirep->fuel_used;
+            // Setting is false, switch back to basic calculation
+            $fuel_amount = $pirep->fuel_used;
         }
 
         $debit = Money::createFromAmount($fuel_amount * $ap->fuel_jeta_cost);

--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -539,6 +539,7 @@ class PirepService extends Service
         $pirep->aircraft->flight_time = $pirep->aircraft->flight_time + $pirep->flight_time;
         $pirep->aircraft->airport_id = $pirep->arr_airport_id;
         $pirep->aircraft->landing_time = $pirep->updated_at;
+        $pirep->aircraft->fuel_onboard = $pirep->block_fuel - $pirep->fuel_used;
         $pirep->aircraft->save();
 
         $pirep->refresh();


### PR DESCRIPTION
PR aims to have realistic fuel debit calculations as in the real ops. When enabled, remaining fuel amounts from previous flight will be reduced from block fuel and airline will only pay for uplifted fuel amount.

If onboard fuel is enough for the flight or exceeds the required amount no fuel debit will be issued.

If this is the first flight of the aircraft or the tanks are dry, full block fuel will be treated as uplifted.

Disabled / uses current default (fuel_used will be debited)

Aircraft table also will hold the fuel_onboard value (not needed for calculations, just saving for displaying purposes)