### PR TITLE
Use Profile Route for Author URL (Discord Messages)

### DIFF
--- a/app/Notifications/Messages/PirepPrefiled.php
+++ b/app/Notifications/Messages/PirepPrefiled.php
@@ -79,7 +79,7 @@ class PirepPrefiled extends Notification implements ShouldQueue
             ->url(route('frontend.pireps.show', [$pirep->id]))
             ->author([
                 'name'     => $pirep->user->ident.' - '.$pirep->user->name_private,
-                'url'      => route('frontend.pireps.show', [$pirep->id]),
+                'url'      => route('frontend.profile.show', [$pirep->user_id]),
                 'icon_url' => $pirep->user->resolveAvatarUrl(),
             ])
             ->fields($fields);

--- a/app/Notifications/Messages/PirepStatusChanged.php
+++ b/app/Notifications/Messages/PirepStatusChanged.php
@@ -118,7 +118,7 @@ class PirepStatusChanged extends Notification implements ShouldQueue
             ->url(route('frontend.pireps.show', [$pirep->id]))
             ->author([
                 'name'     => $pirep->user->ident.' - '.$pirep->user->name_private,
-                'url'      => route('frontend.pireps.show', [$pirep->id]),
+                'url'      => route('frontend.profile.show', [$pirep->user_id]),
                 'icon_url' => $pirep->user->resolveAvatarUrl(),
             ])
             ->fields($fields);

--- a/app/Notifications/Messages/PirepSubmitted.php
+++ b/app/Notifications/Messages/PirepSubmitted.php
@@ -85,7 +85,7 @@ class PirepSubmitted extends Notification implements ShouldQueue
             ->url(route('frontend.pireps.show', [$pirep->id]))
             ->author([
                 'name'     => $pirep->user->ident.' - '.$pirep->user->name_private,
-                'url'      => route('frontend.pireps.show', [$pirep->id]),
+                'url'      => route('frontend.profile.show', [$pirep->user_id]),
                 'icon_url' => $pirep->user->resolveAvatarUrl(),
             ])
             ->fields($fields);


### PR DESCRIPTION
Use profile route for message author instead of using the pirep route twice in the same message.

Message Author will be linked to that user's own profile , flight will be linked to the pirep being used for the message.