### PR TITLE
Fix flight and subfleet import with edited fares

### DIFF
--- a/app/Contracts/ImportExport.php
+++ b/app/Contracts/ImportExport.php
@@ -184,10 +184,10 @@ class ImportExport
                 $ret[$parent] = $children;
 
                 return $ret;
-            } else {
-                // This is not a query string, return it back untouched
-                return [$split_values[0]];
             }
+
+            // This is not a query string, return it back untouched
+            return [$split_values[0]];
         }
 
         foreach ($split_values as $value) {

--- a/app/Contracts/ImportExport.php
+++ b/app/Contracts/ImportExport.php
@@ -166,7 +166,28 @@ class ImportExport
                 return [];
             }
 
-            return [$split_values[0]];
+            if (strpos($split_values[0], '?') !== false) {
+                // This contains the query string, which turns it into a multi-level array
+                $query_str = explode('?', $split_values[0]);
+                $parent = trim($query_str[0]);
+
+                $children = [];
+                $kvp = explode('&', trim($query_str[1]));
+                foreach ($kvp as $items) {
+                    if (!$items) {
+                        continue;
+                    }
+
+                    $this->kvpToArray($items, $children);
+                }
+
+                $ret[$parent] = $children;
+
+                return $ret;
+            } else {
+                // This is not a query string, return it back untouched
+                return [$split_values[0]];
+            }
         }
 
         foreach ($split_values as $value) {

--- a/app/Services/ImportExport/FlightImporter.php
+++ b/app/Services/ImportExport/FlightImporter.php
@@ -253,8 +253,9 @@ class FlightImporter extends ImportExport
                 $fare_attributes = [];
             }
 
-            $fare = Fare::updateOrCreate(['code' => $fare_code], ['name' => $fare_code]);
+            $fare = Fare::firstOrCreate(['code' => $fare_code], ['name' => $fare_code]);
             $this->fareSvc->setForFlight($flight, $fare, $fare_attributes);
+            $fare->save();
         }
     }
 

--- a/app/Services/ImportExport/SubfleetImporter.php
+++ b/app/Services/ImportExport/SubfleetImporter.php
@@ -84,8 +84,9 @@ class SubfleetImporter extends ImportExport
                 $fare_attributes = [];
             }
 
-            $fare = Fare::updateOrCreate(['code' => $fare_code], ['name' => $fare_code]);
+            $fare = Fare::firstOrCreate(['code' => $fare_code], ['name' => $fare_code]);
             $this->fareSvc->setForSubfleet($subfleet, $fare, $fare_attributes);
+            $fare->save();
         }
     }
 }


### PR DESCRIPTION
Two fixes;

- Single value column entries with query string format are now properly handled like the multi value columns (ImportExport.php)
- Fixes the fare name update problem (FlightImporter.php and SubfleetImporter.php)

Closes #1378 
Closes #974 
