### PR TITLE
Last login TimeStamp

### DIFF
--- a/app/Database/migrations/2023_01_28_174436_add_lastlogin_at_to_users.php
+++ b/app/Database/migrations/2023_01_28_174436_add_lastlogin_at_to_users.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('lastlogin_at')->nullable()->after('last_ip');
+        });
+    }
+};

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -7,6 +7,7 @@ use App\Exceptions\PilotIdNotFound;
 use App\Models\Enums\UserState;
 use App\Models\User;
 use App\Services\UserService;
+use Carbon\Carbon;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -113,6 +114,7 @@ class LoginController extends Controller
 
         if (setting('general.record_user_ip', true)) {
             $user->last_ip = $request->ip();
+            $user->lastlogin_at = Carbon::now();
             $user->save();
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,6 +39,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property string           discord_id
  * @property int              state
  * @property string           last_ip
+ * @property \Carbon\Carbon   lastlogin_at
  * @property bool             opt_in
  * @property Pirep[]          pireps
  * @property string           last_pirep_id
@@ -93,6 +94,7 @@ class User extends Authenticatable
         'toc_accepted',
         'opt_in',
         'last_ip',
+        'lastlogin_at',
         'notes',
         'created_at',
         'updated_at',
@@ -131,6 +133,13 @@ class User extends Authenticatable
         'email'    => 'required|email',
         'pilot_id' => 'required|integer',
         'callsign' => 'nullable|max:4',
+    ];
+
+    public $dates = [
+        'lastlogin_at',
+        'created_at',
+        'updated_at',
+        'deleted_at',
     ];
 
     /**

--- a/resources/views/admin/users/fields.blade.php
+++ b/resources/views/admin/users/fields.blade.php
@@ -109,16 +109,20 @@
         <td>@minutestotime($user->flight_time)</td>
       </tr>
       <tr>
-        <td>IP Address</td>
-        <td>{{ $user->last_ip ?? '-' }}</td>
-      </tr>
-      <tr>
         <td>Registered On</td>
         <td>{{ show_datetime($user->created_at) }}</td>
       </tr>
       <tr>
         <td>Last Login</td>
-        <td>{{ show_datetime($user->updated_at) }}</td>
+        <td>
+          @if(filled($user->lastlogin_at))
+            {{ show_datetime($user->lastlogin_at) }}
+          @endif
+        </td>
+      </tr>
+      <tr>
+        <td>IP Address</td>
+        <td>{{ $user->last_ip ?? '-' }}</td>
       </tr>
       <tr>
         <td>@lang('toc.title')</td>


### PR DESCRIPTION
Add a carbon timestamp for last login instead of using _updated_at_. Update login controller to save last login details along with user ip (both tied to the same setting due to GDPR)

Closes #1516 

**Possible Error/Exception Warning** 

If the admin is already logged off during update, when he/she tries to login after update there will be an exception about missing database field. 

**Workaround For Admins**

- Disable IP recording before update (re-enable it after completing migration and cleaning cache) or,
- Visit /update manually after the error (technically authentication is completed at that moment and process fails during model update only)