### PR TITLE
Move SimBrief aircraft selection to Controller

### DIFF
--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -235,6 +235,13 @@
   options: ''
   type: boolean
   description: 'Use pilot ident as Simbrief ATC Callsign'
+- key: simbrief.name_private
+  name: 'Use Privatized Name at OFPs'
+  group: simbrief
+  value: false
+  options: ''
+  type: boolean
+  description: 'Use privatized user name as SimBrief OFP captain name'
 - key: pireps.duplicate_check_time
   name: 'PIREP duplicate time check'
   group: pireps

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -76,10 +76,10 @@ class SimBriefController
             } else {
                 $subfleets = $this->userSvc->getAllowableSubfleets($user);
             }
-            
+
             // Build an array of subfleet id's from the subfleets collection
             $sf_ids = $subfleets->map(function ($subfleets) {
-              return collect($subfleets->toArray())
+                return collect($subfleets->toArray())
                   ->only(['id'])
                   ->all();
             });
@@ -92,8 +92,8 @@ class SimBriefController
                                 ->where('status', AircraftStatus::ACTIVE)
                                 ->get();
 
-            if(setting('pireps.only_aircraft_at_dpt_airport')) {
-              $aircrafts = $aircrafts->where('airport_id', $flight->dpt_airport_id);
+            if (setting('pireps.only_aircraft_at_dpt_airport')) {
+                $aircrafts = $aircrafts->where('airport_id', $flight->dpt_airport_id);
             }
 
             return view('flights.simbrief_aircraft', [

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -76,9 +76,29 @@ class SimBriefController
             } else {
                 $subfleets = $this->userSvc->getAllowableSubfleets($user);
             }
+            
+            // Build an array of subfleet id's from the subfleets collection
+            $sf_ids = $subfleets->map(function ($subfleets) {
+              return collect($subfleets->toArray())
+                  ->only(['id'])
+                  ->all();
+            });
+
+            // Now we can build a proper aircrafts collection
+            // Contents will be either members of flight->subfleets
+            // or members of user's allowable subfleets
+            $aircrafts = Aircraft::whereIn('subfleet_id', $sf_ids)
+                                ->where('state', AircraftState::PARKED)
+                                ->where('status', AircraftStatus::ACTIVE)
+                                ->get();
+
+            if(setting('pireps.only_aircraft_at_dpt_airport')) {
+              $aircrafts = $aircrafts->where('airport_id', $flight->dpt_airport_id);
+            }
 
             return view('flights.simbrief_aircraft', [
                 'flight'    => $flight,
+                'aircrafts' => $aircrafts,
                 'subfleets' => $subfleets,
             ]);
         }

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -90,6 +90,8 @@ class SimBriefController
             $aircrafts = Aircraft::whereIn('subfleet_id', $sf_ids)
                                 ->where('state', AircraftState::PARKED)
                                 ->where('status', AircraftStatus::ACTIVE)
+                                ->orderby('icao')
+                                ->orderby('registration')
                                 ->get();
 
             if (setting('pireps.only_aircraft_at_dpt_airport')) {

--- a/resources/views/layouts/default/flights/simbrief_aircraft.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_aircraft.blade.php
@@ -12,13 +12,9 @@
     <div class="col-md-12">
       <select id="aircraftselection" class="form-control select2" onchange="checkacselection()">
         <option value="ZZZZZ">Please Select An Aircraft</option>
-        @foreach($subfleets as $subfleet)
-          @foreach($subfleet->aircraft as $ac)
-            @if(setting('pireps.only_aircraft_at_dpt_airport') && $flight->dpt_airport_id == $ac->airport_id || !setting('pireps.only_aircraft_at_dpt_airport') 
-            <option value="{{ $ac->id }}">[ {{ $ac->icao }} ] {{ $ac->registration }}</option>
-            @endif
+          @foreach($aircrafts as $ac)
+            <option value="{{ $ac->id }}">[{{ $ac->icao }}] {{ $ac->registration }} @if($ac->registration != $ac->name)'{{ $ac->name }}'@endif</option>
           @endforeach
-        @endforeach
       </select>
     </div>
     <div class="col-md-12 text-right">

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -144,6 +144,9 @@
               @if(setting('simbrief.callsign', true))
                 <input type="hidden" name="callsign" value="{{ $user->ident }}">
               @endif
+              @if(setting('simbrief.name_private', true))
+                <input type="hidden" name="cpt" value="{{ $user->name_private }}">
+              @endif
               <input type="hidden" id="steh" name="steh" maxlength="2">
               <input type="hidden" id="stem" name="stem" maxlength="2">
               <input type="hidden" id="date" name="date" maxlength="9">


### PR DESCRIPTION
Instead of passing subfleets to blade (and doing two foreach loops and ifs to populate the dropdown), we are building a proper aircraft list here.

Did not removed $subfleets from data being passed to blade on purpose, it may be removed later on.