### PR TITLE
Fix new user register with custom fields (RegisterController.php)

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -138,7 +138,7 @@ class RegisterController extends Controller
 
         Log::info('User registered: ', $user->toArray());
 
-        $userFields = UserField::all();
+        $userFields = UserField::where(['show_on_registration' => true, 'active' => true])->get();
         foreach ($userFields as $field) {
             $field_name = 'field_'.$field->slug;
             UserFieldValue::updateOrCreate([


### PR DESCRIPTION
Get only active and displayed UserFields.

Current code `UserField::all()` generates an exception 'cause it tries to get *all* custom user fields even they are not displayed at register form or not active at all.

![error_userfields](https://user-images.githubusercontent.com/74361521/148095854-abbf46e1-35b9-4061-863e-4b871fd0e2bf.png)
