### PR TITLE
Optimize view paths for module views in theme folder

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Services\ModuleService;
+use App\Support\ThemeViewFinder;
 use App\Support\Utils;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Schema;
@@ -23,6 +24,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->app->singleton('view.finder', function ($app) {
+            return new ThemeViewFinder(
+                $app['files'],
+                $app['config']['view.paths'],
+                null
+            );
+        });
+
         // Only load the IDE helper if it's included and enabled
         if (config('app.debug') === true) {
             /* @noinspection NestedPositiveIfStatementsInspection */

--- a/app/Support/ThemeViewFinder.php
+++ b/app/Support/ThemeViewFinder.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace App\Support;
+
+
+use Igaster\LaravelTheme\Facades\Theme;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+
+class ThemeViewFinder extends \Igaster\LaravelTheme\themeViewFinder
+{
+    public function __construct(Filesystem $files, array $paths, array $extensions = null)
+    {
+        //$this->themeEngine = \App::make('igaster.themes');
+        parent::__construct($files, $paths, $extensions);
+    }
+
+    /*
+     * Override findNamespacedView() to add "Theme/vendor/..." paths
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function findNamespacedView($name)
+    {
+        // Extract the $view and the $namespace parts
+        list($namespace, $view) = $this->parseNamespaceSegments($name);
+
+        $paths = $this->addThemeNamespacePaths($namespace);
+
+        // Find and return the view
+        return $this->findInPaths($view, $paths);
+    }
+
+    public function addThemeNamespacePaths($namespace)
+    {
+        // This rule will remap all paths starting with $key to $value.
+        // For exapmle paths starting with 'resources/views/vendor' (relative to base_path())
+        // will be maped to path 'THEMENAME/vendor' (relative to current theme views-path)
+        $pathsMap = [
+            // 'resources/views/vendor/mail' => 'mail',
+            'resources/views/vendor' => 'vendor',
+            'resources/views/modules' => 'modules',
+        ];
+
+        // Does $namespace exists?
+        if (!isset($this->hints[$namespace])) {
+            return [];
+        }
+
+        // Get the paths registered to the $namespace
+        $paths = $this->hints[$namespace];
+
+        // Search $paths array and remap paths that start with a key of $pathsMap array.
+        // replace with the value of $pathsMap array
+        $themeSubPaths = [];
+        foreach ($paths as $path) {
+            $pathRelativeToApp = substr($path, strlen(base_path()) + 1);
+            // Ignore paths in composer installed packages (paths inside vendor folder)
+            if (strpos($pathRelativeToApp, 'vendor') !== 0) {
+                // Remap paths definded int $pathsMap array
+                foreach ($pathsMap as $key => $value) {
+                    if (strpos($pathRelativeToApp, $key) === 0) {
+                        $pathRelativeToApp = str_replace($key, $value, $pathRelativeToApp);
+                        break;
+                    }
+                }
+                $themeSubPaths[] = $pathRelativeToApp;
+            }
+        }
+
+        // Prepend current theme's view path to the remaped paths
+        $newPaths = [];
+        $searchPaths = array_diff($this->paths, Theme::getLaravelViewPaths());
+        foreach ($searchPaths as $path1) {
+            foreach ($themeSubPaths as $path2) {
+                $newPaths[] = $path1 . '/' . $path2;
+            }
+        }
+
+        // Add new paths in the beggin of the search paths array
+        foreach (array_reverse($newPaths) as $path) {
+            if (!in_array($path, $paths)) {
+                $paths = Arr::prepend($paths, $path);
+            }
+        }
+        return $paths;
+    }
+}

--- a/app/Support/ThemeViewFinder.php
+++ b/app/Support/ThemeViewFinder.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace App\Support;
-
 
 use Igaster\LaravelTheme\Facades\Theme;
 use Illuminate\Filesystem\Filesystem;
@@ -40,7 +38,7 @@ class ThemeViewFinder extends \Igaster\LaravelTheme\themeViewFinder
         // will be maped to path 'THEMENAME/vendor' (relative to current theme views-path)
         $pathsMap = [
             // 'resources/views/vendor/mail' => 'mail',
-            'resources/views/vendor' => 'vendor',
+            'resources/views/vendor'  => 'vendor',
             'resources/views/modules' => 'modules',
         ];
 
@@ -75,7 +73,7 @@ class ThemeViewFinder extends \Igaster\LaravelTheme\themeViewFinder
         $searchPaths = array_diff($this->paths, Theme::getLaravelViewPaths());
         foreach ($searchPaths as $path1) {
             foreach ($themeSubPaths as $path2) {
-                $newPaths[] = $path1 . '/' . $path2;
+                $newPaths[] = $path1.'/'.$path2;
             }
         }
 

--- a/app/Support/ThemeViewFinder.php
+++ b/app/Support/ThemeViewFinder.php
@@ -79,7 +79,7 @@ class ThemeViewFinder extends \Igaster\LaravelTheme\themeViewFinder
 
         // Add new paths in the beggin of the search paths array
         foreach (array_reverse($newPaths) as $path) {
-            if (!in_array($path, $paths)) {
+            if (!in_array($path, $paths, true)) {
                 $paths = Arr::prepend($paths, $path);
             }
         }


### PR DESCRIPTION
Currently views from modules can be overridden in resources/views/layouts/<activetheme>/resources/views/modules/<modulename>
This override removes the duplicated "resources/views" part.

in igaster/laravel-theme a PR has been created but is not yet merged. This is considered a workaround until PR is merged into laravel-theme package