### PR TITLE
PirepCancelled Event (Cron Expired Pirep Deletion)

### DIFF
--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -31,7 +31,7 @@ class RemoveExpiredLiveFlights extends Listener
         $pireps = Pirep::where('updated_at', '<', $date)
             ->where('state', PirepState::IN_PROGRESS)
             ->get();
-        foreach($pireps as $pirep) {
+        foreach ($pireps as $pirep) {
             event(new PirepCancelled($pirep));
             Log::info('Cron: Deleting Expired Live PIREP id='.$pirep->id.', state='.PirepState::label($pirep->state));
             $pirep->delete();

--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -8,6 +8,7 @@ use App\Events\PirepCancelled;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Remove expired live flights

--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -4,6 +4,7 @@ namespace App\Cron\Hourly;
 
 use App\Contracts\Listener;
 use App\Events\CronHourly;
+use App\Events\PirepCancelled;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;
 use Carbon\Carbon;
@@ -27,8 +28,13 @@ class RemoveExpiredLiveFlights extends Listener
         }
 
         $date = Carbon::now('UTC')->subHours(setting('acars.live_time'));
-        Pirep::where('updated_at', '<', $date)
+        $pireps = Pirep::where('updated_at', '<', $date)
             ->where('state', PirepState::IN_PROGRESS)
-            ->delete();
+            ->get();
+        $foreach($pireps as $pirep) {
+            event(new PirepCancelled($pirep));
+            Log::info('Cron: Deleting Expired Live PIREP id='.$pirep->id.', state='.PirepState::label($pirep->state));
+            $pirep->delete();
+        }
     }
 }

--- a/app/Cron/Hourly/RemoveExpiredLiveFlights.php
+++ b/app/Cron/Hourly/RemoveExpiredLiveFlights.php
@@ -31,7 +31,7 @@ class RemoveExpiredLiveFlights extends Listener
         $pireps = Pirep::where('updated_at', '<', $date)
             ->where('state', PirepState::IN_PROGRESS)
             ->get();
-        $foreach($pireps as $pirep) {
+        foreach($pireps as $pirep) {
             event(new PirepCancelled($pirep));
             Log::info('Cron: Deleting Expired Live PIREP id='.$pirep->id.', state='.PirepState::label($pirep->state));
             $pirep->delete();


### PR DESCRIPTION
While deleting frozen/expired in progress pireps we should at least send a PirepCancelled event for those who are listening.

(or we may have a new PirepDeleted event to be issued in such cases, I think PirepCancelled is enough though)