### PR TITLE
DownloadController Improvements

### DIFF
--- a/app/Http/Controllers/Frontend/DownloadController.php
+++ b/app/Http/Controllers/Frontend/DownloadController.php
@@ -67,7 +67,7 @@ class DownloadController extends Controller
     }
 
     /**
-     * Show the application dashboard.
+     * Show the application dashboard
      *
      * @param string $id
      *

--- a/app/Http/Controllers/Frontend/DownloadController.php
+++ b/app/Http/Controllers/Frontend/DownloadController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Contracts\Controller;
+use App\Models\Airline;
 use App\Models\File;
 use Auth;
 use Flash;
@@ -18,6 +19,7 @@ class DownloadController extends Controller
      */
     public function index()
     {
+        $airlines = Airline::where('active', 1)->count();
         $files = File::orderBy('ref_model', 'asc')->get();
 
         /**
@@ -42,16 +44,22 @@ class DownloadController extends Controller
             $category = explode('\\', $class);
             $category = end($category);
 
-            if ($category == 'Aircraft') {
+            if ($category == 'Aircraft' && $airlines > 1) {
+                $group_name = $category.' > '.$obj->subfleet->airline->name.' '.$obj->icao.' '.$obj->registration;
+            } elseif ($category == 'Aircraft') {
                 $group_name = $category.' > '.$obj->icao.' '.$obj->registration;
             } elseif ($category == 'Airport') {
                 $group_name = $category.' > '.$obj->icao.' : '.$obj->name.' ('.$obj->country.')';
+            } elseif ($category == 'Subfleet' && $airlines > 1) {
+                $group_name = $category.' > '.$obj->airline->name.' '.$obj->name;
             } else {
                 $group_name = $category.' > '.$obj->name;
             }
 
             $regrouped_files[$group_name] = $files;
         }
+
+        ksort($regrouped_files, SORT_STRING);
 
         return view('downloads.index', [
             'grouped_files' => $regrouped_files,


### PR DESCRIPTION
Added multiple airline support to both Aircraft and Subfleet downloads, if the user has more than one active airline, downloads will display the airline name before the object name. Also sorted the returned results to have a better look at the blade.

![downloads](https://user-images.githubusercontent.com/74361521/111898631-627b9500-8a38-11eb-851a-4eba8aa39901.png)

![downloads_default](https://user-images.githubusercontent.com/74361521/111898828-5fcd6f80-8a39-11eb-8d8c-dd2f54ad0fcd.png)

