### PR TITLE
Fix `pirep->ident` usage issues

### DIFF
--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -80,7 +80,7 @@ class ProfileController extends Controller
     public function show($id)
     {
         /** @var \App\Models\User $user */
-        $user = User::with('airline', 'awards', 'current_airport', 'home_airport', 'fields.field', 'rank')
+        $user = User::with('airline', 'awards', 'current_airport', 'fields.field', 'home_airport', 'last_pirep', 'rank')
             ->where('id', $id)
             ->first();
 

--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -80,7 +80,7 @@ class ProfileController extends Controller
     public function show($id)
     {
         /** @var \App\Models\User $user */
-        $user = User::with(['awards', 'fields', 'fields.field'])
+        $user = User::with('airline', 'awards', 'current_airport', 'home_airport', 'fields.field', 'rank')
             ->where('id', $id)
             ->first();
 
@@ -89,13 +89,11 @@ class ProfileController extends Controller
             return redirect(route('frontend.dashboard.index'));
         }
 
-        $airports = $this->airportRepo->all();
         $userFields = $this->userRepo->getUserFields($user, true);
 
         return view('profile.index', [
             'user'       => $user,
             'userFields' => $userFields,
-            'airports'   => $airports,
             'acars'      => $this->acarsEnabled(),
         ]);
     }

--- a/resources/views/layouts/default/dashboard/pirep_card.blade.php
+++ b/resources/views/layouts/default/dashboard/pirep_card.blade.php
@@ -2,8 +2,7 @@
   <div class="row">
     <div class="col-sm-10">
       <p>
-        <a href="{{ route('frontend.pireps.show', [$pirep->id]) }}">
-          {{ $pirep->airline->code }}{{ $pirep->ident }}</a>
+        <a href="{{ route('frontend.pireps.show', [$pirep->id]) }}">{{ $pirep->ident }}</a>
         -
         {{ $pirep->dpt_airport->name }}
         (<a href="{{route('frontend.airports.show', [

--- a/resources/views/layouts/default/pireps/show.blade.php
+++ b/resources/views/layouts/default/pireps/show.blade.php
@@ -4,8 +4,7 @@
 @section('content')
   <div class="row">
     <div class="col-sm-8">
-      <h2>{{ $pirep->airline->icao }}{{ $pirep->ident }}
-        : {{ $pirep->dpt_airport_id }} to {{ $pirep->arr_airport_id }}</h2>
+      <h2>{{ $pirep->ident }} : {{ $pirep->dpt_airport_id }} to {{ $pirep->arr_airport_id }}</h2>
     </div>
 
     <div class="col-sm-4">

--- a/resources/views/layouts/default/pireps/table.blade.php
+++ b/resources/views/layouts/default/pireps/table.blade.php
@@ -17,8 +17,7 @@
     @foreach($pireps as $pirep)
       <tr>
         <td>
-          <a href="{{ route('frontend.pireps.show', [
-                      $pirep->id]) }}">{{ $pirep->airline->code }}{{ $pirep->ident }}</a>
+          <a href="{{ route('frontend.pireps.show', [$pirep->id]) }}">{{ $pirep->ident }}</a>
         </td>
         <td>
           @if($pirep->dpt_airport){{ $pirep->dpt_airport->name }}@endif

--- a/resources/views/layouts/default/widgets/latest_pireps.blade.php
+++ b/resources/views/layouts/default/widgets/latest_pireps.blade.php
@@ -2,15 +2,15 @@
   @foreach($pireps as $p)
     <tr>
       <td style="padding-right: 10px;">
-        <span class="title">{{ $p->airline->code }} {{ $p->flight_number }}</span>
+        <span class="title">{{ $p->ident }}</span>
       </td>
       <td>
         <a href="{{route('frontend.airports.show', [$p->dpt_airport_id])}}">{{$p->dpt_airport_id}}</a>
         &nbsp;-&nbsp;
-        <a href="{{route('frontend.airports.show', [$p->arr_airport_id])}}">{{$p->arr_airport_id}}</a>&nbsp;
-        @if(!empty($p->aircraft))
-          {{ optional($p->aircraft)->registration }} ({{ $p->aircraft->icao }})
-        @endif
+        <a href="{{route('frontend.airports.show', [$p->arr_airport_id])}}">{{$p->arr_airport_id}}</a>
+      </td>
+      <td>
+        {{ optional($p->aircraft)->ident }}
       </td>
     </tr>
   @endforeach


### PR DESCRIPTION
Found 3 places where `pirep->airline->code` and `pirep->ident` being used together resulting `TKTK1978/C.HR/L.19` style strange output.

Fixed those and also edited latest pireps widget blade to use pirep and aircraft idents.

Closes #1346 