### PR TITLE
Fleet Identification Number for Aircraft

### DIFF
--- a/app/Database/migrations/2023_06_24_211137_add_fin_to_aircraft.php
+++ b/app/Database/migrations/2023_06_24_211137_add_fin_to_aircraft.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up()
+    {
+        Schema::table('aircraft', function (Blueprint $table) {
+            $table->unsignedInteger('fin')->unique()->nullable()->after('registration');
+        });
+    }
+};

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -50,6 +50,7 @@ class Aircraft extends Model
         'icao',
         'name',
         'registration',
+        'fin',
         'hex_code',
         'flight_time',
         'mtow',
@@ -63,23 +64,25 @@ class Aircraft extends Model
      * The attributes that should be casted to native types.
      */
     protected $casts = [
-        'subfleet_id'  => 'integer',
-        'mtow'         => 'float',
-        'zfw'          => 'float',
+        'fin'          => 'integer',
         'flight_time'  => 'float',
         'fuel_onboard' => FuelCast::class,
+        'mtow'         => 'float',
         'state'        => 'integer',
+        'subfleet_id'  => 'integer',
+        'zfw'          => 'float',
     ];
 
     /**
      * Validation rules
      */
     public static $rules = [
-        'subfleet_id'  => 'required',
-        'name'         => 'required',
-        'status'       => 'required',
-        'registration' => 'required',
+        'fin'          => 'nullable|numeric',
         'mtow'         => 'nullable|numeric',
+        'name'         => 'required',
+        'registration' => 'required',
+        'status'       => 'required',
+        'subfleet_id'  => 'required',
         'zfw'          => 'nullable|numeric',
     ];
 

--- a/resources/views/admin/aircraft/fields.blade.php
+++ b/resources/views/admin/aircraft/fields.blade.php
@@ -76,6 +76,12 @@
             {{ Form::text('registration', null, ['class' => 'form-control']) }}
             <p class="text-danger">{{ $errors->first('registration') }}</p>
           </div>
+
+          <div class="form-group col-sm-3">
+            {{ Form::label('fin', 'FIN:') }}
+            {{ Form::text('fin', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('fin') }}</p>
+          </div>
         </div>
 
         <div class="row">

--- a/resources/views/admin/aircraft/table.blade.php
+++ b/resources/views/admin/aircraft/table.blade.php
@@ -2,6 +2,7 @@
   <thead>
   <th>Name</th>
   <th style="text-align: center;">Registration</th>
+  <th style="text-align: center;">FIN</th>
   <th>Subfleet</th>
   <th style="text-align: center;">Hub</th>
   <th style="text-align: center;">Location</th>
@@ -14,6 +15,7 @@
     <tr>
       <td><a href="{{ route('admin.aircraft.edit', [$ac->id]) }}">{{ $ac->name }}</a></td>
       <td style="text-align: center;">{{ $ac->registration }}</td>
+      <td style="text-align: center;">{{ $ac->fin }}</td>
       <td>
         @if($ac->subfleet_id && $ac->subfleet)
           <a href="{{ route('admin.subfleets.edit', [$ac->subfleet_id]) }}">


### PR DESCRIPTION
Add FIN (Fleet Identification Number) field to aircraft model (as an unique unsigned integer)

Can be useful for easy identification of fleet members where registrations and names are not enough.

![image](https://github.com/nabeelio/phpvms/assets/74361521/3ec3f155-64b0-46d6-84c2-2d9076d0ed7a)

Closes #1554 