### PR TITLE
100LL and MOGAS Fuel Cost

### DIFF
--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -144,6 +144,20 @@
   options:
   type: text
   description: If an airport's Jet A Fuel Cost isn't added, set this value by default
+- key: airports.default_100ll_fuel_cost
+  name: 'Default 100LL Fuel Cost'
+  group: airports
+  value: 0.9
+  options:
+  type: text
+  description: If an airport's 100LL Fuel Cost isn't added, set this value by default
+- key: airports.default_mogas_fuel_cost
+  name: 'Default MOGAS Fuel Cost'
+  group: airports
+  value: 0.8
+  options:
+  type: text
+  description: If an airport's MOGAS Fuel Cost isn't added, set this value by default
 - key: bids.disable_flight_on_bid
   name: 'Disable flight on bid'
   group: bids

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -20,6 +20,7 @@ use App\Models\Traits\FilesTrait;
  * @property float   cost_delay_minute
  * @property Airline airline
  * @property Airport hub
+ * @property int     fuel_type
  */
 class Subfleet extends Model
 {

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -167,11 +167,11 @@ class PirepFinanceService extends Service
         }
 
         if ($fuel_type === FuelType::LOW_LEAD) {
-            $fuel_cost = empty($ap->fuel_100ll_cost) ? setting('airports.default_100ll_fuel_cost') : $ap->fuel_100ll_cost;
+            $fuel_cost = !empty($ap->fuel_100ll_cost) ? $ap->fuel_100ll_cost : setting('airports.default_100ll_fuel_cost');
         } elseif ($fuel_type === FuelType::MOGAS) {
-            $fuel_cost = empty($ap->fuel_mogas_cost) ? setting('airports.default_mogas_fuel_cost') : $ap->fuel_mogas_cost;
+            $fuel_cost = !empty($ap->fuel_mogas_cost) ? $ap->fuel_mogas_cost : setting('airports.default_mogas_fuel_cost');
         } else { // Default to JetA
-            $fuel_cost = empty($ap->fuel_jeta_cost) ? setting('airports.default_jet_a_fuel_cost') : $ap->fuel_jeta_cost;
+            $fuel_cost = !empty($ap->fuel_jeta_cost) ? $ap->fuel_jeta_cost : setting('airports.default_jet_a_fuel_cost');
         }
 
         if (setting('pireps.advanced_fuel', false)) {

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -180,11 +180,11 @@ class PirepFinanceService extends Service
             $fuel_type = FuelType::JET_A;
         }
 
-        if ($fuel_type === FuelType::LOW_LEAD) {
+        if ($fuel_type == FuelType::LOW_LEAD) {
             $fuel_cost = $lowlead_cost;
-        } elseif ($fuel_type === FuelType::JET_A) {
+        } elseif ($fuel_type == FuelType::JET_A) {
             $fuel_cost = $jeta_cost;
-        } elseif ($fuel_type === FuelType::MOGAS) {
+        } elseif ($fuel_type == FuelType::MOGAS) {
             $fuel_cost = $mogas_cost;
         }
 

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -177,10 +177,10 @@ class PirepFinanceService extends Service
         if (setting('pireps.advanced_fuel', false)) {
             // Reading second row by skip(1) to reach the previous accepted pirep. Current pirep is at the first row
             $prev_flight = Pirep::where([
-                    'aircraft_id' => $pirep->aircraft->id,
-                    'state'       => PirepState::ACCEPTED,
-                    'status'      => PirepStatus::ARRIVED,
-                ])
+                'aircraft_id' => $pirep->aircraft->id,
+                'state'       => PirepState::ACCEPTED,
+                'status'      => PirepStatus::ARRIVED,
+            ])
                 ->orderby('submitted_at', 'desc')
                 ->skip(1)
                 ->first();


### PR DESCRIPTION
Add missing defaults for 100LL and MOGAS prices to admin settings and use proper subfleet fuel type at pirep finances. (instead of using always JET-A1)

Closes #1145 