### PR TITLE
Update simbrief_aircraft.blade.php

### DIFF
--- a/resources/views/layouts/default/flights/simbrief_aircraft.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_aircraft.blade.php
@@ -15,8 +15,8 @@
         @foreach($subfleets as $subfleet)
           @foreach($subfleet->aircraft as $ac)
             @if(setting('pireps.only_aircraft_at_dpt_airport') && $flight->dpt_airport_id == $ac->airport_id || !setting('pireps.only_aircraft_at_dpt_airport') 
-            @endif
             <option value="{{ $ac->id }}">[ {{ $ac->icao }} ] {{ $ac->registration }}</option>
+            @endif
           @endforeach
         @endforeach
       </select>

--- a/resources/views/layouts/default/flights/simbrief_aircraft.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_aircraft.blade.php
@@ -14,6 +14,8 @@
         <option value="ZZZZZ">Please Select An Aircraft</option>
         @foreach($subfleets as $subfleet)
           @foreach($subfleet->aircraft as $ac)
+            @if(setting('pireps.only_aircraft_at_dpt_airport') && $flight->dpt_airport_id == $ac->airport_id || !setting('pireps.only_aircraft_at_dpt_airport') 
+            @endif
             <option value="{{ $ac->id }}">[ {{ $ac->icao }} ] {{ $ac->registration }}</option>
           @endforeach
         @endforeach


### PR DESCRIPTION
If restrict airplane at location settings is enabled, will show how only  aircraft at the departure location of the flight. Kindly made by @FatihKoz (aka disposable hero) at my ocd request.