### PR TITLE
Remove extraneous data from API response; force API to en

### DIFF
--- a/app/Http/Middleware/ApiAuth.php
+++ b/app/Http/Middleware/ApiAuth.php
@@ -50,6 +50,9 @@ class ApiAuth implements Middleware
             return $user;
         });
 
+        // Force english locale for API
+        app()->setLocale('en');
+
         return $next($request);
     }
 

--- a/app/Http/Middleware/JsonResponse.php
+++ b/app/Http/Middleware/JsonResponse.php
@@ -15,6 +15,7 @@ class JsonResponse implements Middleware
     {
         $response = $next($request);
         $response->headers->set('Content-Type', 'application/json');
+        $response->headers->set('charset', 'utf-8');
 
         return $response;
     }

--- a/app/Http/Resources/PirepFieldCollection.php
+++ b/app/Http/Resources/PirepFieldCollection.php
@@ -7,8 +7,6 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 
 class PirepFieldCollection extends ResourceCollection
 {
-    public $collects = PirepField::class;
-
     public function toArray($request)
     {
         $res = [];

--- a/app/Http/Resources/PirepFieldCollection.php
+++ b/app/Http/Resources/PirepFieldCollection.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Resources;
 
+use App\Models\PirepField;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
 class PirepFieldCollection extends ResourceCollection
 {
+    public $collects = PirepField::class;
+
     public function toArray($request)
     {
         $res = [];

--- a/app/Http/Resources/PirepFieldCollection.php
+++ b/app/Http/Resources/PirepFieldCollection.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources;
 
-use App\Models\PirepField;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
 class PirepFieldCollection extends ResourceCollection

--- a/app/Support/Resources/CustomAnonymousResourceCollection.php
+++ b/app/Support/Resources/CustomAnonymousResourceCollection.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Support\Resources;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Pagination\AbstractPaginator;
+
+class CustomAnonymousResourceCollection extends AnonymousResourceCollection
+{
+    public function toResponse($request)
+    {
+        return $this->resource instanceof AbstractPaginator
+                    ? (new CustomPaginatedResourceResponse($this))->toResponse($request)
+                    : parent::toResponse($request);
+    }
+}

--- a/app/Support/Resources/CustomAnonymousResourceCollection.php
+++ b/app/Support/Resources/CustomAnonymousResourceCollection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Support\Resources;
 
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;

--- a/app/Support/Resources/CustomPaginatedResourceResponse.php
+++ b/app/Support/Resources/CustomPaginatedResourceResponse.php
@@ -14,17 +14,13 @@ class CustomPaginatedResourceResponse extends PaginatedResourceResponse
 
     protected function meta($paginated)
     {
-        $meta = ['pagination' => Arr::except($paginated, [
+        return Arr::except($paginated, [
             'data',
             'first_page_url',
             'last_page_url',
             'prev_page_url',
             'next_page_url',
             'links',
-        ])];
-
-        $meta['pagination']['total_pages'] = $paginated['last_page'];
-
-        return $meta;
+        ]);
     }
 }

--- a/app/Support/Resources/CustomPaginatedResourceResponse.php
+++ b/app/Support/Resources/CustomPaginatedResourceResponse.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Support\Resources;
+
+use Illuminate\Http\Resources\Json\PaginatedResourceResponse;
+use Illuminate\Support\Arr;
+
+class CustomPaginatedResourceResponse extends PaginatedResourceResponse
+{
+    protected function paginationLinks($paginated)
+    {
+        return [];
+    }
+
+    protected function meta($paginated)
+    {
+        $meta = ['pagination' => Arr::except($paginated, [
+            'data',
+            'first_page_url',
+            'last_page_url',
+            'prev_page_url',
+            'next_page_url',
+            'links',
+        ])];
+
+        $meta['pagination']['total_pages'] = $paginated['last_page'];
+
+        return $meta;
+    }
+}

--- a/app/Support/Resources/CustomPaginatedResourceResponse.php
+++ b/app/Support/Resources/CustomPaginatedResourceResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Support\Resources;
 
 use Illuminate\Http\Resources\Json\PaginatedResourceResponse;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -104,6 +104,36 @@ class ApiTest extends TestCase
              ->assertJson(['data' => ['name' => $airline->name]]);
     }
 
+    public function testGetAirlinesChineseChars()
+    {
+        $this->user = factory(User::class)->create([
+            'airline_id' => 0,
+        ]);
+
+        factory(Airline::class)->create([
+            'icao' => 'DKH',
+            'name' => '吉祥航空',
+        ]);
+
+        factory(Airline::class)->create([
+            'icao' => 'CSZ',
+            'name' => '深圳航空',
+        ]);
+
+        factory(Airline::class)->create([
+            'icao' => 'CCA',
+            'name' => '中国国际航空',
+        ]);
+
+        factory(Airline::class)->create([
+            'icao' => 'CXA',
+            'name' => '厦门航空',
+        ]);
+
+        $res = $this->get('/api/airlines');
+        $this->assertTrue($res->isOk());
+    }
+
     /**
      * @throws Exception
      */


### PR DESCRIPTION
Start as issues with Chinese language utf-8 problems in pagination (API was showing links/text). Remove those as they are not needed, just shrink down the API response in total. Also force the API to use `en` as the locale, just to prevent these weird issues from happening when they might be OK on the web side but errors in the encoding in JSON.