### PR TITLE
Add baggage weight to acdata (SimBrief, Default Theme)

### DIFF
--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -127,7 +127,7 @@
               </div>
 
               {{-- Prepare Form Fields For SimBrief --}}
-                <input type="hidden" name="acdata" value="{'paxwgt':{{ round($pax_weight + $bag_weight) }}}">
+                <input type="hidden" name="acdata" value="{'paxwgt':{{ round($pax_weight) }}, 'bagwgt': {{ round($bag_weight) }}}">
                 @if($tpaxfig)
                   <input type="hidden" name="pax" value="{{ $tpaxfig }}">
                 @elseif(!$tpaxfig && $tcargoload)


### PR DESCRIPTION
Follow up for improved SimBrief API, sending separate pax and bag weights is possible now.

Core v7 already had them separated ;)