### PR TITLE
Check DRAFT state too when deciding auto approval by rank

### DIFF
--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -485,8 +485,8 @@ class PirepService extends Service
             $default_state = $pirep->state;
         }
 
-        // If pirep is still at PENDING state decide the default behavior by looking at rank settings
-        if ($pirep->state === PirepState::PENDING) {
+        // If pirep is still at PENDING or DRAFT state decide the default behavior by looking at rank settings
+        if ($pirep->state === PirepState::PENDING || $pirep->state === PirepState::DRAFT) {
             if ($pirep->source === PirepSource::ACARS && $pirep->user->rank->auto_approve_acars) {
                 $default_state = PirepState::ACCEPTED;
             } elseif ($pirep->source === PirepSource::MANUAL && $pirep->user->rank->auto_approve_manual) {


### PR DESCRIPTION
- If a manual pirep gets saved before being submitted, state is set to **DRAFT**.
- That state is not being considered during `auto approval by rank` check when the pirep gets submitted.
- So it passes the check and gets **_IN PROGRESS_** state 'cause it is the default state defined.

Pull request adds **DRAFT** state to `auto approval by rank` check.

Closes #1420 