### PR TITLE
Alphanumeric Callsign For Flights

### DIFF
--- a/app/Database/migrations/2021_04_05_055245_flights_add_alphanumeric_callsign.php
+++ b/app/Database/migrations/2021_04_05_055245_flights_add_alphanumeric_callsign.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a `anumeric_callsign` column for Alphanumeric Callsign to be assigned for a flight
+ * Exp DLH78BF, THY8EA, OGE1978
+ * According to FAA and EASA, callsigns must be maximum 7 chars in which first 3 chars is
+ * airline ICAO code remaining rest can be used freely according to airline's choices
+ */
+class FlightsAddAlphanumericCallsign extends Migration
+{
+    public function up()
+    {
+        Schema::table('flights', function (Blueprint $table) {
+            $table->string('anumeric_callsign', 4)
+                ->nullable()
+                ->after('flight_number');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('flights', function (Blueprint $table) {
+            $table->dropColumn('anumeric_callsign');
+        });
+    }
+}

--- a/app/Database/migrations/2021_04_05_055245_flights_add_alphanumeric_callsign.php
+++ b/app/Database/migrations/2021_04_05_055245_flights_add_alphanumeric_callsign.php
@@ -15,7 +15,7 @@ class FlightsAddAlphanumericCallsign extends Migration
     public function up()
     {
         Schema::table('flights', function (Blueprint $table) {
-            $table->string('anumeric_callsign', 4)
+            $table->string('callsign', 4)
                 ->nullable()
                 ->after('flight_number');
         });
@@ -24,7 +24,7 @@ class FlightsAddAlphanumericCallsign extends Migration
     public function down()
     {
         Schema::table('flights', function (Blueprint $table) {
-            $table->dropColumn('anumeric_callsign');
+            $table->dropColumn('callsign');
         });
     }
 }

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Collection;
  * @property Airline    airline
  * @property int        airline_id
  * @property mixed      flight_number
+ * @property mixed      anumeric_callsign
  * @property mixed      route_code
  * @property int        route_leg
  * @property bool       has_bid
@@ -60,6 +61,7 @@ class Flight extends Model
         'id',
         'airline_id',
         'flight_number',
+        'anumeric_callsign',
         'route_code',
         'route_leg',
         'dpt_airport_id',
@@ -104,6 +106,7 @@ class Flight extends Model
     public static $rules = [
         'airline_id'           => 'required|exists:airlines,id',
         'flight_number'        => 'required',
+        'anumeric_callsign'    => 'nullable',
         'route_code'           => 'nullable',
         'route_leg'            => 'nullable',
         'dpt_airport_id'       => 'required|exists:airports,id',

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Collection;
  * @property Airline    airline
  * @property int        airline_id
  * @property mixed      flight_number
- * @property mixed      anumeric_callsign
+ * @property mixed      callsign
  * @property mixed      route_code
  * @property int        route_leg
  * @property bool       has_bid
@@ -61,7 +61,7 @@ class Flight extends Model
         'id',
         'airline_id',
         'flight_number',
-        'anumeric_callsign',
+        'callsign',
         'route_code',
         'route_leg',
         'dpt_airport_id',
@@ -106,7 +106,7 @@ class Flight extends Model
     public static $rules = [
         'airline_id'           => 'required|exists:airlines,id',
         'flight_number'        => 'required',
-        'anumeric_callsign'    => 'nullable',
+        'callsign'             => 'string|max:4|nullable',
         'route_code'           => 'nullable',
         'route_leg'            => 'nullable',
         'dpt_airport_id'       => 'required|exists:airports,id',

--- a/resources/lang/en/flights.php
+++ b/resources/lang/en/flights.php
@@ -5,6 +5,7 @@ return [
     'flighttime'       => 'Flight Time',
     'flighttype'       => 'Flight Type',
     'flighthours'      => 'Flight Hours',
+    'callsign'         => 'Callsign',
     'route'            => 'Route',
     'mybid'            => 'My Bids',
     'search'           => 'Search',

--- a/resources/lang/es/flights.php
+++ b/resources/lang/es/flights.php
@@ -5,6 +5,7 @@ return [
     'flighttime'       => 'Tiempo de vuelo',
     'flighttype'       => 'Tipo de vuelo',
     'flighthours'      => 'Horas de vuelo',
+    'callsign'         => 'Indicativo',
     'route'            => 'Ruta',
     'mybid'            => 'Mis reservas',
     'search'           => 'Buscar',

--- a/resources/lang/it/flights.php
+++ b/resources/lang/it/flights.php
@@ -5,6 +5,7 @@ return [
     'flighttime'       => 'Tempo di Volo',
     'flighttype'       => 'Tipo di Volo',
     'flighthours'      => 'Ore di Volo',
+    'callsign'         => 'Nominativo',
     'route'            => 'Rotta',
     'mybid'            => 'Mie Prenotazioni',
     'addremovebid'     => 'Aggiungi/Rimuovi Prenotazione',

--- a/resources/lang/pt-br/flights.php
+++ b/resources/lang/pt-br/flights.php
@@ -5,6 +5,7 @@ return [
     'flighttime'       => 'Tempo do Voo',
     'flighttype'       => 'Tipo de Voo',
     'flighthours'      => 'Horas de Voo',
+    'callsign'         => 'Indicativo',
     'route'            => 'Rota',
     'mybid'            => 'Minhas Reservas',
     'search'           => 'Procurar',

--- a/resources/views/admin/flights/fields.blade.php
+++ b/resources/views/admin/flights/fields.blade.php
@@ -29,11 +29,11 @@
 
           </div>
 
-          <!-- Alphanumeric Callsign Field -->
+          <!-- Callsign Field -->
           <div class="form-group input-group-sm col-sm-2">
-            {{ Form::label('anumeric_callsign', 'Alphanumeric Callsign:') }}
-            {{ Form::text('anumeric_callsign', null, ['class'=>'form-control', 'placeholder'=>'optional', 'maxlength' => 4]) }}
-            <p class="text-danger">{{ $errors->first('anumeric_callsign') }}</p>
+            {{ Form::label('callsign', 'Callsign:') }}
+            {{ Form::text('callsign', null, ['class'=>'form-control', 'placeholder'=>'optional', 'maxlength' => 4]) }}
+            <p class="text-danger">{{ $errors->first('callsign') }}</p>
           </div>
 
           <!-- Flight Type Field -->

--- a/resources/views/admin/flights/fields.blade.php
+++ b/resources/views/admin/flights/fields.blade.php
@@ -29,15 +29,22 @@
 
           </div>
 
-          <!-- Route Code Field -->
-          <div class="form-group col-sm-3">
+          <!-- Alphanumeric Callsign Field -->
+          <div class="form-group input-group-sm col-sm-2">
+            {{ Form::label('anumeric_callsign', 'Alphanumeric Callsign:') }}
+            {{ Form::text('anumeric_callsign', null, ['class'=>'form-control', 'placeholder'=>'optional', 'maxlength' => 4]) }}
+            <p class="text-danger">{{ $errors->first('anumeric_callsign') }}</p>
+          </div>
+
+          <!-- Flight Type Field -->
+          <div class="form-group col-sm-2">
             {{ Form::label('level', 'Flight Type:') }}&nbsp;<span class="required">*</span>
             {{ Form::select('flight_type', $flight_types, null, ['class' => 'form-control select2']) }}
             <p class="text-danger">{{ $errors->first('flight_type') }}</p>
           </div>
 
-          <!-- Route Leg Field -->
-          <div class="form-group col-sm-3">
+          <!-- Flight Time Field -->
+          <div class="form-group col-sm-2">
             {{ Form::label('flight_time', 'Flight Time (hours & minutes)') }}
 
             <div class="input-group input-group-sm mb3">

--- a/resources/views/layouts/default/flights/show.blade.php
+++ b/resources/views/layouts/default/flights/show.blade.php
@@ -43,12 +43,18 @@
                 </td>
               </tr>
             @endif
-
-            <tr>
-              <td>@lang('flights.route')</td>
-              <td>{{ $flight->route }}</td>
-            </tr>
-
+            @if(filled($flight->route))
+              <tr>
+                <td>@lang('flights.route')</td>
+                <td>{{ $flight->route }}</td>
+              </tr>
+            @endif
+            @if(filled($flight->anumeric_callsign))
+              <tr>
+                <td>@lang('flights.callsign')</td>
+                <td>{{ $flight->airline->icao }} {{ $flight->anumeric_callsign }}</td>
+              </tr>
+            @endif
             @if(filled($flight->notes))
               <tr>
                 <td>{{ trans_choice('common.note', 2) }}</td>

--- a/resources/views/layouts/default/flights/show.blade.php
+++ b/resources/views/layouts/default/flights/show.blade.php
@@ -49,10 +49,10 @@
                 <td>{{ $flight->route }}</td>
               </tr>
             @endif
-            @if(filled($flight->anumeric_callsign))
+            @if(filled($flight->callsign))
               <tr>
                 <td>@lang('flights.callsign')</td>
-                <td>{{ $flight->airline->icao }} {{ $flight->anumeric_callsign }}</td>
+                <td>{{ $flight->airline->icao }} {{ $flight->callsign }}</td>
               </tr>
             @endif
             @if(filled($flight->notes))

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -144,7 +144,7 @@
               @if(setting('simbrief.callsign', true))
                 <input type="hidden" name="callsign" value="{{ $user->ident }}">
               @else
-                <input type="hidden" name="callsign" value="{{ $flight->airline->icao }}{{ $flight->anumeric_callsign ?? $flight->flight_number }}">
+                <input type="hidden" name="callsign" value="{{ $flight->airline->icao }}{{ $flight->callsign ?? $flight->flight_number }}">
               @endif
               @if(setting('simbrief.name_private', true))
                 <input type="hidden" name="cpt" value="{{ $user->name_private }}">

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -143,6 +143,8 @@
               <input type="hidden" name="fltnum" value="{{ $flight->flight_number }}">
               @if(setting('simbrief.callsign', true))
                 <input type="hidden" name="callsign" value="{{ $user->ident }}">
+              @else
+                <input type="hidden" name="callsign" value="{{ $flight->airline->icao }}{{ $flight->anumeric_callsign ?? $flight->flight_number }}">
               @endif
               @if(setting('simbrief.name_private', true))
                 <input type="hidden" name="cpt" value="{{ $user->name_private }}">

--- a/resources/views/layouts/default/flights/table.blade.php
+++ b/resources/views/layouts/default/flights/table.blade.php
@@ -51,9 +51,9 @@
               ])}}">{{$flight->arr_airport_id}}</a>)
           @if($flight->arr_time), {{ $flight->arr_time }}@endif
           <br/>
-          @if(filled($flight->anumeric_callsign))
+          @if(filled($flight->callsign))
             <span class="title">{{ strtoupper(__('flights.callsign')) }}&nbsp;</span>
-            {{ $flight->airline->icao }} {{ $flight->anumeric_callsign }}
+            {{ $flight->airline->icao }} {{ $flight->callsign }}
             <br/>
           @endif
           @if($flight->distance)

--- a/resources/views/layouts/default/flights/table.blade.php
+++ b/resources/views/layouts/default/flights/table.blade.php
@@ -51,14 +51,20 @@
               ])}}">{{$flight->arr_airport_id}}</a>)
           @if($flight->arr_time), {{ $flight->arr_time }}@endif
           <br/>
+          @if(filled($flight->anumeric_callsign))
+            <span class="title">{{ strtoupper(__('flights.callsign')) }}&nbsp;</span>
+            {{ $flight->airline->icao }} {{ $flight->anumeric_callsign }}
+            <br/>
+          @endif
           @if($flight->distance)
             <span class="title">{{ strtoupper(__('common.distance')) }}&nbsp;</span>
             {{ $flight->distance }} {{ setting('units.distance') }}
+            <br/>
           @endif
-          <br/>
           @if($flight->level)
             <span class="title">{{ strtoupper(__('flights.level')) }}&nbsp;</span>
             {{ $flight->level }} {{ setting('units.altitude') }}
+            <br/>
           @endif
         </div>
         <div class="col-sm-5">


### PR DESCRIPTION
PR adds ability to define alphanumeric callsigns for flights, display them and use them during SimBrief OFP generation (if pilot ident as callsign option is not enabled)

Translations for en/es/it/pt-br added.