### PR TITLE
Use where iso whereTime

### DIFF
--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -27,7 +27,7 @@ class RemoveExpiredLiveFlights extends Listener
         }
 
         $date = Carbon::now()->subHours(setting('acars.live_time'));
-        Pirep::whereTime('updated_at', '<', $date)
+        Pirep::where('updated_at', '<', $date)
             ->where('state', PirepState::IN_PROGRESS)
             ->delete();
     }


### PR DESCRIPTION
Using whereTime may present a problem for flights conducted during utc midnight and some active/live flights may be deleted with whereTime.

Scenario;

now     = today-01:00  utc
setting = 2 hours
date     = yesterday-23:00 utc

Any live pireps will/may be deleted with whereTime 'cause their last updated TIME will be maximum 00:59 which is smaller than 23:00.