### PR TITLE
Fix Admin/Subfleet Fields (for no Hub)

### DIFF
--- a/resources/views/admin/subfleets/fields.blade.php
+++ b/resources/views/admin/subfleets/fields.blade.php
@@ -20,7 +20,7 @@
 
       <div class="form-group col-sm-3">
         {{ Form::label('hub_id', 'Main Hub:') }}
-        {{ Form::select('hub_id', $hubs, null , ['class' => 'form-control select2']) }}
+        {{ Form::select('hub_id', $hubs, null , ['class' => 'form-control select2', 'placeholder' => '']) }}
         <p class="text-danger">{{ $errors->first('hub_id') }}</p>
       </div>
 


### PR DESCRIPTION
As like the db and model, admins should be able to not choosing a hub for their fleets here.