### PR TITLE
Add Aircraft > Simbrief relationship

### DIFF
--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -130,6 +130,11 @@ class Aircraft extends Model
         return $this->hasMany(Pirep::class, 'aircraft_id');
     }
 
+    public function simbriefs()
+    {
+        return $this->hasMany(Simbrief::class, 'aircraft_id');
+    }
+
     public function subfleet()
     {
         return $this->belongsTo(Subfleet::class, 'subfleet_id');


### PR DESCRIPTION
When needed all (or some) simbrief packs may be reached from aircraft level

Like `whereNotNull('flight_id')` will return only active simbrief packs generated for that aircraft, this also can be used along with SimBrief Block Aircraft setting etc.