### PR TITLE
Fix Expenses Not Being Multiplied

### DIFF
--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -301,7 +301,7 @@ class PirepFinanceService extends Service
 
             if (filled($pirep->aircraft->subfleet->ground_handling_multiplier)
                 && $expense->multiplier
-                && $expense->multiplier == 1) {
+                && $expense->multiplier === 1) {
                 // force into percent mode
                 $multiplier = $pirep->aircraft->subfleet->ground_handling_multiplier.'%';
                 // do the math and return

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -299,6 +299,15 @@ class PirepFinanceService extends Service
                 $transaction_group = "Expense: {$expense->name}";
             }
 
+            if (filled($pirep->aircraft->subfleet->ground_handling_multiplier)
+                && $expense->multiplier
+                && $expense->multiplier == 1) {
+                // force into percent mode
+                $multiplier = $pirep->aircraft->subfleet->ground_handling_multiplier.'%';
+                // do the math and return
+                $expense->amount = Math::applyAmountOrPercent($expense->amount,$multiplier);
+            }
+
             $debit = Money::createFromAmount($expense->amount);
 
             // If the expense is marked to charge it to a user (only applicable to Flight)

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -305,7 +305,7 @@ class PirepFinanceService extends Service
                 // force into percent mode
                 $multiplier = $pirep->aircraft->subfleet->ground_handling_multiplier.'%';
                 // do the math and return
-                $expense->amount = Math::applyAmountOrPercent($expense->amount,$multiplier);
+                $expense->amount = Math::applyAmountOrPercent($expense->amount, $multiplier);
             }
 
             $debit = Money::createFromAmount($expense->amount);


### PR DESCRIPTION
There is no such field to define multipliers for expenses (in subfleets and/or aircrafts), thus i assumed that the subfleet GH multiplier is the place to control the multiplier value for other expenses too.

If it is the wrong value to use, or if we need to define a new one, just let me know so we can enhance this.