### PR TITLE
Admin | Flight Types and Users/Fields fixes

### DIFF
--- a/app/Http/Controllers/Admin/FlightController.php
+++ b/app/Http/Controllers/Admin/FlightController.php
@@ -141,7 +141,7 @@ class FlightController extends Controller
             'airlines'      => $this->airlineRepo->selectBoxList(),
             'airports'      => $this->airportRepo->selectBoxList(true, false),
             'alt_airports'  => $this->airportRepo->selectBoxList(true),
-            'flight_types'  => FlightType::select(true),
+            'flight_types'  => FlightType::select(false),
         ]);
     }
 

--- a/resources/views/admin/users/fields.blade.php
+++ b/resources/views/admin/users/fields.blade.php
@@ -66,9 +66,10 @@
     {{ Form::select('rank_id', $ranks, null, ['class' => 'form-control select2', 'placeholder' => 'Select Rank']) }}
   </div>
   <div class="form-group col-sm-4">
-    {{ Form::label('roles', 'Roles:') }}
-    {{ Form::select('roles[]', $roles, $user->roles->pluck('id'),
-        ['class' => 'form-control select2', 'placeholder' => 'Select Roles', 'multiple']) }}
+    @ability('admin', 'admin-user')
+      {{ Form::label('roles', 'Roles:') }}
+      {{ Form::select('roles[]', $roles, $user->roles->pluck('id'), ['class' => 'form-control select2', 'placeholder' => 'Select Roles', 'multiple']) }}
+    @endability
   </div>
 </div>
 


### PR DESCRIPTION
Closes #1566 (Controller update)
Closes #1568 (Blade update)

- Removes the "blank" entry for flight type dropdown (admin > flights > add flight)
- Make Roles field and dropdown for role selector available only to admin / admin-user (admin > user > edit)

![image](https://github.com/nabeelio/phpvms/assets/74361521/9ad6502a-7cea-4684-94c6-d5179b730e1f)

![image](https://github.com/nabeelio/phpvms/assets/74361521/7db42737-23d0-4982-823d-aeb6f35e9d69)
