### PR TITLE
Fix logical operator

### DIFF
--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -479,7 +479,7 @@ class PirepService extends Service
         $pirep->refresh();
 
         // Figure out what pirep state should be, if nothing provided yet.
-        if ($pirep->state != PirepState::ACCEPTED || $pirep->state != PirepState::REJECTED) {
+        if ($pirep->state != PirepState::ACCEPTED && $pirep->state != PirepState::REJECTED) {
             $default_state = PirepState::PENDING;
         } else {
             $default_state = $pirep->state;


### PR DESCRIPTION
That `if` should return `true` when both conditions are met (pirep not accepted and not rejected yet), so **AND** must be used there ;) Sorry for the trouble.

Now it works and listens more carefully.