### PR TITLE
Fare Service Fix and Airport Importer Update

### DIFF
--- a/app/Services/FareService.php
+++ b/app/Services/FareService.php
@@ -169,7 +169,7 @@ class FareService extends Service
             }
         }
 
-        $fare->notes = '';
+        // $fare->notes = '';
         $fare->active = true;
 
         return $fare;

--- a/app/Services/ImportExport/AirportImporter.php
+++ b/app/Services/ImportExport/AirportImporter.php
@@ -18,7 +18,7 @@ class AirportImporter extends ImportExport
      */
     public static $columns = [
         'icao'                 => 'required',
-        'iata'                 => 'required',
+        'iata'                 => 'nullable',
         'name'                 => 'required',
         'location'             => 'nullable',
         'country'              => 'nullable',


### PR DESCRIPTION
- Fare Service : Return the note, do not force it to an empty string
- Airport Importer : Make IATA nullable (as in the model)

Closes #1465 