### PR TITLE
Move the prefile event and add a new error exception

### DIFF
--- a/app/Exceptions/PrefileError.php
+++ b/app/Exceptions/PrefileError.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Exceptions;
+
+/**
+ * Prefile Error
+ *
+ * If listening to the prefile event message, use `throw new PrefileError("message message");`
+ * to abort the prefile process and send the message up to ACARS
+ */
+class PrefileError extends AbstractHttpException
+{
+    private $error;
+
+    public function __construct(string $error)
+    {
+        $this->error = $error;
+        parent::__construct(400, $error);
+    }
+
+    /**
+     * Return the RFC 7807 error type (without the URL root)
+     */
+    public function getErrorType(): string
+    {
+        return 'prefile-error';
+    }
+
+    /**
+     * Get the detailed error string
+     */
+    public function getErrorDetails(): string
+    {
+        return $this->getMessage();
+    }
+
+    /**
+     * Return an array with the error details, merged with the RFC7807 response
+     */
+    public function getErrorMetadata(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/Api/PirepController.php
+++ b/app/Http/Controllers/Api/PirepController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Contracts\Controller;
-use App\Events\PirepPrefiled;
 use App\Events\PirepUpdated;
 use App\Exceptions\AircraftPermissionDenied;
 use App\Exceptions\PirepCancelled;

--- a/app/Http/Controllers/Api/PirepController.php
+++ b/app/Http/Controllers/Api/PirepController.php
@@ -219,8 +219,6 @@ class PirepController extends Controller
         $this->updateFields($pirep, $request);
         $this->updateFares($pirep, $request);
 
-        event(new PirepPrefiled($pirep));
-
         return $this->get($pirep->id);
     }
 

--- a/app/Listeners/PirepEventsHandler.php
+++ b/app/Listeners/PirepEventsHandler.php
@@ -15,7 +15,7 @@ class PirepEventsHandler extends Listener
 {
     /** The events and the callback */
     public static $callbacks = [
-        PirepPrefiled::class    => 'onPirepPrefile',
+        PirepPrefiled::class => 'onPirepPrefile',
     ];
 
     /**

--- a/app/Listeners/PirepEventsHandler.php
+++ b/app/Listeners/PirepEventsHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Contracts\Listener;
+use App\Events\PirepPrefiled;
+
+/**
+ * Look for and run any of the award classes. Don't modify this.
+ * See the documentation on creating awards:
+ *
+ * @url http://docs.phpvms.net/customizing/awards
+ */
+class PirepEventsHandler extends Listener
+{
+    /** The events and the callback */
+    public static $callbacks = [
+        PirepPrefiled::class    => 'onPirepPrefile',
+    ];
+
+    /**
+     * Called when a PIREP is prefiled
+     *
+     * @param PirepPrefiled $event
+     */
+    public function onPirepPrefile(PirepPrefiled $event)
+    {
+
+    }
+}

--- a/app/Listeners/PirepEventsHandler.php
+++ b/app/Listeners/PirepEventsHandler.php
@@ -25,6 +25,5 @@ class PirepEventsHandler extends Listener
      */
     public function onPirepPrefile(PirepPrefiled $event)
     {
-
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,6 +9,7 @@ use App\Listeners\AwardHandler;
 use App\Listeners\BidEventHandler;
 use App\Listeners\ExpenseListener;
 use App\Listeners\FinanceEventHandler;
+use App\Listeners\PirepEventsHandler;
 use App\Listeners\UserStateListener;
 use App\Notifications\EventHandler;
 use Codedge\Updater\Events\UpdateAvailable;
@@ -45,5 +46,6 @@ class EventServiceProvider extends ServiceProvider
         FinanceEventHandler::class,
         EventHandler::class,
         AwardHandler::class,
+        PirepEventsHandler::class,
     ];
 }

--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -6,6 +6,7 @@ use App\Contracts\Service;
 use App\Events\PirepAccepted;
 use App\Events\PirepCancelled;
 use App\Events\PirepFiled;
+use App\Events\PirepPrefiled;
 use App\Events\PirepRejected;
 use App\Events\UserStatsChanged;
 use App\Exceptions\AircraftInvalid;
@@ -150,6 +151,8 @@ class PirepService extends Service
                 throw new \App\Exceptions\PirepCancelled($pirep);
             }
         }
+
+        event(new PirepPrefiled($pirep));
 
         $pirep->save();
 


### PR DESCRIPTION
To abort a prefile, use:

```php
throw new \App\Exceptions\PrefileError('failing prefile because of something');
```

And that message should go up to ACARS

Closes #1110