### PR TITLE
Update UserFieldValue Model

### DIFF
--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -140,7 +140,7 @@ class Flight extends Model
      */
     public function getIdentAttribute(): string
     {
-        $flight_id = $this->airline->code;
+        $flight_id = optional($this->airline)->code;
         $flight_id .= $this->flight_number;
 
         if (filled($this->route_code)) {

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -219,7 +219,7 @@ class Pirep extends Model
      */
     public function getIdentAttribute(): string
     {
-        $flight_id = $this->airline->code;
+        $flight_id = optional($this->airline)->code;
         $flight_id .= $this->flight_number;
 
         if (filled($this->route_code)) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -126,7 +126,7 @@ class User extends Authenticatable
     {
         $length = setting('pilots.id_length');
 
-        return $this->airline->icao.str_pad($this->pilot_id, $length, '0', STR_PAD_LEFT);
+        return optional($this->airline)->icao.str_pad($this->pilot_id, $length, '0', STR_PAD_LEFT);
     }
 
     /**

--- a/app/Models/UserFieldValue.php
+++ b/app/Models/UserFieldValue.php
@@ -27,7 +27,7 @@ class UserFieldValue extends Model
      */
     public function getNameAttribute(): string
     {
-        return $this->field->name;
+        return isset($this->field) ? $this->field->name : null;
     }
 
     /**

--- a/app/Models/UserFieldValue.php
+++ b/app/Models/UserFieldValue.php
@@ -27,7 +27,7 @@ class UserFieldValue extends Model
      */
     public function getNameAttribute(): string
     {
-        return isset($this->field) ? $this->field->name : null;
+        return optional($this->field)->name;
     }
 
     /**

--- a/app/Models/UserFieldValue.php
+++ b/app/Models/UserFieldValue.php
@@ -21,7 +21,7 @@ class UserFieldValue extends Model
     ];
 
     public static $rules = [];
-    
+
     /**
      * Return related field's name along with field values
      */

--- a/app/Models/UserFieldValue.php
+++ b/app/Models/UserFieldValue.php
@@ -21,6 +21,14 @@ class UserFieldValue extends Model
     ];
 
     public static $rules = [];
+    
+    /**
+     * Return related field's name along with field values
+     */
+    public function getNameAttribute(): string
+    {
+        return $this->field->name;
+    }
 
     /**
      * Foreign Keys


### PR DESCRIPTION
Just added `name` attribute to get the name of the related UserField model.

Now when needed,  below simple code works to reach desired field value directly.

`$user->fields->where('name', 'IVAO PID')`

`$user->fields->where('name', 'IVAO PID')->first()->value` 

Without the name attribute, it was possible only with field_id or by doing loops in the collection to find out the proper field value by name match.