### PR TITLE
Laravel9 Branch | User > name_private attribute

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -150,8 +150,7 @@ class User extends Authenticatable
     }
 
     /**
-     * Return a "privateized" version of someones name - First name full, rest of the names are
-     * initials
+     * Return a "privatized" version of someones name - First and middle names full, last name initials
      *
      * @return Attribute
      */
@@ -165,10 +164,18 @@ class User extends Authenticatable
                     return $name_parts[0];
                 }
 
-                $first_name = $name_parts[0];
+                $gdpr_name = '';
                 $last_name = $name_parts[$count - 1];
+                $loop_count = 0;
 
-                return $first_name.' '.mb_substr($last_name, 0, 1);
+                while ($loop_count < ($count - 1)) {
+                    $gdpr_name .= ' '.$name_parts[$loop_count];
+                    $loop_count++;
+                }
+
+                $gdpr_name .= ' '.mb_substr($last_name, 0, 1);
+
+                return mb_convert_case($gdpr_name, MB_CASE_TITLE);
             }
         );
     }


### PR DESCRIPTION
First and middle names are full, last name initial only. 
Capitalized first letters with php's multibyte convert case.

name : first middle surname
name_private : First Middle S

---

Even though a persons name is not enough to identify someone and can not be considered alone as "personal info" by GDPR, it is still possible to identify or narrow down a user to a "person" with combined other info.

Like the avatar image + name_private or name_private and pilot_ident, even becoming a member to a VA can narrow down search results. Thus any information published by the VA then can be considered as private etc.

Anyway, this is a strange subject to deal with.