### PR TITLE
Display Members of Roles (Admin Controller & Blade)

### DIFF
--- a/app/Http/Controllers/Admin/RolesController.php
+++ b/app/Http/Controllers/Admin/RolesController.php
@@ -48,7 +48,7 @@ class RolesController extends Controller
     public function index(Request $request)
     {
         $this->rolesRepo->pushCriteria(new RequestCriteria($request));
-        $roles = $this->rolesRepo->findWhere(['read_only' => false]);
+        $roles = $this->rolesRepo->withCount('users')->findWhere(['read_only' => false]);
 
         return view('admin.roles.index', [
             'roles' => $roles,
@@ -117,7 +117,7 @@ class RolesController extends Controller
      */
     public function edit($id)
     {
-        $role = $this->rolesRepo->findWithoutFail($id);
+        $role = $this->rolesRepo->withCount('users')->with('users')->findWithoutFail($id);
 
         if (empty($role)) {
             Flash::error('Role not found');
@@ -126,6 +126,8 @@ class RolesController extends Controller
 
         return view('admin.roles.edit', [
             'role'        => $role,
+            'users'       => $role->users,
+            'users_count' => $role->users_count,
             'permissions' => $this->permsRepo->all(),
         ]);
     }

--- a/resources/views/admin/roles/table.blade.php
+++ b/resources/views/admin/roles/table.blade.php
@@ -1,12 +1,14 @@
 <table class="table table-hover table-responsive" id="roles-table">
   <thead>
   <th>Name</th>
-  <th></th>
+  <th class="text-center">Members</th>
+  <th class="text-right">Actions</th>
   </thead>
   <tbody>
   @foreach($roles as $role)
     <tr>
       <td>{{ $role->display_name }}</td>
+      <td class="text-center">{{ $role->users_count }}</td>
       <td class="text-right">
         {{ Form::open(['route' => ['admin.roles.destroy', $role->id], 'method' => 'delete']) }}
         <a href="{{ route('admin.roles.edit', [$role->id]) }}"

--- a/resources/views/admin/roles/users.blade.php
+++ b/resources/views/admin/roles/users.blade.php
@@ -2,15 +2,20 @@
   <!-- Code Field -->
   <div class="form-group col-sm-12">
     <div class="form-container">
-      <h6><i class="fas fa-users"></i>
-        &nbsp;Users
+      <h6>
+        <i class="fas fa-users mr-2"></i>
+        @if($users_count > 0) {{ $users_count.' users are assigned to this role' }} @else No Users @endif
       </h6>
       <div class="form-container-body">
-        <div class="row">
-          <div class="col-sm-12">
-            TO DO
+        @if($users_count > 0)
+          <div class="row">
+            <div class="col-sm-12">
+              @foreach($users as $u)
+                &nbsp;&bull;&nbsp;<a href="{{ route('admin.users.edit', [$u->id]) }}">{{ $u->ident.' '.$u->name }}</a>
+              @endforeach
+            </div>
           </div>
-        </div>
+        @endif
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds member count to roles\index and member list to roles\edit pages.

![image](https://user-images.githubusercontent.com/74361521/185478737-2c190e24-6f62-421b-a32c-342a3ebf16e9.png)

![image](https://user-images.githubusercontent.com/74361521/185479117-6de8bde2-d71c-41e2-9ef5-3b4b5b32040d.png)

PS: It was there with a note "TODO" for ages, it is better to have a least a count and list there instead of nothing ;) Maybe we can update it later with ajax to add/remove users live.