### PR TITLE
Fix Admin / PirepController

### DIFF
--- a/app/Http/Controllers/Admin/PirepController.php
+++ b/app/Http/Controllers/Admin/PirepController.php
@@ -9,6 +9,7 @@ use App\Models\Enums\PirepSource;
 use App\Models\Enums\PirepState;
 use App\Models\Pirep;
 use App\Models\PirepComment;
+use App\Models\PirepFare;
 use App\Repositories\AircraftRepository;
 use App\Repositories\AirlineRepository;
 use App\Repositories\AirportRepository;
@@ -151,10 +152,10 @@ class PirepController extends Controller
                 $count = $request->input($field_name);
             }
 
-            $fares[] = [
-                'fare_id' => $fare->id,
-                'count'   => $count,
-            ];
+            $fares[] = new PirepFare([
+                'fare_id'  => $fare->id,
+                'count'    => $count,
+            ]);
         }
 
         $this->fareSvc->saveForPirep($pirep, $fares);

--- a/app/Http/Controllers/Admin/PirepController.php
+++ b/app/Http/Controllers/Admin/PirepController.php
@@ -153,8 +153,8 @@ class PirepController extends Controller
             }
 
             $fares[] = new PirepFare([
-                'fare_id'  => $fare->id,
-                'count'    => $count,
+                'fare_id' => $fare->id,
+                'count'   => $count,
             ]);
         }
 

--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -308,9 +308,13 @@ class FareService extends Service
 
         // Add them in
         foreach ($fares as $fare) {
-            $fare->pirep_id = $pirep->id;
-            Log::info('Saving fare pirep='.$pirep->id.', fare='.$fare['count']);
-            $fare->save();
+            $fare['pirep_id'] = $pirep->id;
+            Log::info('Saving fare pirep='.$pirep->id.', fare='.$fare['fare_id'].', count='.$fare['count']);
+            PirepFare::create([
+                'pirep_id' => $fare['pirep_id'],
+                'fare_id'  => $fare['fare_id'],
+                'count'    => $fare['count'],
+            ]);
         }
     }
 }

--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -308,13 +308,9 @@ class FareService extends Service
 
         // Add them in
         foreach ($fares as $fare) {
-            $fare['pirep_id'] = $pirep->id;
-            Log::info('Saving fare pirep='.$pirep->id.', fare='.$fare['fare_id'].', count='.$fare['count']);
-            PirepFare::create([
-                'pirep_id' => $fare['pirep_id'],
-                'fare_id'  => $fare['fare_id'],
-                'count'    => $fare['count'],
-            ]);
+            $fare->pirep_id = $pirep->id;
+            Log::info('Saving fare pirep='.$pirep->id.', fare='.$fare['count']);
+            $fare->save();
         }
     }
 }


### PR DESCRIPTION
`$fares` was an **array** but was being handled like a _collection_ , which of course was causing problems while assigning a value to `$fare->pirep_id` and with the `$fare->save()` calls.
 
PR fixes both and Closes #1233 and #1244 