### PR TITLE
Add GD PHP Extension for docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN docker-php-ext-install \
   calendar \
   intl \
   pdo_mysql \
+  gd \
   gmp \
   opcache && \
   docker-php-ext-enable pdo_mysql opcache


### PR DESCRIPTION
GD is used when uploading profile picture to convert the image. Doing this in the current docker container crashes the process and the stack-trace says that the GD module is missing.