### PR TITLE
Use queues for notifications #1154

### DIFF
--- a/app/Console/Commands/EmailTest.php
+++ b/app/Console/Commands/EmailTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App;
+use App\Contracts\Command;
+
+class EmailTest extends Command
+{
+    protected $signature = 'phpvms:email-test';
+    protected $description = 'Send a test notification to admins';
+
+    /**
+     * Run dev related commands
+     *
+     * @throws \Symfony\Component\HttpFoundation\File\Exception\FileException
+     */
+    public function handle()
+    {
+        /** @var App\Notifications\EventHandler $eventHandler */
+        $eventHandler = app(App\Notifications\EventHandler::class);
+
+        $news = new App\Models\News();
+        $news->user_id = 1;
+        $news->subject = 'Test News';
+        $news->body = 'Test Body';
+        $news->save();
+
+        $newsEvent = new App\Events\NewsAdded($news);
+        $eventHandler->onNewsAdded($newsEvent);
+    }
+}

--- a/app/Console/Commands/ProcessQueue.php
+++ b/app/Console/Commands/ProcessQueue.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App;
+use App\Contracts\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+class ProcessQueue extends Command
+{
+    protected $signature = 'queue:cron';
+    protected $description = 'Process the queue from a cron job';
+
+    /**
+     * Run the queue tasks
+     *
+     */
+    public function handle()
+    {
+        Artisan::call('queue:work', [
+            '--sansdaemon'      => null,
+            '--stop-when-empty' => null,
+        ]);
+
+        Log::info(Artisan::output());
+        ///** @var App\Support\WorkCommand $queueWorker */
+        //$queueWorker = new App\Support\WorkCommand(app('queue.worker'), app('cache.store'));
+
+        //$queueWorker->setInput($queueWorker->createInputFromArguments([]));
+        //$queueWorker->handle();
+
+        /*$output = $this->call('queue:work', [
+            '--stop-when-empty' => null,
+        ]);
+
+        Log::info($output);*/
+    }
+}

--- a/app/Console/Commands/ProcessQueue.php
+++ b/app/Console/Commands/ProcessQueue.php
@@ -14,7 +14,6 @@ class ProcessQueue extends Command
 
     /**
      * Run the queue tasks
-     *
      */
     public function handle()
     {

--- a/app/Console/Cron/JobQueue.php
+++ b/app/Console/Cron/JobQueue.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console\Cron;
+
+use App\Contracts\Command;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * This just calls the CronHourly event, so all of the
+ * listeners, etc can just be called to run those tasks
+ */
+class JobQueue extends Command
+{
+    protected $signature = 'cron:queue';
+    protected $description = 'Run the cron queue tasks';
+    protected $schedule;
+
+    public function handle(): void
+    {
+        $this->redirectLoggingToFile('cron');
+        Artisan::call('queue:cron');
+
+        $this->info(Artisan::output());
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Cron\Hourly;
 use App\Console\Cron\Monthly;
 use App\Console\Cron\Nightly;
+use App\Console\Cron\JobQueue;
 use App\Console\Cron\Weekly;
 use App\Services\CronService;
 use Illuminate\Console\Scheduling\Schedule;
@@ -25,6 +26,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
+        $schedule->command(JobQueue::class)
+            ->everyMinute()
+            ->withoutOverlapping();
+
         $schedule->command(Nightly::class)->dailyAt('01:00');
         $schedule->command(Weekly::class)->weeklyOn(0);
         $schedule->command(Monthly::class)->monthlyOn(1);

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,9 +3,9 @@
 namespace App\Console;
 
 use App\Console\Cron\Hourly;
+use App\Console\Cron\JobQueue;
 use App\Console\Cron\Monthly;
 use App\Console\Cron\Nightly;
-use App\Console\Cron\JobQueue;
 use App\Console\Cron\Weekly;
 use App\Services\CronService;
 use Illuminate\Console\Scheduling\Schedule;

--- a/app/Contracts/Command.php
+++ b/app/Contracts/Command.php
@@ -24,9 +24,9 @@ abstract class Command extends \Illuminate\Console\Command
         parent::__construct();
 
         // Running in the console but not in the tests
-        if (app()->runningInConsole() && env('APP_ENV') !== 'testing') {
+        /*if (app()->runningInConsole() && env('APP_ENV') !== 'testing') {
             $this->redirectLoggingToFile('stdout');
-        }
+        }*/
     }
 
     /**

--- a/app/Listeners/MessageLoggedListener.php
+++ b/app/Listeners/MessageLoggedListener.php
@@ -9,8 +9,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  * Show logs in the console
  *
  * https://stackoverflow.com/questions/48264479/log-laravel-with-artisan-output
- *
- * @package App\Listeners
  */
 class MessageLoggedListener
 {

--- a/app/Listeners/MessageLoggedListener.php
+++ b/app/Listeners/MessageLoggedListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Log\Events\MessageLogged;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+/**
+ * Show logs in the console
+ *
+ * https://stackoverflow.com/questions/48264479/log-laravel-with-artisan-output
+ *
+ * @package App\Listeners
+ */
+class MessageLoggedListener
+{
+    public function handle(MessageLogged $event)
+    {
+        if (app()->runningInConsole()) {
+            $output = new ConsoleOutput();
+            $output->writeln("<$event->level>$event->message</$event->level>");
+        }
+    }
+}

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -5,8 +5,11 @@ namespace App\Models;
 use App\Contracts\Model;
 
 /**
- * @property string subject
- * @property string body
+ * @property int       id
+ * @property int|mixed user_id
+ * @property string    subject
+ * @property string    body
+ * @property User      user
  */
 class News extends Model
 {

--- a/app/Notifications/Messages/AdminUserRegistered.php
+++ b/app/Notifications/Messages/AdminUserRegistered.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\User;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class AdminUserRegistered extends Notification
+class AdminUserRegistered extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/NewsAdded.php
+++ b/app/Notifications/Messages/NewsAdded.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\News;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class NewsAdded extends Notification
+class NewsAdded extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/PirepAccepted.php
+++ b/app/Notifications/Messages/PirepAccepted.php
@@ -5,12 +5,15 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\Pirep;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
  * Send the PIREP accepted message to a particular user
  */
-class PirepAccepted extends Notification
+class PirepAccepted extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/PirepRejected.php
+++ b/app/Notifications/Messages/PirepRejected.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\Pirep;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class PirepRejected extends Notification
+class PirepRejected extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/PirepSubmitted.php
+++ b/app/Notifications/Messages/PirepSubmitted.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\Pirep;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class PirepSubmitted extends Notification
+class PirepSubmitted extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/UserPending.php
+++ b/app/Notifications/Messages/UserPending.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\User;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UserPending extends Notification
+class UserPending extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/UserRegistered.php
+++ b/app/Notifications/Messages/UserRegistered.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\User;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UserRegistered extends Notification
+class UserRegistered extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Notifications/Messages/UserRejected.php
+++ b/app/Notifications/Messages/UserRejected.php
@@ -5,9 +5,12 @@ namespace App\Notifications\Messages;
 use App\Contracts\Notification;
 use App\Models\User;
 use App\Notifications\Channels\MailChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UserRejected extends Notification
+class UserRejected extends Notification implements ShouldQueue
 {
+    use Queueable;
     use MailChannel;
 
     public $channels = ['mail'];

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -39,6 +39,11 @@ class EventServiceProvider extends ServiceProvider
 
         UpdateAvailable::class => [],
         UpdateSucceeded::class => [],
+
+        // Log messages out to the console if running there
+        'Illuminate\Log\Events\MessageLogged' => [
+            'App\Listeners\MessageLoggedListener',
+        ],
     ];
 
     protected $subscribe = [

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
         "elcobvg/laravel-opcache": "^0.4.1",
         "laravel/legacy-factories": "^1.1",
         "fakerphp/faker": "^v1.14",
-        "wildbit/swiftmailer-postmark": "^3.3"
+        "wildbit/swiftmailer-postmark": "^3.3",
+        "queueworker/sansdaemon": "^1.2"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9306757768b0fad9102766b70d4e18d8",
+    "content-hash": "8ab12b349948ff95fed99c6e898f1a89",
     "packages": [
         {
             "name": "akaunting/money",
@@ -5641,6 +5641,63 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
             "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "queueworker/sansdaemon",
+            "version": "v1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orobogenius/sansdaemon.git",
+                "reference": "b23ae9d22202bb2a59a5c3ce275c27fc00100060"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orobogenius/sansdaemon/zipball/b23ae9d22202bb2a59a5c3ce275c27fc00100060",
+                "reference": "b23ae9d22202bb2a59a5c3ce275c27fc00100060",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^6.0|^7.0|^8.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "orchestra/testbench": "^4.0",
+                "phpunit/phpunit": "^8"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Queueworker\\SansDaemon\\SansDaemonServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Queueworker\\SansDaemon\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lucky Ozoka",
+                    "email": "orobolucky@gmail.com"
+                }
+            ],
+            "description": "Batch process Laravel Queue without a daemon; Processes queue jobs and kills the process",
+            "keywords": [
+                "laravel",
+                "queue"
+            ],
+            "support": {
+                "issues": "https://github.com/orobogenius/sansdaemon/issues",
+                "source": "https://github.com/orobogenius/sansdaemon/tree/v1.2.4"
+            },
+            "time": "2021-02-12T11:09:45+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/config/logging.php
+++ b/config/logging.php
@@ -40,7 +40,7 @@ return [
             'driver'   => 'stack',
             'channels' => [
                 'cron_rotating',
-                'stdout',
+                //'stdout',
             ],
         ],
         'single' => [

--- a/config/queue.php
+++ b/config/queue.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_DRIVER', 'sync'),
+    'default' => env('QUEUE_DRIVER', 'database'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/queue.php
+++ b/config/queue.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_DRIVER', 'database'),
+    'default' => env('QUEUE_DRIVER', 'sync'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/stubs/installer/env.stub
+++ b/resources/stubs/installer/env.stub
@@ -37,6 +37,11 @@ DB_SOCKET=
 CACHE_DRIVER=$CACHE_DRIVER$
 CACHE_PREFIX='$CACHE_PREFIX$'
 
+# QUEUE SETTINGS
+# Set this to "database" if you have slow pages due to notifications/emails
+# They will then be sent out via cron
+QUEUE_DRIVER=sync
+
 # EMAIL SETTINGS
 # Look at the available mail configs in config/mail.php
 # Also refer to the Laravel docs here: https://laravel.com/docs/8.x/mail


### PR DESCRIPTION
Use queues for notifications and process the queue in the cron instead of a separate worker. Closes #1154 