### PR TITLE
Remove Scripts

### DIFF
--- a/resources/views/admin/flights/create.blade.php
+++ b/resources/views/admin/flights/create.blade.php
@@ -9,4 +9,3 @@
     </div>
   </div>
 @endsection
-@include('admin.flights.scripts')

--- a/resources/views/admin/flights/fields.blade.php
+++ b/resources/views/admin/flights/fields.blade.php
@@ -186,13 +186,13 @@
           <div class="col-sm-4">
             {{ Form::label('start_date', 'Start Date') }}
             <span class="description small">optional</span>
-            {{ Form::text('start_date', null, ['id' => 'start_date', 'class' => 'form-control']) }}
+            {{ Form::text('start_date', null, ['id' => 'start_date', 'class' => 'form-control', 'placeholder'=>'2021-03-25']) }}
           </div>
 
           <div class="col-sm-4">
             {{ Form::label('end_date', 'End Date') }}
             <span class="description small">optional</span>
-            {{ Form::text('end_date', null, ['id' => 'end_date', 'class' => 'form-control']) }}
+            {{ Form::text('end_date', null, ['id' => 'end_date', 'class' => 'form-control', 'placeholder'=>'2021-06-30']) }}
           </div>
 
           <div class="form-group col-sm-4">


### PR DESCRIPTION
Remove scripts from create blade which are designed for edit blade in the first place (thus looking for flight object and its properties). 
No need to have an eyecandy date picker or a days selector, previous working version of create.blade was more than enough to manually add fights.

![321](https://user-images.githubusercontent.com/74361521/119221885-36dd5f80-bafa-11eb-8077-803fbca51ce1.png)

Closes #1199 