### PR TITLE
Change LatestPireps Widget Sort Order

### DIFF
--- a/app/Widgets/LatestPireps.php
+++ b/app/Widgets/LatestPireps.php
@@ -28,7 +28,7 @@ class LatestPireps extends Widget
                 PirepState::CANCELLED,
                 PirepState::DRAFT,
                 PirepState::IN_PROGRESS,
-            ], 'created_at', 'desc')
+            ], 'submitted_at', 'desc')
             ->recent($this->config['count']);
 
         return view('widgets.latest_pireps', [

--- a/app/Widgets/LatestPireps.php
+++ b/app/Widgets/LatestPireps.php
@@ -8,6 +8,7 @@ use App\Repositories\PirepRepository;
 
 /**
  * Show the latest PIREPs in a view
+ * sorted nicely by their submit time
  */
 class LatestPireps extends Widget
 {


### PR DESCRIPTION
Latest pireps should be ordered by `submitted_at` instead of `created_at` . 

Pirep may be created even a day before others (with the pause/resume ability we have in acars) but it gets submitted once when the flight is ended, thus I think it should be our reference to sort them in proper order.