### PR TITLE
SimBrief Integration Update

### DIFF
--- a/app/Database/migrations/2021_02_23_205630_add_sbtype_to_subfleets.php
+++ b/app/Database/migrations/2021_02_23_205630_add_sbtype_to_subfleets.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a SimBrief Type to subfleet
+ */
+class AddSbtypeToSubfleets extends Migration
+{
+    public function up()
+    {
+        Schema::table('subfleets', function (Blueprint $table) {
+            $table->string('simbrief_type', 20)
+                ->nullable()
+                ->after('type');
+        });
+    }
+}

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -200,6 +200,41 @@
   options: ''
   type: number
   description: 'Days after how long to remove unused briefs'
+- key: simbrief.noncharter_pax_weight
+  name: 'SimBrief Passenger Weight for Non-Charter (Scheduled etc) Flights'
+  group: simbrief
+  value: 185
+  options: ''
+  type: number
+  description: 'Passenger weight for Non-Charter flights excluding baggage (lbs)'
+- key: simbrief.noncharter_baggage_weight
+  name: 'SimBrief Baggage Weight per Pax for Non-Charter (Scheduled etc) Flights'
+  group: simbrief
+  value: 35
+  options: ''
+  type: number
+  description: 'Passenger baggage weight for Non-Charter flights (lbs)'
+- key: simbrief.charter_pax_weight
+  name: 'SimBrief Passenger Weight for Charter Flights'
+  group: simbrief
+  value: 168
+  options: ''
+  type: number
+  description: 'Passenger weight for Charter flights excluding baggage (lbs)'
+- key: simbrief.charter_baggage_weight
+  name: 'SimBrief Baggage Weight per Pax for Charter Flights'
+  group: simbrief
+  value: 28
+  options: ''
+  type: number
+  description: 'Passenger baggage weight for Charter flights (lbs)'
+- key: simbrief.callsign
+  name: 'SimBrief ATC Callsign'
+  group: simbrief
+  value: false
+  options: ''
+  type: boolean
+  description: 'Use pilot ident as SimBrief ATC Callsign'
 - key: pireps.duplicate_check_time
   name: 'PIREP duplicate time check'
   group: pireps

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -73,10 +73,8 @@ class SimBriefController
             return redirect(route('frontend.simbrief.briefing', [$simbrief->id]));
         }
 
-        // Simbrief Profile doesn't exist; prompt the user to create a new one
-        $aircraft = Aircraft::select('registration', 'name', 'icao', 'iata', 'subfleet_id')
-            ->where('id', $aircraft_id)
-            ->get();
+        // Select aircraft which will be used for calculations and details
+        $aircraft = Aircraft::where('id', $aircraft_id)->first();
 
         if ($flight->subfleets->count() > 0) {
             $subfleets = $flight->subfleets;
@@ -85,9 +83,11 @@ class SimBriefController
         }
 
         if ($flight->flight_type === FlightType::CHARTER_PAX_ONLY) {
-            $pax_weight = 197;
+            $pax_weight = setting('simbrief.charter_pax_weight') ?? 168;
+            $bag_weight = setting('simbrief.charter_baggage_weight') ?? 28; 
         } else {
-            $pax_weight = 208;
+            $pax_weight = setting('simbrief.noncharter_pax_weight') ?? 185;
+            $bag_weight = setting('simbrief.noncharter_baggage_weight') ?? 35;
         }
 
         // No aircraft selected, show that form
@@ -122,6 +122,7 @@ class SimBriefController
             'aircraft'   => $aircraft,
             'subfleets'  => $subfleets,
             'pax_weight' => $pax_weight,
+            'bag_weight' => $bag_weight,
             'loadmin'    => $loadmin,
             'loadmax'    => $loadmax,
         ]);

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -73,8 +73,8 @@ class SimBriefController
         // No aircraft selected, show selection form
         if (!$aircraft_id) {
             return view('flights.simbrief_aircraft', [
-                'flight'     => $flight,
-                'subfleets'  => $subfleets,
+                'flight'    => $flight,
+                'subfleets' => $subfleets,
             ]);
         }
 

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -84,7 +84,7 @@ class SimBriefController
 
         if ($flight->flight_type === FlightType::CHARTER_PAX_ONLY) {
             $pax_weight = setting('simbrief.charter_pax_weight') ?? 168;
-            $bag_weight = setting('simbrief.charter_baggage_weight') ?? 28; 
+            $bag_weight = setting('simbrief.charter_baggage_weight') ?? 28;
         } else {
             $pax_weight = setting('simbrief.noncharter_pax_weight') ?? 185;
             $bag_weight = setting('simbrief.noncharter_baggage_weight') ?? 35;

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -50,7 +50,7 @@ class SimBriefController
         $flight_id = $request->input('flight_id');
         $aircraft_id = $request->input('aircraft_id');
         $flight = $this->flightRepo->with(['subfleets'])->find($flight_id);
-        $flight = $this->fareSvc->getReconciledFaresForFlight($flight);
+        // $flight = $this->fareSvc->getReconciledFaresForFlight($flight);
 
         if (!$flight) {
             flash()->error('Unknown flight');

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -63,6 +63,21 @@ class SimBriefController
             return redirect(route('frontend.flights.index'));
         }
 
+        // If no subfleets defined for flight get them from user
+        if ($flight->subfleets->count() > 0) {
+            $subfleets = $flight->subfleets;
+        } else {
+            $subfleets = $this->userSvc->getAllowableSubfleets($user);
+        }
+
+        // No aircraft selected, show selection form
+        if (!$aircraft_id) {
+            return view('flights.simbrief_aircraft', [
+                'flight'     => $flight,
+                'subfleets'  => $subfleets,
+            ]);
+        }
+
         // Check if a Simbrief profile already exists
         $simbrief = SimBrief::select('id')->where([
             'flight_id' => $flight_id,
@@ -73,34 +88,20 @@ class SimBriefController
             return redirect(route('frontend.simbrief.briefing', [$simbrief->id]));
         }
 
+        // SimBrief profile does not exists and everything else is ok
         // Select aircraft which will be used for calculations and details
         $aircraft = Aircraft::where('id', $aircraft_id)->first();
 
-        if ($flight->subfleets->count() > 0) {
-            $subfleets = $flight->subfleets;
-        } else {
-            $subfleets = $this->userSvc->getAllowableSubfleets($user);
-        }
-
+        // Get passenger and baggage weights with failsafe defaults
         if ($flight->flight_type === FlightType::CHARTER_PAX_ONLY) {
-            $pax_weight = setting('simbrief.charter_pax_weight') ?? 168;
-            $bag_weight = setting('simbrief.charter_baggage_weight') ?? 28;
+            $pax_weight = setting('simbrief.charter_pax_weight', 168);
+            $bag_weight = setting('simbrief.charter_baggage_weight', 28);
         } else {
-            $pax_weight = setting('simbrief.noncharter_pax_weight') ?? 185;
-            $bag_weight = setting('simbrief.noncharter_baggage_weight') ?? 35;
+            $pax_weight = setting('simbrief.noncharter_pax_weight', 185);
+            $bag_weight = setting('simbrief.noncharter_baggage_weight', 35);
         }
 
-        // No aircraft selected, show that form
-        if (!$aircraft_id) {
-            return view('flights.simbrief_aircraft', [
-                'flight'     => $flight,
-                'aircraft'   => $aircraft,
-                'subfleets'  => $subfleets,
-                'pax_weight' => $pax_weight,
-            ]);
-        }
-
-        // Get the correct load factors
+        // Get the load factors with failsafe for loadmax if nothing is defined
         $lfactor = $flight->load_factor ?? setting('flights.default_load_factor');
         $lfactorv = $flight->load_factor_variance ?? setting('flights.load_factor_variance');
 
@@ -110,8 +111,6 @@ class SimBriefController
         $loadmax = $lfactor + $lfactorv;
         $loadmax = $loadmax > 100 ? 100 : $loadmax;
 
-        // Failsafe for admins not defining load values for their flights
-        // and also leave the general settings empty, set loadmax to 100
         if ($loadmax === 0) {
             $loadmax = 100;
         }
@@ -120,7 +119,6 @@ class SimBriefController
         return view('flights.simbrief_form', [
             'flight'     => $flight,
             'aircraft'   => $aircraft,
-            'subfleets'  => $subfleets,
             'pax_weight' => $pax_weight,
             'bag_weight' => $bag_weight,
             'loadmin'    => $loadmin,

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -10,6 +10,7 @@ use App\Models\Traits\FilesTrait;
 /**
  * @property int     id
  * @property string  type
+ * @property string  simbrief_type
  * @property string  name
  * @property int     airline_id
  * @property int     hub_id
@@ -29,6 +30,7 @@ class Subfleet extends Model
         'airline_id',
         'hub_id',
         'type',
+        'simbrief_type',
         'name',
         'fuel_type',
         'cost_block_hour',

--- a/resources/views/admin/subfleets/fields.blade.php
+++ b/resources/views/admin/subfleets/fields.blade.php
@@ -24,13 +24,19 @@
         <p class="text-danger">{{ $errors->first('hub_id') }}</p>
       </div>
 
-      <div class="form-group col-sm-3">
+      <div class="form-group col-sm-2">
         {{ Form::label('type', 'Type:') }}
         {{ Form::text('type', null, ['class' => 'form-control']) }}
         <p class="text-danger">{{ $errors->first('type') }}</p>
       </div>
 
-      <div class="form-group col-sm-3">
+      <div class="form-group col-sm-2">
+        {{ Form::label('simbrief_type', 'SimBrief Type:') }}
+        {{ Form::text('simbrief_type', null, ['class' => 'form-control']) }}
+        <p class="text-danger">{{ $errors->first('simbrief_type') }}</p>
+      </div>
+
+      <div class="form-group col-sm-2">
         {{ Form::label('name', 'Name:') }}
         {{ Form::text('name', null, ['class' => 'form-control']) }}
         <p class="text-danger">{{ $errors->first('name') }}</p>

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -17,13 +17,13 @@
                   <div class="row">
                     <div class="col-sm-4">
                       <label for="type">Type</label>
-                      <input type="text" class="form-control" value="{{ $aircraft->icao }}" maxlength="4" disabled/>
-                      <input type="hidden" id="type" name="type" value="{{ $aircraft->subfleet->simbrief_type ?? $aircraft->icao }}"/>
+                      <input type="text" class="form-control" value="{{ $aircraft->icao }}" maxlength="4" disabled>
+                      <input type="hidden" name="type" value="{{ $aircraft->subfleet->simbrief_type ?? $aircraft->icao }}">
                     </div>
                     <div class="col-sm-4">
                       <label for="reg">Registration</label>
-                      <input type="text" class="form-control" value="{{ $aircraft->registration }}" maxlength="6" disabled/>
-                      <input type="hidden" id="reg" name="reg" value="{{ $aircraft->registration }}"/>
+                      <input type="text" class="form-control" value="{{ $aircraft->registration }}" maxlength="6" disabled>
+                      <input type="hidden" name="reg" value="{{ $aircraft->registration }}">
                     </div>
                   </div>
                   <br>
@@ -35,29 +35,28 @@
                   <div class="row">
                     <div class="col-sm-4">
                       <label for="dorig">Departure Airport</label>
-                      <input id="dorig" type="text" class="form-control" maxlength="4" value="{{ $flight->dpt_airport_id }}" disabled/>
-                      <input id="orig" name="orig" type="hidden" maxlength="4" value="{{ $flight->dpt_airport_id }}"/>
+                      <input id="dorig" type="text" class="form-control" maxlength="4" value="{{ $flight->dpt_airport_id }}" disabled>
+                      <input name="orig" type="hidden" maxlength="4" value="{{ $flight->dpt_airport_id }}">
                     </div>
                     <div class="col-sm-4">
                       <label for="ddest">Arrival Airport</label>
-                      <input id="ddest" type="text" class="form-control" maxlength="4" value="{{ $flight->arr_airport_id }}" disabled/>
-                      <input id="dest" name="dest" type="hidden" maxlength="4" value="{{ $flight->arr_airport_id }}"/>
+                      <input id="ddest" type="text" class="form-control" maxlength="4" value="{{ $flight->arr_airport_id }}" disabled>
+                      <input name="dest" type="hidden" maxlength="4" value="{{ $flight->arr_airport_id }}">
                     </div>
                     <div class="col-sm-4">
                       <label for="altn">Alternate Airport</label>
-                      <input id="altn" name="altn" type="text" class="form-control" maxlength="4"
-                             value="{{ $flight->alt_airport_id ?? 'AUTO' }}"/>
+                      <input name="altn" type="text" class="form-control" maxlength="4" value="{{ $flight->alt_airport_id ?? 'AUTO' }}">
                     </div>
                   </div>
                   <br>
                   <div class="row">
                     <div class="col-sm-8">
                       <label for="route">Preferred Company Route</label>
-                      <input id="route" name="route" type="text" class="form-control" value="{{ $flight->route }}"/>
+                      <input name="route" type="text" class="form-control" value="{{ $flight->route }}">
                     </div>
                     <div class="col-sm-4">
                       <label for="fl">Preferred Flight Level</label>
-                      <input id="fl" name="fl" type="text" class="form-control" maxlength="5" value="{{ $flight->level }}"/>
+                      <input id="fl" name="fl" type="text" class="form-control" maxlength="5" value="{{ $flight->level }}">
                     </div>
                   </div>
                   <br>
@@ -65,113 +64,107 @@
                     <div class="col-sm-4">
                       @if($flight->dpt_time)
                         <label for="std">Scheduled Departure Time (UTC)</label>
-                        <input id="std" type="text" class="form-control" maxlength="4" value="{{ $flight->dpt_time }}" disabled/>
+                        <input id="std" type="text" class="form-control" maxlength="4" value="{{ $flight->dpt_time }}" disabled>
                       @endif
                     </div>
                     <div class="col-sm-4">
                       <label for="etd">Estimated Departure Time (UTC)</label>
-                      <input id="etd" type="text" class="form-control" maxlength="4" disabled/>
+                      <input id="etd" type="text" class="form-control" maxlength="4" disabled>
                     </div>
                     <div class="col-sm-4">
                       <label for="dof">Date Of Flight (UTC)</label>
-                      <input id="dof" type="text" class="form-control" maxlength="4" disabled/>
+                      <input id="dof" type="text" class="form-control" maxlength="4" disabled>
                     </div>
                   </div>
                   <br>
                 </div>
 
                 <div class="form-container-body">
-                  @foreach($subfleets as $subfleet)
-                    @if($subfleet->id == $aircraft->subfleet_id)
-                      <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Load Information For
-                      <b>{{ $aircraft->registration }} ({{ $subfleet->name }})</b></h6>
-                      <div class="row">
-                        @php $loadarray = [] ; @endphp
-                        {{-- Generate Load Figures For Passenger Fares --}}
-                          @foreach($subfleet->fares as $fare)
-                            @if($fare->type == 0)
-                              @php
-                                $randompaxperfare = ceil(($fare->capacity * (rand($loadmin, $loadmax))) /100);
-                                $loadarray[] = ['LoadType' => $fare->code];
-                                $loadarray[] = ['LoadFigure' => $randompaxperfare];
-                              @endphp
-                              <div class="col-sm-3">
-                                <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} [Max: {{ number_format($fare->capacity) }}]</label>
-                                <input id="LoadFare{{ $fare->id }}" type="text" class="form-control" value="{{ number_format($randompaxperfare) }}" disabled/>
-                              </div>
-                            @endif
-                          @endforeach
-                          @php
-                            $paxcollection = collect($loadarray);
-                            $tpaxfig = $paxcollection->sum('LoadFigure');
+                  <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Load Information For
+                  <b>{{ $aircraft->registration }} ({{ $aircraft->subfleet->name }})</b></h6>
+                  <div class="row">
+                    @php $loadarray = [] ; @endphp
+                    {{-- Generate Load Figures For Pax Fares --}}
+                      @foreach($aircraft->subfleet->fares->where('type', 0) as $fare)
+                        @php
+                          $randompaxperfare = floor(($fare->pivot->capacity * rand($loadmin, $loadmax)) /100);
+                          $loadarray[] = ['LoadType' => $fare->code];
+                          $loadarray[] = ['LoadFigure' => $randompaxperfare];
+                        @endphp
+                        <div class="col-sm-3">
+                          <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} [Max: {{ number_format($fare->pivot->capacity) }}]</label>
+                          <input id="LoadFare{{ $fare->id }}" type="text" class="form-control" value="{{ number_format($randompaxperfare) }}" disabled>
+                        </div>
+                      @endforeach
+                    {{-- Calculate weights for Pax Loads Before moving to Cargo Fares --}}
+                      @php
+                        $paxcollection = collect($loadarray);
+                        $tpaxfig = $paxcollection->sum('LoadFigure');
 
-                            if(setting('units.weight') === 'kg') {
-                              $tpaxload = round(($pax_weight * $tpaxfig) / 2.205);
-                              $tbagload = round(($bag_weight * $tpaxfig) / 2.205);
-                            } else {
-                              $tpaxload = round($pax_weight * $tpaxfig);
-                              $tbagload = round($bag_weight * $tpaxfig);
-                            }
-                          @endphp
-                        {{-- Generate Load Figures For Cargo Fares --}}
-                          @foreach($subfleet->fares as $fare)
-                            @if($fare->type == 1)
-                              @php
-                                $randomcargoperfare = ceil((($fare->capacity - $tbagload) * (rand($loadmin, $loadmax))) /100);
-                                $loadarray[] = ['LoadType' => $fare->code];
-                                $loadarray[] = ['CargoFigure' => $randomcargoperfare];
-                              @endphp
-                              <div class="col-sm-3">
-                                <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} [Max: {{ number_format($fare->capacity - $tbagload) }} {{ setting('units.weight') }}]</label>
-                                <input id="LoadFare{{ $fare->id }}" type="text" class="form-control" value="{{ number_format($randomcargoperfare) }}" disabled/>
-                              </div>
-                            @endif
-                          @endforeach
-                          @php
-                            $loadcollection = collect($loadarray);
-                            $tcargoload = $loadcollection->sum('CargoFigure');
-                            $tpayload = $tpaxload + $tbagload + $tcargoload;
-                          @endphp
-                      </div>
-                      @if(isset($tpayload) && $tpayload > 0)
-                        <br>
-                        <div class="row">
-                          @if($tpaxload)
-                            <div class="col-sm-3">
-                              <label for="tdPaxLoad">Pax Weight</label>
-                              <input id="tdPaxLoad" type="text" class="form-control" value="{{ number_format($tpaxload) }} {{ setting('units.weight') }}" disabled/>
-                            </div>
-                            <div class="col-sm-3">
-                              <label for="tBagLoad">Baggage Weight</label>
-                              <input id="tBagLoad" type="text" class="form-control" value="{{ number_format($tbagload) }} {{ setting('units.weight') }}" disabled/>
-                            </div>
-                          @endif
-                          @if($tpaxload && $tcargoload)
-                            <div class="col-sm-3">
-                              <label for="tCargoload">Cargo Weight</label>
-                              <input id="tCargoload" type="text" class="form-control" value="{{ number_format($tcargoload) }} {{ setting('units.weight') }}" disabled/>
-                            </div>
-                          @endif
-                          <div class="col-sm-3">
-                            <label for="tPayload">Total Payload</label>
-                            <input id="tPayload" type="text" class="form-control" value="{{ number_format($tpayload) }} {{ setting('units.weight') }}" disabled/>
-                          </div>
+                        if(setting('units.weight') === 'kg') {
+                          $tpaxload = round(($pax_weight * $tpaxfig) / 2.205);
+                          $tbagload = round(($bag_weight * $tpaxfig) / 2.205);
+                        } else {
+                          $tpaxload = round($pax_weight * $tpaxfig);
+                          $tbagload = round($bag_weight * $tpaxfig);
+                        }
+                      @endphp
+                    {{-- Generate Load Figures For Cargo Fares --}}
+                      @foreach($aircraft->subfleet->fares->where('type', 1) as $fare)
+                        @php
+                          $randomcargoperfare = ceil((($fare->pivot->capacity - $tbagload) * rand($loadmin, $loadmax)) /100);
+                          $loadarray[] = ['LoadType' => $fare->code];
+                          $loadarray[] = ['CargoFigure' => $randomcargoperfare];
+                        @endphp
+                        <div class="col-sm-3">
+                          <label for="LoadFare{{ $fare->id }}">{{ $fare->name }} [Max: {{ number_format($fare->pivot->capacity - $tbagload) }} {{ setting('units.weight') }}]</label>
+                          <input id="LoadFare{{ $fare->id }}" type="text" class="form-control" value="{{ number_format($randomcargoperfare) }}" disabled>
+                        </div>
+                      @endforeach
+                      @php
+                        $loadcollection = collect($loadarray);
+                        $tcargoload = $loadcollection->sum('CargoFigure');
+                        $tpayload = $tpaxload + $tbagload + $tcargoload;
+                      @endphp
+                  </div>
+                  @if(isset($tpayload) && $tpayload > 0)
+                    {{-- Display The Weights Generated --}}
+                    <br>
+                    <div class="row">
+                      @if($tpaxload)
+                        <div class="col-sm-3">
+                          <label for="tdPaxLoad">Pax Weight</label>
+                          <input id="tdPaxLoad" type="text" class="form-control" value="{{ number_format($tpaxload) }} {{ setting('units.weight') }}" disabled>
+                        </div>
+                        <div class="col-sm-3">
+                          <label for="tBagLoad">Baggage Weight</label>
+                          <input id="tBagLoad" type="text" class="form-control" value="{{ number_format($tbagload) }} {{ setting('units.weight') }}" disabled>
                         </div>
                       @endif
-                    @endif
-                  @endforeach
+                      @if($tpaxload && $tcargoload)
+                        <div class="col-sm-3">
+                          <label for="tCargoload">Cargo Weight</label>
+                          <input id="tCargoload" type="text" class="form-control" value="{{ number_format($tcargoload) }} {{ setting('units.weight') }}" disabled>
+                        </div>
+                      @endif
+                      <div class="col-sm-3">
+                        <label for="tPayload">Total Payload</label>
+                        <input id="tPayload" type="text" class="form-control" value="{{ number_format($tpayload) }} {{ setting('units.weight') }}" disabled>
+                      </div>
+                    </div>
+                  @endif
                 </div>
               </div>
 
-              {{-- Prepare Load Figures For SimBrief --}}
+              {{-- Prepare Form Fields For SimBrief --}}
                 <input type="hidden" name="acdata" value="{'paxwgt':{{ round($pax_weight + $bag_weight) }}}">
                 @if($tpaxfig)
-                  <input type="hidden" id="pax" name="pax" value="{{ $tpaxfig }}"/>
+                  <input type="hidden" name="pax" value="{{ $tpaxfig }}">
                 @elseif(!$tpaxfig && $tcargoload)
-                  <input type="hidden" id="pax" name="pax" value="0"/>
+                  <input type="hidden" name="pax" value="0">
                 @endif
                 @if($tcargoload)
-                  <input type='hidden' id="cargo" name='cargo' value="{{ number_format(($tcargoload / 1000),1) }}" maxlength='3'>
+                  <input type='hidden' name='cargo' value="{{ number_format(($tcargoload / 1000),1) }}">
                 @endif
               {{--
                 Generate the MANUALRMK which is sent to SimBrief and displayed as Dispatch Remark.
@@ -212,7 +205,7 @@
               <input type="hidden" name="omit_stars" value="0">
               <input type="hidden" name="cruise" value="CI">
               <input type="hidden" name="civalue" value="AUTO">
-              {{-- For more info about form fields and their details check SimBrief Forum for API Support --}}
+              {{-- For more info about form fields and their details check SimBrief Forum / API Support --}}
             </div>
             <div class="col-4">
               <div class="form-container">

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -198,7 +198,7 @@
               @endif
               <input type="hidden" name="airline" value="{{ $flight->airline->icao }}">
               <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
-              @if(setting('simbrief.callsign') && setting('simbrief.callsign', true))
+              @if(setting('simbrief.callsign', false))
                 <input type="hidden" name="callsign" value="{{ Auth::user()->ident }}">
               @endif
               <input type="hidden" id="steh" name="steh" maxlength="2">


### PR DESCRIPTION
* Added SimBrief Type field to subfleets, can be used to assign simbrief airframes to subfleets and fix non existing or wrong types. If not used simbrief form will use aircraft's icao type code

* Added Passenger and Baggage weights to settings

* Added setting for using PhpVms Pilot/User  Ident as simbrief atc callsign

* SimBrief form code cleaned up a bit and improved. Now form supports both cargo and passenger fares to be used at the same time.

Generated passenger baggage weight will be reduced from aircraft's cargo capacity and remaining amount will be used for random cargo generation.

Also multiple cargo fares or any mix is possible now (like only cargo, only passenger, multiple cargo and passenger fares)

![sb_0](https://user-images.githubusercontent.com/74361521/108941274-dc04ab00-7665-11eb-8b86-3e095379cdd6.png)

![sb_1](https://user-images.githubusercontent.com/74361521/108941289-e030c880-7665-11eb-9f9c-d6a0ac5ea08a.png)

![sb_2](https://user-images.githubusercontent.com/74361521/108941297-e4f57c80-7665-11eb-88c6-e84d3ee52b37.png)

![sb_3](https://user-images.githubusercontent.com/74361521/108941307-e9ba3080-7665-11eb-8e45-94298d30e271.png)
