### PR TITLE
Add ability to change an award's active state

### DIFF
--- a/app/Database/migrations/2022_01_10_131604_update_awards_add_active.php
+++ b/app/Database/migrations/2022_01_10_131604_update_awards_add_active.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateAwardsAddActive extends Migration
+{
+    public function up()
+    {
+        Schema::table('awards', function (Blueprint $table) {
+            $table->boolean('active')->default(true)->nullable()->after('ref_model_params');
+        });
+    }
+}

--- a/app/Listeners/AwardHandler.php
+++ b/app/Listeners/AwardHandler.php
@@ -60,7 +60,7 @@ class AwardHandler extends Listener
      */
     public function checkForAwards($user)
     {
-        $awards = Award::all();
+        $awards = Award::where('active', 1)->get();
         foreach ($awards as $award) {
             $klass = $award->getReference($award, $user);
             if ($klass) {

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -21,6 +21,7 @@ class Award extends Model
         'image_url',
         'ref_model',
         'ref_model_params',
+        'active',
     ];
 
     public static $rules = [
@@ -29,6 +30,7 @@ class Award extends Model
         'image_url'        => 'nullable',
         'ref_model'        => 'required',
         'ref_model_params' => 'nullable',
+        'active'           => 'nullable',
     ];
 
     /**

--- a/resources/views/admin/awards/edit.blade.php
+++ b/resources/views/admin/awards/edit.blade.php
@@ -1,5 +1,5 @@
 @extends('admin.app')
-@section('title', "Edit \"$award->title\" Award")
+@section('title', "Edit \"$award->name\" Award")
 @section('content')
   <div class="card border-blue-bottom">
     <div class="content">

--- a/resources/views/admin/awards/fields.blade.php
+++ b/resources/views/admin/awards/fields.blade.php
@@ -18,17 +18,13 @@
     <p class="text-danger">{{ $errors->first('name') }}</p>
   </div>
 
-
   <div class="form-group col-sm-6">
     {!! Form::label('image', 'Image:') !!}
     <div class="callout callout-info">
       <i class="icon fa fa-info">&nbsp;&nbsp;</i>
       This is the image of the award. Be creative!
     </div>
-    {!! Form::text('image_url', null, [
-            'class' => 'form-control',
-            'placeholder' => 'Enter the url of the image location'
-        ]) !!}
+    {!! Form::text('image_url', null, ['class' => 'form-control', 'placeholder' => 'Enter the url of the image location']) !!}
     <p class="text-danger">{{ $errors->first('image_url') }}</p>
   </div>
 </div>
@@ -47,29 +43,31 @@
   <div class="form-group col-sm-6">
     <div>
       {{ Form::label('ref_model', 'Award Class:') }}
-      {{ Form::select('ref_model', $award_classes, null , [
-          'class' => 'form-control select2',
-          'id' => 'award_class_select',
-      ]) }}
+      {{ Form::select('ref_model', $award_classes, null, ['class' => 'form-control select2', 'id' => 'award_class_select']) }}
       <p class="text-danger">{{ $errors->first('ref_model') }}</p>
     </div>
-
     <div>
       {{ Form::label('ref_model_params', 'Award Class parameters') }}
       {{ Form::text('ref_model_params', null, ['class' => 'form-control']) }}
       <p class="text-danger">{{ $errors->first('ref_model_params') }}</p>
-
-      <p id="ref_model_param_description">
-
-      </p>
+      <p id="ref_model_param_description"></p>
     </div>
-
   </div>
 </div>
 
 <div class="row">
-  <!-- Submit Field -->
-  <div class="form-group col-sm-12">
+  {{-- Active/Deactive Checkbox --}}
+  <div class="form-group col-sm-6 text-left">
+    <div class="checkbox">
+      <label class="checkbox-inline">
+        {{ Form::label('active', 'Active: ') }}
+        {{ Form::hidden('active', false) }}
+        {{ Form::checkbox('active') }}
+      </label>
+    </div>
+  </div>
+  {{-- Form Actions --}}
+  <div class="form-group col-sm-6">
     <div class="pull-right">
       {!! Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) !!}
       <a href="{!! route('admin.awards.index') !!}" class="btn btn-warn">Cancel</a>

--- a/resources/views/admin/awards/table.blade.php
+++ b/resources/views/admin/awards/table.blade.php
@@ -1,40 +1,47 @@
 <table class="table table-hover table-responsive" id="awards-table">
   <thead>
-  <th>Name</th>
-  <th>Description</th>
-  <th>Image</th>
-  <th class="text-right">Action</th>
+    <th>Name</th>
+    <th>Description</th>
+    <th>Image</th>
+    <th class="text-center">Active</th>
+    <th class="text-right">Action</th>
   </thead>
   <tbody>
-  @foreach($awards as $award)
-    <tr>
-      <td>
-        <a href="{{ route('admin.awards.edit', [$award->id]) }}">
-          {{ $award->name }}</a>
-      </td>
-      <td>{{ $award->description }}</td>
-      <td>
-
-        @if($award->image_url)
-          <img src="{{ $award->image_url }}" name="{{ $award->name }}" alt="No Image Available" style="height: 100px"/>
-        @else
-          -
-        @endif
-      </td>
-      <td class="text-right">
-        {{ Form::open(['route' => ['admin.awards.destroy', $award->id], 'method' => 'delete']) }}
-        <a href="{{ route('admin.awards.edit', [$award->id]) }}" class='btn btn-sm btn-success btn-icon'>
-          <i class="fas fa-pencil-alt"></i></a>
-
-        {{ Form::button('<i class="fa fa-times"></i>', [
-                'type' => 'submit',
-                'class' => 'btn btn-sm btn-danger btn-icon',
-                'onclick' => "return confirm('Are you sure you want to delete this award?')"
-        ]) }}
-
-        {{ Form::close() }}
-      </td>
-    </tr>
-  @endforeach
+    @foreach($awards->sortby('name', SORT_NATURAL) as $award)
+      <tr>
+        <td>
+          <a href="{{ route('admin.awards.edit', [$award->id]) }}">{{ $award->name }}</a>
+        </td>
+        <td>
+          {{ $award->description }}
+        </td>
+        <td>
+          @if($award->image_url)
+            <img src="{{ $award->image_url }}" name="{{ $award->name }}" alt="No Image Available" style="height: 100px"/>
+          @else
+            -
+          @endif
+        </td>
+        <td class="text-center">
+          @if($award->active)
+            <i class="fas fa-check-circle fa-2x text-success"></i>
+          @else 
+            <i class="fas fa-times-circle fa-2x text-danger"></i>
+          @endif
+        </td>
+        <td class="text-right">
+          {{ Form::open(['route' => ['admin.awards.destroy', $award->id], 'method' => 'delete']) }}
+          <a href="{{ route('admin.awards.edit', [$award->id]) }}" class='btn btn-sm btn-success btn-icon'>
+            <i class="fas fa-pencil-alt"></i>
+          </a>
+          {{ Form::button('<i class="fa fa-times"></i>', [
+                  'type' => 'submit',
+                  'class' => 'btn btn-sm btn-danger btn-icon',
+                  'onclick' => "return confirm('Are you sure you want to delete this award?')"
+          ]) }}
+          {{ Form::close() }}
+        </td>
+      </tr>
+    @endforeach
   </tbody>
 </table>


### PR DESCRIPTION
Add active/passive check for awards and update the handler to pass only `active` ones to the checking process when needed.

![award_1](https://user-images.githubusercontent.com/74361521/148802829-faf48dea-d0f0-4329-9126-82993a98d94f.png)

![award_2](https://user-images.githubusercontent.com/74361521/148802851-d1614932-d15f-4ec5-b835-02a5207a0c83.png)

After migration all current awards defined by VA will be considered as active.