### PR TITLE
Patch currency subunit conversion

### DIFF
--- a/app/Support/Money.php
+++ b/app/Support/Money.php
@@ -33,7 +33,7 @@ class Money
     /**
      * Create from a dollar amount
      *
-     * @param mixed $amount The amount in pennies
+     * @param mixed $amount The amount in dollar
      *
      * @throws \UnexpectedValueException
      * @throws \InvalidArgumentException
@@ -52,12 +52,12 @@ class Money
      *
      * @param mixed $amount
      *
-     * @return float|int
+     * @return int
      */
     public static function convertToSubunit($amount)
     {
         $currency = setting('units.currency', 'USD');
-        return (int) $amount * config('money.'.$currency.'.subunit');
+        return (int) ($amount * config('money.'.$currency.'.subunit'));
     }
 
     /**

--- a/tests/FinanceTest.php
+++ b/tests/FinanceTest.php
@@ -712,20 +712,20 @@ class FinanceTest extends TestCase
 
         $journalRepo->post(
             $journal,
-            Money::createFromAmount(100),
+            Money::createFromAmount(100.5),
             null,
             $user
         );
 
         $balance = $journalRepo->getBalance($journal);
-        $this->assertEquals(100, $balance->getValue());
-        $this->assertEquals(100, $journal->balance->getValue());
+        $this->assertEquals(100.5, $balance->getValue());
+        $this->assertEquals(100.5, $journal->balance->getValue());
 
         // add another transaction
 
         $journalRepo->post(
             $journal,
-            Money::createFromAmount(25),
+            Money::createFromAmount(24.5),
             null,
             $user
         );
@@ -912,7 +912,7 @@ class FinanceTest extends TestCase
 
         // $this->assertCount(9, $transactions['transactions']);
         $this->assertEquals(3020, $transactions['credits']->getValue());
-        $this->assertEquals(2050.0, $transactions['debits']->getValue());
+        $this->assertEquals(2050.4, $transactions['debits']->getValue());
 
         // Check that all the different transaction types are there
         // test by the different groups that exist
@@ -967,7 +967,7 @@ class FinanceTest extends TestCase
 
 //        $this->assertCount(9, $transactions['transactions']);
         $this->assertEquals(3020, $transactions['credits']->getValue());
-        $this->assertEquals(2050.0, $transactions['debits']->getValue());
+        $this->assertEquals(2050.4, $transactions['debits']->getValue());
 
         // Check that all the different transaction types are there
         // test by the different groups that exist
@@ -1006,7 +1006,7 @@ class FinanceTest extends TestCase
 
         $transactions = $journalRepo->getAllForObject($pirep2);
         $this->assertEquals(3020, $transactions['credits']->getValue());
-        $this->assertEquals(2150.0, $transactions['debits']->getValue());
+        $this->assertEquals(2150.4, $transactions['debits']->getValue());
 
         // Check that all the different transaction types are there
         // test by the different groups that exist
@@ -1115,6 +1115,6 @@ class FinanceTest extends TestCase
 
         //        $this->assertCount(9, $transactions['transactions']);
         $this->assertEquals(3020, $transactions['credits']->getValue());
-        $this->assertEquals(2050.0, $transactions['debits']->getValue());
+        $this->assertEquals(2050.4, $transactions['debits']->getValue());
     }
 }


### PR DESCRIPTION
Bug:
In [line 60](https://github.com/nabeelio/phpvms/blob/f30a3bc1efc24ca1ef91533d3e9c00bc2daebf5c/app/Support/Money.php#L60)  in Money.php, `$amount` is cast to an integer before multiplying by the currency subunit.

Fix:
Do multiplication first before casting to an integer

Test:
FinanceTest.php is updated to test floating point handling.

Closes #1483 