### PR TITLE
Laravel9 | Frontend > Download Controller

### DIFF
--- a/app/Http/Controllers/Frontend/DownloadController.php
+++ b/app/Http/Controllers/Frontend/DownloadController.php
@@ -67,7 +67,7 @@ class DownloadController extends Controller
 
         // See if they inserted a link to the ACARS download
         try {
-            Module::find('VMSAcars');
+            Module::findOrFail('VMSAcars');
             $downloadUrl = DB::table('vmsacars_config')->where(['id' => 'download_url'])->first();
             if (!empty($downloadUrl) && !empty($downloadUrl->value)) {
                 $regrouped_files['ACARS'] = collect([


### PR DESCRIPTION
`findOrFail` was needed there to catch the exception, otherwise it was failing on a fresh install :)

Closes #1429 