### PR TITLE
Send news to active and on leave users only

### DIFF
--- a/app/Notifications/NotificationEventsHandler.php
+++ b/app/Notifications/NotificationEventsHandler.php
@@ -98,7 +98,7 @@ class NotificationEventsHandler extends Listener
         }
 
         /** @var Collection $users */
-        $users = User::where($where)->where('state', '<>', UserState::DELETED)->get();
+        $users = User::where($where)->whereIn('state', [UserState::ACTIVE, UserState::ON_LEAVE])->get();
         if (empty($users) || $users->count() === 0) {
             return;
         }


### PR DESCRIPTION
As the title says, news should be broadcasted to only ACTIVE and ON LEAVE users, no need to use server resources to send out mails to inactive (pending, rejected, suspended, deleted) users.

Closes #1518 