### PR TITLE
Add Custom Fares

### DIFF
--- a/app/Events/Fares.php
+++ b/app/Events/Fares.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use App\Contracts\Event;
+use App\Models\Pirep;
+
+/**
+ * This event is dispatched when the fares for a flight report
+ * are collected. Your listeners should return a list of Fare
+ * models. Don't call save on the model!
+ *
+ * Example return:
+ *
+ *   new Fare([
+ *      'name'  => '', # displayed as the memo
+ *      'type'  => [INTEGER], # from FareType enum class
+ *      'price' => [DECIMAL],
+ *      'cost'  => [DECIMAL], # optional
+ *      'notes' => '', # used as Transaction Group
+ *   ]);
+ *
+ * The event caller will check the 'type' to make sure that it
+ * will filter out fares that only apply to the current process
+ *
+ * The event will have a copy of the PIREP model, if it's applicable
+ */
+class Fares extends Event
+{
+    public $pirep;
+
+    /**
+     * @param Pirep|null $pirep
+     */
+    public function __construct(Pirep $pirep = null)
+    {
+        $this->pirep = $pirep;
+    }
+}

--- a/app/Listeners/ExpenseListener.php
+++ b/app/Listeners/ExpenseListener.php
@@ -4,6 +4,8 @@ namespace App\Listeners;
 
 use App\Contracts\Listener;
 use App\Events\Expenses;
+use App\Models\Enums\ExpenseType;
+use App\Models\Expense;
 
 class ExpenseListener extends Listener
 {
@@ -23,7 +25,7 @@ class ExpenseListener extends Listener
         // The transaction group is how it will show as a line item
         /*$expenses[] = new Expense([
             'type' => ExpenseType::FLIGHT,
-            'amount' => 15000,  # $150
+            'amount' => 150,  # $150
             'transaction_group' => '',
             'charge_to_user' => true|false
         ]);*/

--- a/app/Listeners/FareListener.php
+++ b/app/Listeners/FareListener.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Contracts\Listener;
+use App\Events\Fares;
+use App\Models\Enums\FareType;
+use App\Models\Fare;
+
+class FareListener extends Listener
+{
+    /**
+     * Return a list of additional fares/income items
+     *
+     * @param Fares $event
+     *
+     * @return mixed
+     */
+    public function handle(Fares $event)
+    {
+        $fares = [];
+
+        // This is an example of a fare to return
+        // You have the pirep on $event->pirep and any associated data
+        // Cost may be skipped at all if not needed
+        // Notes will be used as transaction group and it is how it will show as a line item
+        /*
+          $fares[] = new Fare([
+            'name'  => 'Duty Free Sales',
+            'type'  => FareType::PASSENGER,
+            'price' => 985,
+            'cost'  => 126,
+            'notes' => 'InFlight Sales',
+          ]);
+        */
+
+        return $fares;
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -3,11 +3,13 @@
 namespace App\Providers;
 
 use App\Events\Expenses;
+use App\Events\Fares;
 use App\Events\PirepFiled;
 use App\Events\UserStatsChanged;
 use App\Listeners\AwardHandler;
 use App\Listeners\BidEventHandler;
 use App\Listeners\ExpenseListener;
+use App\Listeners\FareListener;
 use App\Listeners\FinanceEventHandler;
 use App\Listeners\PirepEventsHandler;
 use App\Listeners\UserStateListener;
@@ -23,6 +25,10 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Expenses::class => [
             ExpenseListener::class,
+        ],
+
+        Fares::class => [
+            FareListener::class,
         ],
 
         PirepFiled::class => [


### PR DESCRIPTION
PR adds the ability to send in custom fares to pireps. An event is triggered during finance calculations, if returned by the listener any custom fares get applied to the pirep.

Same logic used as custom expenses.

Closes #1189 