### PR TITLE
TypeRatingFix

### DIFF
--- a/resources/views/admin/typeratings/fields.blade.php
+++ b/resources/views/admin/typeratings/fields.blade.php
@@ -29,7 +29,7 @@
     <div class="checkbox">
       <label class="checkbox-inline">
         {{ Form::label('active', 'Active:') }}
-        {{ Form::hidden('active', false) }}
+        {{ Form::hidden('active', 0) }}
         {{ Form::checkbox('active') }}
       </label>
     </div>


### PR DESCRIPTION
Fixes `Integrity constraint violation: 1048 Column 'active' cannot be null` problem while saving inactive type ratings.

Closes #1536 