### PR TITLE
Airline Flight Export

### DIFF
--- a/app/Http/Controllers/Admin/FlightController.php
+++ b/app/Http/Controllers/Admin/FlightController.php
@@ -311,7 +311,7 @@ class FlightController extends Controller
         $flights = $this->flightRepo->where($where)->get();
 
         $path = $exporter->exportFlights($flights);
-        return response()->download($path, $file_name, ['content-type' => 'text/csv',])->deleteFileAfterSend(true);
+        return response()->download($path, $file_name, ['content-type' => 'text/csv'])->deleteFileAfterSend(true);
     }
 
     /**

--- a/app/Http/Controllers/Admin/FlightController.php
+++ b/app/Http/Controllers/Admin/FlightController.php
@@ -300,14 +300,18 @@ class FlightController extends Controller
     public function export(Request $request)
     {
         $exporter = app(ExportService::class);
-        $flights = $this->flightRepo->all();
+
+        $where = [];
+        $file_name = 'flights.csv';
+        if ($request->input('airline_id')) {
+            $airline_id = $request->input('airline_id');
+            $where['airline_id'] = $airline_id;
+            $file_name = 'flights-'.$airline_id.'.csv';
+        }
+        $flights = $this->flightRepo->where($where)->get();
 
         $path = $exporter->exportFlights($flights);
-        return response()
-            ->download($path, 'flights.csv', [
-                'content-type' => 'text/csv',
-            ])
-            ->deleteFileAfterSend(true);
+        return response()->download($path, $file_name, ['content-type' => 'text/csv',])->deleteFileAfterSend(true);
     }
 
     /**

--- a/resources/views/admin/flights/index.blade.php
+++ b/resources/views/admin/flights/index.blade.php
@@ -2,8 +2,15 @@
 @section('title', 'Flights')
 
 @section('actions')
-  <li><a href="{{ route('admin.flights.export') }}"><i class="ti-plus"></i>Export to CSV</a></li>
-  <li><a href="{{ route('admin.flights.import') }}"><i class="ti-plus"></i>Import from CSV</a></li>
+  <li>
+    <a href="{{ route('admin.flights.export') }}@if(request()->get('airline_id')){{ '?airline_id='.request()->get('airline_id') }}@endif">
+      <i class="ti-plus"></i>
+      Export to CSV @if(request()->get('airline_id')) (Selected Airline) @endif
+    </a>
+  </li>
+  <li>
+    <a href="{{ route('admin.flights.import') }}"><i class="ti-plus"></i>Import from CSV</a>
+  </li>
   <li>
     <a href="{{ route('admin.flights.create') }}">
       <i class="ti-plus"></i>


### PR DESCRIPTION
Add ability to export flights of an airline only.

![export_def](https://user-images.githubusercontent.com/74361521/148759709-f2286d02-0952-4d74-ab05-44528abb2dc7.png)

![export](https://user-images.githubusercontent.com/74361521/148758765-5764da81-2079-45aa-b890-c4423c08aca1.png)

When at admin > flights, select the airline and filter/show its flights by clicking the find button. Now the export button will generate the csv file only for that airline's flights. 

In a multi airline environment helps a lot and saves time during flight management via export/import.