### PR TITLE
Fix logical operator | Admin -> Pireps

### DIFF
--- a/resources/views/admin/pireps/actions.blade.php
+++ b/resources/views/admin/pireps/actions.blade.php
@@ -12,7 +12,8 @@
         {{ Form::button('Accept', ['type' => 'submit', 'class' => 'btn btn-success']) }}
         {{ Form::close() }}
       </td>
-    @elseif ($pirep->state === PirepState::PENDING || $pirep->state === PirepState::ACCEPTED)
+    @endif
+    @if ($pirep->state === PirepState::PENDING || $pirep->state === PirepState::ACCEPTED)
       <td>
         {{ Form::open(['url' => route('admin.pirep.status', [$pirep->id]),
                         'method' => 'post',


### PR DESCRIPTION
Reject button was not showing up for pending pireps due to usage of `@elseif`. Now both Accept and Reject buttons should be visible for pending pireps.