### PR TITLE
Allow session lifetime to be set in env variables

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -16,7 +16,7 @@ return [
     */
 
     'driver'          => env('SESSION_DRIVER', 'file'),
-    'lifetime'        => 120,
+    'lifetime'        => env('SESSION_LIFETIME',120),
     'expire_on_close' => false,
     'encrypt'         => false,
     'files'           => storage_path('framework/sessions'),

--- a/config/session.php
+++ b/config/session.php
@@ -16,7 +16,7 @@ return [
     */
 
     'driver'          => env('SESSION_DRIVER', 'file'),
-    'lifetime'        => env('SESSION_LIFETIME',120),
+    'lifetime'        => env('SESSION_LIFETIME', 120),
     'expire_on_close' => false,
     'encrypt'         => false,
     'files'           => storage_path('framework/sessions'),


### PR DESCRIPTION
Currently the session live time defaults to 2 hours, adding an env variable will allow us to change this on a per site basis