### PR TITLE
Fix Return Type Problem

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -175,12 +175,10 @@ class RegisterController extends Controller
      * Handle a registration request for the application.
      *
      * @param Request $request
-     *
      * @throws \Exception
-     *
-     * @return RedirectResponse
+     * @return RedirectResponse|View
      */
-    public function register(Request $request): RedirectResponse
+    public function register(Request $request): RedirectResponse|View
     {
         $this->validator($request->all())->validate();
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -175,9 +175,9 @@ class RegisterController extends Controller
      * Handle a registration request for the application.
      *
      * @param Request $request
-     * 
+     *
      * @throws \Exception
-     * 
+     *
      * @return RedirectResponse|View
      */
     public function register(Request $request): RedirectResponse|View

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -175,7 +175,9 @@ class RegisterController extends Controller
      * Handle a registration request for the application.
      *
      * @param Request $request
+     * 
      * @throws \Exception
+     * 
      * @return RedirectResponse|View
      */
     public function register(Request $request): RedirectResponse|View


### PR DESCRIPTION
Function returns either a view or redirect, both should be allowed.

Fixes `production.ERROR: App\Http\Controllers\Auth\RegisterController::register(): Return value must be of type Illuminate\Http\RedirectResponse, Illuminate\View\View returned` problem reported by @dougjuk