### PR TITLE
Fix SubfleetImporter

### DIFF
--- a/app/Services/ImportExport/SubfleetImporter.php
+++ b/app/Services/ImportExport/SubfleetImporter.php
@@ -20,7 +20,7 @@ class SubfleetImporter extends ImportExport
      */
     public static $columns = [
         'airline'                    => 'required',
-        'hub_id'                     => 'required',
+        'hub_id'                     => 'nullable',
         'type'                       => 'required',
         'simbrief_type'              => 'nullable',
         'name'                       => 'required',


### PR DESCRIPTION
`hub_id` is not a mandatory field (both in model and database), so it should be `nullable` here too.