### PR TITLE
Sortable Columns

### DIFF
--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -147,8 +147,7 @@ class FlightController extends Controller
             ->when($filter_by_user, function ($query) use ($allowed_flights) {
                 return $query->whereIn('id', $allowed_flights);
             })
-            ->orderBy('flight_number')
-            ->orderBy('route_leg')
+            ->sortable('flight_number', 'route_code', 'route_leg')
             ->paginate();
 
         $saved_flights = [];

--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -193,9 +193,8 @@ class PirepController extends Controller
             'fares',
         ];
 
-        $this->pirepRepo->with($with)
-            ->pushCriteria(new WhereCriteria($request, $where));
-        $pireps = $this->pirepRepo->orderBy('created_at', 'desc')->paginate();
+        $this->pirepRepo->with($with)->pushCriteria(new WhereCriteria($request, $where));
+        $pireps = $this->pirepRepo->sortable(['submitted_at' => 'desc'])->paginate();
 
         return view('pireps.index', [
             'user'   => $user,

--- a/app/Http/Controllers/Frontend/UserController.php
+++ b/app/Http/Controllers/Frontend/UserController.php
@@ -49,7 +49,7 @@ class UserController extends Controller
         $users = $this->userRepo
             ->withCount($with_count)
             ->with($with)
-            ->orderBy('pilot_id', 'asc')
+            ->sortable('id')
             ->paginate();
 
         return view('users.index', [

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Kyslik\ColumnSortable\Sortable;
 use Znck\Eloquent\Relations\BelongsToThrough as ZnckBelongsToThrough;
 use Znck\Eloquent\Traits\BelongsToThrough;
 
@@ -41,11 +42,12 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  */
 class Aircraft extends Model
 {
-    use HasFactory;
-    use SoftDeletes;
+    use BelongsToThrough;
     use ExpensableTrait;
     use FilesTrait;
-    use BelongsToThrough;
+    use HasFactory;
+    use SoftDeletes;
+    use Sortable;
 
     public $table = 'aircraft';
 
@@ -90,6 +92,24 @@ class Aircraft extends Model
         'status'       => 'required',
         'subfleet_id'  => 'required',
         'zfw'          => 'nullable|numeric',
+    ];
+
+    public $sortable = [
+        'subfleet_id',
+        'airport_id',
+        'hub_id',
+        'iata',
+        'icao',
+        'name',
+        'registration',
+        'fin',
+        'hex_code',
+        'flight_time',
+        'mtow',
+        'zfw',
+        'fuel_onboard',
+        'status',
+        'state',
     ];
 
     /**

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * @property mixed   id
@@ -31,6 +32,7 @@ class Airline extends Model
     use HasFactory;
     use JournalTrait;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'airlines';
 
@@ -68,12 +70,21 @@ class Airline extends Model
      * @var array
      */
     public static $rules = [
+        'callsign' => 'nullable',
         'country'  => 'nullable',
         'iata'     => 'nullable|max:5',
         'icao'     => 'required|max:5',
         'logo'     => 'nullable',
         'name'     => 'required',
-        'callsign' => 'nullable',
+    ];
+
+    public $sortable = [
+        'id',
+        'name',
+        'icao',
+        'iata',
+        'country',
+        'callsign',
     ];
 
     /**

--- a/app/Models/Airport.php
+++ b/app/Models/Airport.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * Class Airport
@@ -35,6 +36,7 @@ class Airport extends Model
     use FilesTrait;
     use HasFactory;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'airports';
 
@@ -87,6 +89,15 @@ class Airport extends Model
         'fuel_100ll_cost'      => 'nullable|numeric',
         'fuel_jeta_cost'       => 'nullable|numeric',
         'fuel_mogas_cost'      => 'nullable|numeric',
+    ];
+
+    public $sortable = [
+        'id',
+        'iata',
+        'icao',
+        'name',
+        'location',
+        'country',
     ];
 
     /**

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * The Award model
@@ -21,6 +22,7 @@ class Award extends Model
 {
     use HasFactory;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'awards';
 
@@ -40,6 +42,12 @@ class Award extends Model
         'ref_model'        => 'required',
         'ref_model_params' => 'nullable',
         'active'           => 'nullable',
+    ];
+
+    public $sortable = [
+        'id',
+        'name',
+        'description',
     ];
 
     /**

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * @property string     id
@@ -60,6 +61,7 @@ class Flight extends Model
     use HashIdTrait;
     use HasFactory;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'flights';
 
@@ -135,6 +137,23 @@ class Flight extends Model
         'level'                => 'nullable',
         'event_id'             => 'nullable|numeric',
         'user_id'              => 'nullable|numeric',
+    ];
+
+    public $sortable = [
+        'airline_id',
+        'flight_number',
+        'callsign',
+        'route_code',
+        'route_leg',
+        'dpt_airport_id',
+        'arr_airport_id',
+        'dpt_time',
+        'arr_time',
+        'distance',
+        'flight_time',
+        'flight_type',
+        'event_id',
+        'user_id',
     ];
 
     /**

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -6,6 +6,7 @@ use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Notifications\Notifiable;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * @property int       id
@@ -18,6 +19,7 @@ class News extends Model
 {
     use HasFactory;
     use Notifiable;
+    use Sortable;
 
     public $table = 'news';
 
@@ -30,6 +32,13 @@ class News extends Model
     public static $rules = [
         'subject' => 'required',
         'body'    => 'required',
+    ];
+
+    public $sortable = [
+        'id',
+        'subject',
+        'user_id',
+        'created_at',
     ];
 
     /**

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
 use Kleemans\AttributeEvents;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * @property string      id
@@ -78,6 +79,7 @@ class Pirep extends Model
     use HasFactory;
     use Notifiable;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'pireps';
 
@@ -163,6 +165,30 @@ class Pirep extends Model
         'level'          => 'nullable|numeric',
         'notes'          => 'nullable',
         'route'          => 'nullable',
+    ];
+
+    public $sortable = [
+        'user_id',
+        'airline_id',
+        'aircraft_id',
+        'event_id',
+        'flight_number',
+        'route_code',
+        'route_leg',
+        'flight_id',
+        'dpt_airport_id',
+        'arr_airport_id',
+        'alt_airport_id',
+        'distance',
+        'flight_time',
+        'fuel_used',
+        'landing_rate',
+        'score',
+        'flight_type',
+        'state',
+        'status',
+        'submitted_at',
+        'created_at',
     ];
 
     /**

--- a/app/Models/Rank.php
+++ b/app/Models/Rank.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * @property string name
@@ -21,6 +22,7 @@ class Rank extends Model
 {
     use HasFactory;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'ranks';
 
@@ -47,6 +49,14 @@ class Rank extends Model
         'hours'                => 'required|integer',
         'acars_base_pay_rate'  => 'nullable|numeric',
         'manual_base_pay_rate' => 'nullable|numeric',
+    ];
+
+    public $sortable = [
+        'id',
+        'name',
+        'hours',
+        'acars_base_pay_rate',
+        'manual_base_pay_rate',
     ];
 
     /*

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Kyslik\ColumnSortable\Sortable;
 
 /**
  * @property int     id
@@ -35,6 +36,7 @@ class Subfleet extends Model
     use FilesTrait;
     use HasFactory;
     use SoftDeletes;
+    use Sortable;
 
     public $fillable = [
         'airline_id',
@@ -70,6 +72,14 @@ class Subfleet extends Model
         'name'                       => 'required',
         'hub_id'                     => 'nullable',
         'ground_handling_multiplier' => 'nullable|numeric',
+    ];
+
+    public $sortable = [
+        'id',
+        'airline_id',
+        'hub_id',
+        'type',
+        'name'
     ];
 
     /**

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -79,7 +79,7 @@ class Subfleet extends Model
         'airline_id',
         'hub_id',
         'type',
-        'name'
+        'name',
     ];
 
     /**

--- a/app/Models/Typerating.php
+++ b/app/Models/Typerating.php
@@ -4,9 +4,12 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Kyslik\ColumnSortable\Sortable;
 
 class Typerating extends Model
 {
+    use Sortable;
+
     public $table = 'typeratings';
 
     protected $fillable = [
@@ -23,6 +26,13 @@ class Typerating extends Model
         'type'        => 'required',
         'description' => 'nullable',
         'image_url'   => 'nullable',
+    ];
+
+    public $sortable = [
+        'id',
+        'name',
+        'type',
+        'description',
     ];
 
     // Relationships

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Kyslik\ColumnSortable\Sortable;
 use Laratrust\Contracts\LaratrustUser;
 use Laratrust\Traits\HasRolesAndPermissions;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
@@ -66,6 +67,7 @@ class User extends Authenticatable implements LaratrustUser
     use JournalTrait;
     use Notifiable;
     use SoftDeletes;
+    use Sortable;
 
     public $table = 'users';
 
@@ -141,6 +143,22 @@ class User extends Authenticatable implements LaratrustUser
         'email'    => 'required|email',
         'pilot_id' => 'required|integer',
         'callsign' => 'nullable|max:4',
+    ];
+
+    public $sortable = [
+        'id',
+        'name',
+        'pilot_id',
+        'callsign',
+        'country',
+        'airline_id',
+        'rank_id',
+        'home_airport_id',
+        'curr_airport_id',
+        'flights',
+        'flight_time',
+        'transfer_time',
+        'created_at',
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         "akaunting/laravel-money": "^4.0.1",
         "staudenmeir/belongs-to-through": "^v2.13.0",
         "staudenmeir/eloquent-has-many-deep": "1.18.0",
-        "spatie/laravel-ignition": "^2.0"
+        "spatie/laravel-ignition": "^2.0",
+        "kyslik/column-sortable": "^6.5"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b7f93644d4d98198ab192b89947e87d",
+    "content-hash": "39c4011503c8328a9aa6d74f95d8dff9",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -3194,6 +3194,67 @@
                 "source": "https://github.com/kkszymanowski/traitor"
             },
             "time": "2022-03-02T17:32:19+00:00"
+        },
+        {
+            "name": "kyslik/column-sortable",
+            "version": "6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kyslik/column-sortable.git",
+                "reference": "80a7f053cf8e457be06d5fe59371f1b2b5cd8d03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kyslik/column-sortable/zipball/80a7f053cf8e457be06d5fe59371f1b2b5cd8d03",
+                "reference": "80a7f053cf8e457be06d5fe59371f1b2b5cd8d03",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^5.0|^7.0|^8.0",
+                "phpunit/phpunit": "^8.5|^9.5.10"
+            },
+            "type": "package",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Kyslik\\ColumnSortable\\ColumnSortableServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kyslik\\ColumnSortable\\": "src/ColumnSortable/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Kiesel",
+                    "email": "martin.kiesel@gmail.com",
+                    "role": "Developer and maintainer"
+                }
+            ],
+            "description": "Package for handling column sorting in Laravel 6.x",
+            "keywords": [
+                "column",
+                "laravel",
+                "sort",
+                "sortable",
+                "sorting"
+            ],
+            "support": {
+                "issues": "https://github.com/Kyslik/column-sortable/issues",
+                "source": "https://github.com/Kyslik/column-sortable/tree/6.5.0"
+            },
+            "time": "2023-02-17T09:46:34+00:00"
         },
         {
             "name": "laracasts/flash",

--- a/config/columnsortable.php
+++ b/config/columnsortable.php
@@ -1,0 +1,121 @@
+<?php
+
+return [
+
+    /*
+    spec columns
+    */
+    'columns'                       => [
+        'alpha'   => [
+            'rows'  => ['description', 'email', 'name', 'slug'],
+            'class' => 'fa fa-sort-alpha',
+        ],
+        'amount'  => [
+            'rows'  => ['amount', 'price'],
+            'class' => 'fa fa-sort-amount',
+        ],
+        'numeric' => [
+            'rows'  => ['created_at', 'updated_at', 'level', 'id', 'phone_number'],
+            'class' => 'fa fa-sort-numeric',
+        ],
+    ],
+
+    /*
+    whether icons should be enabled
+     */
+    'enable_icons'                  => true,
+
+    /*
+    defines icon set to use when sorted data is none above (alpha nor amount nor numeric)
+     */
+    'default_icon_set'              => 'fa fa-sort',
+
+    /*
+    icon that shows when generating sortable link while column is not sorted
+     */
+    'sortable_icon'                 => 'fa fa-sort',
+
+    /*
+    generated icon is clickable non-clickable (default)
+     */
+    'clickable_icon'                => false,
+
+    /*
+    icon and text separator (any string)
+    in case of 'clickable_icon' => true; separator creates possibility to style icon and anchor-text properly
+     */
+    'icon_text_separator'           => ' ',
+
+    /*
+    suffix class that is appended when ascending direction is applied
+     */
+    'asc_suffix'                    => '-asc',
+
+    /*
+    suffix class that is appended when descending direction is applied
+     */
+    'desc_suffix'                   => '-desc',
+
+    /*
+    default anchor class, if value is null none is added
+     */
+    'anchor_class'                  => null,
+
+    /*
+    default active anchor class, if value is null none is added
+     */
+    'active_anchor_class'           => null,
+
+    /*
+    default sort direction anchor class, if value is null none is added
+     */
+    'direction_anchor_class_prefix' => null,
+
+    /*
+    relation - column separator ex: detail.phone_number means relation "detail" and column "phone_number"
+     */
+    'uri_relation_column_separator' => '.',
+
+    /*
+    formatting function applied to name of column, use null to turn formatting off
+     */
+    'formatting_function'           => 'ucfirst',
+
+    /*
+    apply formatting function to custom titles as well as column names
+     */
+    'format_custom_titles'          => true,
+
+    /*
+    inject title parameter in query strings, use null to turn injection off
+    example: 'inject_title' => 't' will result in ..user/?t="formatted title of sorted column"
+     */
+    'inject_title_as'               => null,
+
+    /*
+    allow request modification, when default sorting is set but is not in URI (first load)
+     */
+    'allow_request_modification'    => true,
+
+    /*
+    default direction for: $user->sortable('id') usage
+     */
+    'default_direction'             => 'asc',
+
+    /*
+    default direction for non-sorted columns
+     */
+    'default_direction_unsorted'    => 'asc',
+
+    /*
+    use the first defined sortable column (Model::$sortable) as default
+    also applies if sorting parameters are invalid for example: 'sort' => 'name', 'direction' => ''
+     */
+    'default_first_column'          => false,
+
+    /*
+    join type: join vs leftJoin (default leftJoin)
+    for more information see https://github.com/Kyslik/column-sortable/issues/59
+    */
+    'join_type'                     => 'leftJoin',
+];

--- a/config/columnsortable.php
+++ b/config/columnsortable.php
@@ -49,12 +49,12 @@ return [
     /*
     suffix class that is appended when ascending direction is applied
      */
-    'asc_suffix'                    => '-asc',
+    'asc_suffix'                    => '-up',
 
     /*
     suffix class that is appended when descending direction is applied
      */
-    'desc_suffix'                   => '-desc',
+    'desc_suffix'                   => '-down',
 
     /*
     default anchor class, if value is null none is added

--- a/config/columnsortable.php
+++ b/config/columnsortable.php
@@ -3,11 +3,11 @@
 return [
     // spec columns
     'columns' => [
-        'alpha'   => [
+        'alpha' => [
             'rows'  => ['description', 'email', 'name', 'slug', 'registration', 'icao', 'iata', 'dpt_airport_id', 'arr_airport_id', 'home_airport_id', 'curr_airport_id', 'airport_id'],
             'class' => 'fa fa-sort-alpha',
         ],
-        'amount'  => [
+        'amount' => [
             'rows'  => ['amount', 'price', 'cost', 'balance'],
             'class' => 'fa fa-sort-amount',
         ],

--- a/config/columnsortable.php
+++ b/config/columnsortable.php
@@ -1,121 +1,76 @@
 <?php
 
 return [
-
-    /*
-    spec columns
-    */
-    'columns'                       => [
+    // spec columns
+    'columns' => [
         'alpha'   => [
-            'rows'  => ['description', 'email', 'name', 'slug'],
+            'rows'  => ['description', 'email', 'name', 'slug', 'registration', 'icao', 'iata', 'dpt_airport_id', 'arr_airport_id', 'home_airport_id', 'curr_airport_id', 'airport_id'],
             'class' => 'fa fa-sort-alpha',
         ],
         'amount'  => [
-            'rows'  => ['amount', 'price'],
+            'rows'  => ['amount', 'price', 'cost', 'balance'],
             'class' => 'fa fa-sort-amount',
         ],
         'numeric' => [
-            'rows'  => ['created_at', 'updated_at', 'level', 'id', 'phone_number'],
+            'rows'  => ['created_at', 'updated_at', 'submitted_at', 'level', 'id', 'phone_number', 'mtow', 'zfw', 'distance', 'flight_time', 'score', 'landing_rate'],
             'class' => 'fa fa-sort-numeric',
         ],
     ],
 
-    /*
-    whether icons should be enabled
-     */
-    'enable_icons'                  => true,
+    // whether icons should be enabled
+    'enable_icons' => true,
 
-    /*
-    defines icon set to use when sorted data is none above (alpha nor amount nor numeric)
-     */
-    'default_icon_set'              => 'fa fa-sort',
+    // defines icon set to use when sorted data is none above (alpha nor amount nor numeric)
+    'default_icon_set' => 'fa fa-sort',
 
-    /*
-    icon that shows when generating sortable link while column is not sorted
-     */
-    'sortable_icon'                 => 'fa fa-sort',
+    // icon that shows when generating sortable link while column is not sorted
+    'sortable_icon' => 'fa fa-sort',
 
-    /*
-    generated icon is clickable non-clickable (default)
-     */
-    'clickable_icon'                => false,
+    //generated icon is clickable non-clickable (default)
+    'clickable_icon' => false,
 
-    /*
-    icon and text separator (any string)
-    in case of 'clickable_icon' => true; separator creates possibility to style icon and anchor-text properly
-     */
-    'icon_text_separator'           => ' ',
+    // icon and text separator (any string), in case of 'clickable_icon' => true; separator creates possibility to style icon and anchor-text properly
+    'icon_text_separator' => ' ',
 
-    /*
-    suffix class that is appended when ascending direction is applied
-     */
-    'asc_suffix'                    => '-up',
+    // suffix class that is appended when ascending direction is applied (FA5 Compatible)
+    'asc_suffix' => '-up',
 
-    /*
-    suffix class that is appended when descending direction is applied
-     */
-    'desc_suffix'                   => '-down',
+    // suffix class that is appended when descending direction is applied (FA5 Compatible)
+    'desc_suffix' => '-down',
 
-    /*
-    default anchor class, if value is null none is added
-     */
-    'anchor_class'                  => null,
+    // default anchor class, if value is null none is added
+    'anchor_class' => null,
 
-    /*
-    default active anchor class, if value is null none is added
-     */
-    'active_anchor_class'           => null,
+    // default active anchor class, if value is null none is added
+    'active_anchor_class' => null,
 
-    /*
-    default sort direction anchor class, if value is null none is added
-     */
+    // default sort direction anchor class, if value is null none is added
     'direction_anchor_class_prefix' => null,
 
-    /*
-    relation - column separator ex: detail.phone_number means relation "detail" and column "phone_number"
-     */
+    // relation - column separator ex: detail.phone_number means relation "detail" and column "phone_number"
     'uri_relation_column_separator' => '.',
 
-    /*
-    formatting function applied to name of column, use null to turn formatting off
-     */
-    'formatting_function'           => 'ucfirst',
+    // formatting function applied to name of column, use null to turn formatting off
+    'formatting_function' => 'ucfirst',
 
-    /*
-    apply formatting function to custom titles as well as column names
-     */
-    'format_custom_titles'          => true,
+    // apply formatting function to custom titles as well as column names
+    'format_custom_titles' => true,
 
-    /*
-    inject title parameter in query strings, use null to turn injection off
-    example: 'inject_title' => 't' will result in ..user/?t="formatted title of sorted column"
-     */
-    'inject_title_as'               => null,
+    // inject title parameter in query strings, use null to turn injection off example: 'inject_title' => 't' will result in ..user/?t="formatted title of sorted column"
+    'inject_title_as' => null,
 
-    /*
-    allow request modification, when default sorting is set but is not in URI (first load)
-     */
-    'allow_request_modification'    => true,
+    // allow request modification, when default sorting is set but is not in URI (first load)
+    'allow_request_modification' => true,
 
-    /*
-    default direction for: $user->sortable('id') usage
-     */
-    'default_direction'             => 'asc',
+    // default direction for: $user->sortable('id') usage
+    'default_direction' => 'asc',
 
-    /*
-    default direction for non-sorted columns
-     */
-    'default_direction_unsorted'    => 'asc',
+    // default direction for non-sorted columns
+    'default_direction_unsorted' => 'asc',
 
-    /*
-    use the first defined sortable column (Model::$sortable) as default
-    also applies if sorting parameters are invalid for example: 'sort' => 'name', 'direction' => ''
-     */
-    'default_first_column'          => false,
+    // use the first defined sortable column (Model::$sortable) as default also applies if sorting parameters are invalid for example: 'sort' => 'name', 'direction' => ''
+    'default_first_column' => false,
 
-    /*
-    join type: join vs leftJoin (default leftJoin)
-    for more information see https://github.com/Kyslik/column-sortable/issues/59
-    */
-    'join_type'                     => 'leftJoin',
+    // join type: join vs leftJoin (default leftJoin) for more information see https://github.com/Kyslik/column-sortable/issues/59
+    'join_type' => 'leftJoin',
 ];

--- a/resources/views/layouts/default/flights/index.blade.php
+++ b/resources/views/layouts/default/flights/index.blade.php
@@ -15,7 +15,7 @@
   </div>
   <div class="row">
     <div class="col-12 text-center">
-      {{ $flights->appends(\Illuminate\Support\Facades\Request::except('page'))->links('pagination.default') }}
+      {{ $flights->withQueryString()->links('pagination.default') }}
     </div>
   </div>
 @endsection

--- a/resources/views/layouts/default/flights/table.blade.php
+++ b/resources/views/layouts/default/flights/table.blade.php
@@ -1,3 +1,19 @@
+<div class="row">
+  <div class="col">
+    <table class="table table-sm table-borderless align-middle text-nowrap mb-2">
+      <tr>
+        <th>@sortablelink('airline_id', __('common.airline'))</th>
+        <th>@sortablelink('flight_number', __('flights.flightnumber'))</th>
+        <th>@sortablelink('dpt_airport_id', __('airports.departure'))</th>
+        <th>@sortablelink('arr_airport_id', __('airports.arrival'))</th>
+        <th>@sortablelink('dpt_time', 'STD')</th>
+        <th>@sortablelink('arr_time', 'STA')</th>
+        <th>@sortablelink('distance', 'Distance')</th>
+        <th>@sortablelink('flight_time', 'Flight Time')</th>
+      </tr>
+    </table>
+  </div>
+</div>
 @foreach($flights as $flight)
   <div class="card border-blue-bottom">
     <div class="card-body" style="min-height: 0">

--- a/resources/views/layouts/default/pireps/index.blade.php
+++ b/resources/views/layouts/default/pireps/index.blade.php
@@ -16,7 +16,7 @@
   </div>
   <div class="row">
     <div class="col-12 text-center">
-      {{ $pireps->links('pagination.default') }}
+      {{ $pireps->withQueryString()->links('pagination.default') }}
     </div>
   </div>
 @endsection

--- a/resources/views/layouts/default/pireps/table.blade.php
+++ b/resources/views/layouts/default/pireps/table.blade.php
@@ -2,13 +2,13 @@
   <table class="table table-hover table-striped">
     <thead>
     <tr>
-      <th>{{ trans_choice('common.flight', 1) }}</th>
-      <th>@lang('common.departure')</th>
-      <th>@lang('common.arrival')</th>
-      <th>@lang('common.aircraft')</th>
-      <th class="text-center">@lang('flights.flighttime')</th>
-      <th class="text-center">@lang('common.status')</th>
-      <th>@lang('pireps.submitted')</th>
+      <th>@sortablelink('flight_number', trans_choice('common.flight', 1))</th>
+      <th>@sortablelink('dpt_airport_id', __('common.departure'))</th>
+      <th>@sortablelink('arr_airport_id', __('common.arrival'))</th>
+      <th>@sortablelink('aircraft_id', __('common.aircraft'))</th>
+      <th class="text-center">@sortablelink('flight_time', __('flights.flighttime'))</th>
+      <th class="text-center">@sortablelink('status', __('common.status'))</th>
+      <th>@sortablelink('submitted_at', __('pireps.submitted'))</th>
       <th></th>
     </tr>
     </thead>
@@ -29,7 +29,7 @@
         </td>
         <td>
           @if($pirep->aircraft)
-            {{ optional($pirep->aircraft)->name }}
+            {{ optional($pirep->aircraft)->ident }}
           @else
             -
           @endif

--- a/resources/views/layouts/default/users/index.blade.php
+++ b/resources/views/layouts/default/users/index.blade.php
@@ -10,7 +10,7 @@
   </div>
   <div class="row">
     <div class="col-12 text-center">
-      {{ $users->links('pagination.default') }}
+      {{ $users->withQueryString()->links('pagination.default') }}
     </div>
   </div>
 @endsection

--- a/resources/views/layouts/default/users/table.blade.php
+++ b/resources/views/layouts/default/users/table.blade.php
@@ -1,12 +1,12 @@
 <table class="table table-hover" id="users-table">
   <thead>
   <th></th>
-  <th>@lang('common.name')</th>
+  <th>@sortablelink('name', __('common.name'))</th>
   <th style="text-align: center"></th>
-  <th style="text-align: center">@lang('common.airline')</th>
-  <th style="text-align: center">@lang('user.location')</th>
-  <th style="text-align: center">{{ trans_choice('common.flight', 2) }}</th>
-  <th style="text-align: center">{{ trans_choice('common.hour', 2) }}</th>
+  <th style="text-align: center">@sortablelink('airline_id', __('common.airline'))</th>
+  <th style="text-align: center">@sortablelink('curr_airport_id', __('user.location'))</th>
+  <th style="text-align: center">@sortablelink('flights', trans_choice('common.flight', 2))</th>
+  <th style="text-align: center">@sortablelink('flight_time', trans_choice('common.hour', 2))</th>
   </thead>
   <tbody>
   @foreach($users as $user)


### PR DESCRIPTION
Allows sortable columns with pagination support.

Uses https://github.com/Kyslik/column-sortable 

Relevant models, controllers and default theme blades are updated to support sortable results with pagination.

![image](https://github.com/nabeelio/phpvms/assets/74361521/398a1f03-57f0-4de0-94b6-049c444feece)

![image](https://github.com/nabeelio/phpvms/assets/74361521/a5b05ee3-cadd-4007-a40f-b0c2dd9b424d)

![image](https://github.com/nabeelio/phpvms/assets/74361521/6163dcc1-4a66-47ba-9932-a74c626e49b9)
