### PR TITLE
Fix SimBriefService

### DIFF
--- a/app/Services/SimBriefService.php
+++ b/app/Services/SimBriefService.php
@@ -192,11 +192,11 @@ class SimBriefService extends Service
     public function removeExpiredEntries(): void
     {
         $expire_days = setting('simbrief.expire_days', 5);
-        $expire_time = Carbon::now('UTC')->subDays($expire_days)->toDateTimeString();
+        $expire_time = Carbon::now('UTC')->subDays($expire_days);
 
         $briefs = SimBrief::where([
-            ['pirep_id', '=', ''],
-            ['created_at', '<', $expire_time],
+            ['pirep_id', null],
+            ['created_at', '<=', $expire_time],
         ])->get();
 
         foreach ($briefs as $brief) {


### PR DESCRIPTION
No need to convert the Carbon object to DateTimeString and also `'pirep_id' , '=', ''` was not working.

Closes #1208 