### PR TITLE
Fix typo

### DIFF
--- a/app/Notifications/Messages/PirepStatusChanged.php
+++ b/app/Notifications/Messages/PirepStatusChanged.php
@@ -43,7 +43,7 @@ class PirepStatusChanged extends Notification implements ShouldQueue
         PirepStatus::LANDING       => 'is landing',
         PirepStatus::LANDED        => 'has landed',
         PirepStatus::ARRIVED       => 'has arrived',
-        PirepStatus::CANCELLED     => 'has cancelled',
+        PirepStatus::CANCELLED     => 'is cancelled',
         PirepStatus::EMERG_DESCENT => 'in emergency descent',
     ];
 


### PR DESCRIPTION
Fix typo in cancelled notification Flight ABC123 is cancelled instead of Flight ABC123 has cancelled