### PR TITLE
Custom Code for Pilot IDents

### DIFF
--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -333,6 +333,13 @@
   options: ''
   type: int
   description: 'The length of a pilot''s ID'
+- key: pilots.id_code
+  name: 'Pilot ID Code'
+  group: pilots
+  value: ''
+  options: ''
+  type: text
+  description: 'Fixed ICAO code for pilot IDs'
 - key: pilots.auto_accept
   name: 'Auto Accept New Pilot'
   group: pilots

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -131,7 +131,7 @@ class User extends Authenticatable
     public function getIdentAttribute(): string
     {
         $length = setting('pilots.id_length');
-        $ident_code = filled(setting('pilots.id_code')) ? setting('pilots.id_code') :  optional($this->airline)->icao;
+        $ident_code = filled(setting('pilots.id_code')) ? setting('pilots.id_code') : optional($this->airline)->icao;
 
         return $ident_code.str_pad($this->pilot_id, $length, '0', STR_PAD_LEFT);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -131,8 +131,9 @@ class User extends Authenticatable
     public function getIdentAttribute(): string
     {
         $length = setting('pilots.id_length');
+        $ident_code = filled(setting('pilots.id_code')) ? setting('pilots.id_code') :  optional($this->airline)->icao;
 
-        return optional($this->airline)->icao.str_pad($this->pilot_id, $length, '0', STR_PAD_LEFT);
+        return $ident_code.str_pad($this->pilot_id, $length, '0', STR_PAD_LEFT);
     }
 
     /**


### PR DESCRIPTION
Adds a new setting to customize the ident or to use a fixed icao code in a multi airline environment.

If settings is null/empty, airline icao will be used as like before.

![pilot_ident](https://user-images.githubusercontent.com/74361521/152883845-1ed45568-bec3-4fdc-bc1e-ba3424605256.png)
