### PR TITLE
Fix SimBrief Controller | flight relationships

### DIFF
--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -62,7 +62,7 @@ class SimBriefController
         $aircraft_id = $request->input('aircraft_id');
 
         /** @var Flight $flight */
-        $flight = $this->flightRepo->with(['airline', 'arr_airport', 'dpt_airport', 'fares.fare', 'subfleets'])->find($flight_id);
+        $flight = $this->flightRepo->with(['airline', 'arr_airport', 'dpt_airport', 'fares', 'subfleets'])->find($flight_id);
 
         if (!$flight) {
             flash()->error('Unknown flight');

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -134,7 +134,7 @@ class Aircraft extends Model
 
     public function simbriefs()
     {
-        return $this->hasMany(Simbrief::class, 'aircraft_id');
+        return $this->hasMany(SimBrief::class, 'aircraft_id');
     }
 
     public function subfleet()


### PR DESCRIPTION
Fix the fares relationship which was causing trouble when a flight had assigned fares

![error](https://user-images.githubusercontent.com/74361521/141480956-469b0990-25ef-4634-98a2-13ed4ef8cab1.png)
