### PR TITLE
Update User Model (Name conversion for GDPR)

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -151,7 +151,7 @@ class User extends Authenticatable
         $first_name = $name_parts[0];
         $last_name = $name_parts[$count - 1];
 
-        return $first_name.' '.$last_name[0];
+        return $first_name.' '.mb_substr($last_name, 0, 1);
     }
 
     /**


### PR DESCRIPTION
Current GDPR compliant Private Name attribute is not compatible with multi byte strings, when encountered it fails and returns an empty string for the name_private attribute.

`substr($last_name, 0, 1)` or just `$last_name[0]` is not multi byte compatible, therefore only solution is to use `mb_substr`.

It also supports encoding definitions like `mb_substr($last_name, 0, 1, 'UTF-8')`

Admin;
![mb_1](https://user-images.githubusercontent.com/74361521/152693140-017224fc-bbef-4a39-8dae-84ff7476aa74.png)

Before (Current model result)
![mb_2](https://user-images.githubusercontent.com/74361521/152693154-812dfc1f-a78b-4115-b25c-2e34cf7b46e5.png)

After (Updated model result)
![mb_3](https://user-images.githubusercontent.com/74361521/152693166-b28bb9d1-57d5-4fc4-8596-ab60925ee8bc.png)
