### PR TITLE
Fix bug where clicking pagination clears filtered flights.

### DIFF
--- a/resources/views/layouts/default/flights/index.blade.php
+++ b/resources/views/layouts/default/flights/index.blade.php
@@ -15,7 +15,7 @@
   </div>
   <div class="row">
     <div class="col-12 text-center">
-      {{ $flights->links('pagination.default') }}
+      {{ $flights->appends(\Illuminate\Support\Facades\Request::except('page'))->links('pagination.default') }}
     </div>
   </div>
 @endsection


### PR DESCRIPTION
This fixes the bug where when navigating between pages in the pagination, it clears out all the filters from the results view. This doesn't solve the issue for the form clearing.