### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.9-fpm-alpine3.14
+FROM php:8.0-fpm-alpine
 
 WORKDIR /var/www/
 
@@ -24,14 +24,51 @@ RUN docker-php-ext-install \
   zip && \
   docker-php-ext-enable pdo_mysql opcache bcmath zip
 
-COPY . /var/www/
+RUN chown -R www-data:www-data /var/www
+
+USER www-data:www-data
+
+RUN mkdir /var/www/public \
+    /var/www/tests \
+    /var/www/modules \
+    /var/www/config \
+    /var/www/bootstrap \
+    /var/www/app \
+    /var/www/resources
+
+COPY --chown=www-data:www-data \
+    .htaccess \
+    swagger.yml \
+    composer.json \
+    artisan \
+    /var/www/
+
+COPY --chown=www-data:www-data public /var/www/public
+COPY --chown=www-data:www-data tests /var/www/test
+COPY --chown=www-data:www-data modules /var/www/modules
+COPY --chown=www-data:www-data config /var/www/config
+COPY --chown=www-data:www-data bootstrap /var/www/bootstrap
+COPY --chown=www-data:www-data app /var/www/app
+COPY --chown=www-data:www-data resources /var/www/resources
+
+RUN mkdir -p storage/app/public/avatars \
+    storage/app/public/uploads \
+    storage/app/import \
+    storage/docker/mysql \
+    storage/docker/redis \
+    storage/debugbar \
+    storage/framework/cache \
+    storage/framework/sessions \
+    storage/framework/views \
+    storage/logs \
+    storage/navdata \
+    storage/replay
+
 RUN composer install \
     --ignore-platform-reqs \
     --no-interaction \
     --no-plugins \
     --no-scripts \
     --prefer-dist
-
-#RUN chown -R www-data:www-data /var/www
 
 EXPOSE 9000


### PR DESCRIPTION
Removes point release on PHP for security / bug patches
Removes Alpine release restriction since it's coming tested from PHP

Specific includes from git repo vs. copy *

This takes the scenic route, as COPY doesn't copy the directory, just the contents of the directory, so first we create the directories that are required, then we copy the contents from the appropriate source directories, then we make the folder tree for storage as required.

The storage folder tree ends up getting mapped in volumes anyway.

Alternate ways of doing this would be:
- restructure the repo so the actual required contents of a base / live app container live within a directory by themselves
- wrap the Dockerfile in a build script and tar the required files -> ADD them to the container
