### PR TITLE
Fix Flight Importer

### DIFF
--- a/app/Services/ImportExport/FlightImporter.php
+++ b/app/Services/ImportExport/FlightImporter.php
@@ -85,7 +85,6 @@ class FlightImporter extends ImportExport
             'flight_number' => $row['flight_number'],
             'route_code'    => $row['route_code'],
             'route_leg'     => $row['route_leg'],
-            'visible'       => true,
         ], $row);
 
         $row['dpt_airport'] = strtoupper($row['dpt_airport']);
@@ -98,6 +97,10 @@ class FlightImporter extends ImportExport
         if ($row['alt_airport']) {
             $flight->setAttribute('alt_airport_id', $row['alt_airport']);
         }
+
+        // Handle Route and Level Fields
+        $flight->setAttribute('route', strtoupper($row['route']));
+        $flight->setAttribute('level', $row['level']);
 
         // Any specific transformations
 


### PR DESCRIPTION
* Handle Route and Level fields too during import.
* Also removed the check for `'visible' => true` from `firstorNew` 'cause va admin may be importing to update not visible flights too.
  (by default all new flights are visible, so no affect on new flights)

Closes #1201