### PR TITLE
Fix docker dev links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ reset-installer:
 
 .PHONY: docker-test
 docker-test:
-	@docker compose -f docker-compose.local.yml up
+	@docker compose -f docker-compose.dev.yml up
 
 .PHONY: docker-clean
 docker-clean:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make docker-test
 
 # **OR** with docker-compose directly
 
-docker-compose -f docker-compose.yml -f docker-compose.local.yml up
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```
 
 Then go to `http://localhost`. If you're using dnsmasq, the `app` container is listening on `phpvms.test`, or you can add to your `/etc/hosts` file:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 #
 # Run with either `make docker-test` or the following Docker command:
-# docker-compose -f docker-compose.yml -f docker-compose.local.yml up
+# docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
 #
 ---
 services:


### PR DESCRIPTION
Updated `docker-compose.local.yml` to `docker-compose.dev.yml` to reflect the correct docker files