### PR TITLE
Fix Flight Edit (fields.blade.php)

### DIFF
--- a/resources/views/admin/flights/fields.blade.php
+++ b/resources/views/admin/flights/fields.blade.php
@@ -162,7 +162,11 @@
           <div class="form-group col-sm-4">
             {{ Form::label('distance', 'Distance:') }} <span class="description small">in nautical miles</span>
             <a href="#" class="airport_distance_lookup">Calculate</a>
-            {{ Form::text('distance', null, ['id' => 'distance', 'class' => 'form-control']) }}
+            @if(isset($flight->distance))
+              {{ Form::text('distance', $flight->distance['nmi'], null, ['id' => 'distance', 'class' => 'form-control']) }}
+            @else
+              {{ Form::text('distance', null, ['id' => 'distance', 'class' => 'form-control']) }}
+            @endif
             <p class="text-danger">{{ $errors->first('distance') }}</p>
           </div>
         </div>


### PR DESCRIPTION
A simple solution at blade level, which forces the form to use nautical miles (system unit) when editing a flight and passes that data back.

If this is a new flight creation, empty form field is displayed which will let v7 to calculate the distance during save operation or let the user to click calculate.

Closes #1543 