### PR TITLE
Fix Private Profile fields not being editable

### DIFF
--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -123,7 +123,7 @@ class ProfileController extends Controller
 
         $airlines = $this->airlineRepo->selectBoxList();
         $airports = $this->airportRepo->selectBoxList(false, setting('pilots.home_hubs_only'));
-        $userFields = $this->userRepo->getUserFields($user, true);
+        $userFields = $this->userRepo->getUserFields($user);
 
         return view('profile.edit', [
             'user'       => $user,

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -36,8 +36,14 @@ class UserRepository extends Repository
      *
      * @return \App\Models\UserField[]|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
      */
-    public function getUserFields(User $user, $only_public_fields = true): Collection
+    public function getUserFields(User $user, $only_public_fields = null): Collection
     {
+        if (is_bool($only_public_fields)) {
+            $fields = UserField::where('private', !$only_public_fields)->get();
+        } else {
+            $fields = UserField::get();
+        }
+
         $fields = UserField::where(['private' => !$only_public_fields])->get();
         return $fields->map(function ($field, $_) use ($user) {
             foreach ($user->fields as $userFieldValue) {

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -39,12 +39,11 @@ class UserRepository extends Repository
     public function getUserFields(User $user, $only_public_fields = null): Collection
     {
         if (is_bool($only_public_fields)) {
-            $fields = UserField::where('private', !$only_public_fields)->get();
+            $fields = UserField::where(['private' => !$only_public_fields])->get();
         } else {
             $fields = UserField::get();
         }
 
-        $fields = UserField::where(['private' => !$only_public_fields])->get();
         return $fields->map(function ($field, $_) use ($user) {
             foreach ($user->fields as $userFieldValue) {
                 if ($userFieldValue->field->slug === $field->slug) {


### PR DESCRIPTION
Currently UserRepo returns either private or public fields, which is useful for profile display but comes with a logical problem for profile editing phase, which is already private to the user itself and there we need to have all custom profile fields. So the user can edit those when needed.

1. Remove the bool from the method call for edit ( Controller )
2. Alter the method to handle this new change ( Repository )

Closes #1287 