### PR TITLE
Fix PirepService

### DIFF
--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -574,8 +574,8 @@ class PirepService extends Service
 
         foreach ($field_values as $fv) {
             PirepFieldValue::updateOrCreate(
-                ['pirep_id' => $pirep_id, 'name' => $fv->name],
-                ['value' => $fv->value, 'source' => $fv->source]
+                ['pirep_id' => $pirep_id, 'name' => $fv['name']],
+                ['value' => $fv['value'], 'source' => $fv['source']]
             );
         }
     }


### PR DESCRIPTION
`$fv['name']` should be used instead of `$fv->name` due to the nature of source data.

Fixes #1260