### PR TITLE
Update AcarsRepository

### DIFF
--- a/app/Repositories/AcarsRepository.php
+++ b/app/Repositories/AcarsRepository.php
@@ -70,7 +70,7 @@ class AcarsRepository extends Repository
 
         if ($live_time !== null && $live_time > 0) {
             $st = Carbon::now('UTC')->subHours($live_time);
-            $q = $q->whereDate('created_at', '>=', $st);
+            $q = $q->where('created_at', '>=', $st);
         }
 
         $q = $q->orderBy('created_at', 'desc');

--- a/app/Repositories/AcarsRepository.php
+++ b/app/Repositories/AcarsRepository.php
@@ -69,11 +69,11 @@ class AcarsRepository extends Repository
             ->where(['state' => PirepState::IN_PROGRESS]);
 
         if ($live_time !== null && $live_time > 0) {
-            $st = Carbon::now('UTC')->subHours($live_time);
-            $q = $q->where('created_at', '>=', $st);
+            $st = Carbon::now()->subHours($live_time);
+            $q = $q->where('updated_at', '>=', $st);
         }
 
-        $q = $q->orderBy('created_at', 'desc');
+        $q = $q->orderBy('updated_at', 'desc');
         return $q->get();
     }
 


### PR DESCRIPTION
Use `where` instead of `whereDate` , as you know whereDate only checks the date, it skips the time part completely, thus not providing correct live pireps collection.