### PR TITLE
Fix  missing colon on ./vendor volume

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -26,7 +26,7 @@ services:
       - ./composer-lock.json:/var/www/composer-lock.json
       - ./env.php:/var/www/env.php
       - ./resources/docker/php/www.conf:/usr/local/etc/php-fpm.d/www.conf
-      - ./vendor/var/www/vendor
+      - ./vendor:/var/www/vendor
     depends_on:
       - mysql
       - redis


### PR DESCRIPTION
docker up throwing error due to missing colon on the ./vendor folder

![image](https://user-images.githubusercontent.com/18175536/121673730-1ecd8000-caa9-11eb-935e-870708b674a2.png)
