### PR TITLE
Use default Providers and Aliases lists

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -30,34 +30,7 @@ return [
     'key'    => env('APP_KEY', 'base64:zdgcDqu9PM8uGWCtMxd74ZqdGJIrnw812oRMmwDF6KY='),
     'cipher' => 'AES-256-CBC',
 
-    'providers' => [
-
-        /*
-         * Laravel Framework Service Providers...
-         */
-        Illuminate\Auth\AuthServiceProvider::class,
-        Illuminate\Broadcasting\BroadcastServiceProvider::class,
-        Illuminate\Bus\BusServiceProvider::class,
-        Illuminate\Cache\CacheServiceProvider::class,
-        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
-        Illuminate\Cookie\CookieServiceProvider::class,
-        Illuminate\Database\DatabaseServiceProvider::class,
-        Illuminate\Encryption\EncryptionServiceProvider::class,
-        Illuminate\Filesystem\FilesystemServiceProvider::class,
-        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
-        Illuminate\Hashing\HashServiceProvider::class,
-        Illuminate\Mail\MailServiceProvider::class,
-        Illuminate\Notifications\NotificationServiceProvider::class,
-        Illuminate\Pagination\PaginationServiceProvider::class,
-        Illuminate\Pipeline\PipelineServiceProvider::class,
-        Illuminate\Queue\QueueServiceProvider::class,
-        Illuminate\Redis\RedisServiceProvider::class,
-        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
-        Illuminate\Session\SessionServiceProvider::class,
-        Illuminate\Translation\TranslationServiceProvider::class,
-        Illuminate\Validation\ValidationServiceProvider::class,
-        Illuminate\View\ViewServiceProvider::class,
-
+    'providers' =>  \Illuminate\Support\ServiceProvider::defaultProviders()->merge([
         /*
          * Package Service Providers...
          */
@@ -81,45 +54,14 @@ return [
         App\Providers\MeasurementsProvider::class,
         App\Providers\ObserverServiceProviders::class,
         App\Providers\RouteServiceProvider::class,
-    ],
+    ]),
 
-    'aliases' => [
-        'App'          => Illuminate\Support\Facades\App::class,
-        'Artisan'      => Illuminate\Support\Facades\Artisan::class,
-        'Auth'         => Illuminate\Support\Facades\Auth::class,
-        'Blade'        => Illuminate\Support\Facades\Blade::class,
-        'Cache'        => Illuminate\Support\Facades\Cache::class,
+    'aliases' => \Illuminate\Support\Facades\Facade::defaultAliases()->merge([
         'Carbon'       => Carbon::class,
-        'Config'       => Illuminate\Support\Facades\Config::class,
-        'Cookie'       => Illuminate\Support\Facades\Cookie::class,
-        'Crypt'        => Illuminate\Support\Facades\Crypt::class,
-        'DB'           => Illuminate\Support\Facades\DB::class,
-        'Eloquent'     => Illuminate\Database\Eloquent\Model::class,
-        'Event'        => Illuminate\Support\Facades\Event::class,
-        'File'         => Illuminate\Support\Facades\File::class,
         'Flash'        => Laracasts\Flash\Flash::class,
         'Form'         => Collective\Html\FormFacade::class,
-        'Gate'         => Illuminate\Support\Facades\Gate::class,
-        'Hash'         => Illuminate\Support\Facades\Hash::class,
         'Html'         => Collective\Html\HtmlFacade::class,
-        'Lang'         => Illuminate\Support\Facades\Lang::class,
-        'Log'          => Illuminate\Support\Facades\Log::class,
-        'Mail'         => Illuminate\Support\Facades\Mail::class,
-        'Notification' => Illuminate\Support\Facades\Notification::class,
-        'Password'     => Illuminate\Support\Facades\Password::class,
-        'Queue'        => Illuminate\Support\Facades\Queue::class,
-        'Redirect'     => Illuminate\Support\Facades\Redirect::class,
-        'Redis'        => Illuminate\Support\Facades\Redis::class,
-        'Request'      => Illuminate\Support\Facades\Request::class,
-        'Response'     => Illuminate\Support\Facades\Response::class,
-        'Route'        => Illuminate\Support\Facades\Route::class,
-        'Schema'       => Illuminate\Support\Facades\Schema::class,
-        'Session'      => Illuminate\Support\Facades\Session::class,
-        'Storage'      => Illuminate\Support\Facades\Storage::class,
         'Theme'        => Igaster\LaravelTheme\Facades\Theme::class,
-        'URL'          => Illuminate\Support\Facades\URL::class,
-        'Validator'    => Illuminate\Support\Facades\Validator::class,
-        'View'         => Illuminate\Support\Facades\View::class,
         'Yaml'         => Symfony\Component\Yaml\Yaml::class,
 
         // ENUMS
@@ -128,5 +70,5 @@ return [
         'PirepSource' => App\Models\Enums\PirepSource::class,
         'PirepState'  => App\Models\Enums\PirepState::class,
         'PirepStatus' => App\Models\Enums\PirepStatus::class,
-    ],
+    ]),
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -30,7 +30,7 @@ return [
     'key'    => env('APP_KEY', 'base64:zdgcDqu9PM8uGWCtMxd74ZqdGJIrnw812oRMmwDF6KY='),
     'cipher' => 'AES-256-CBC',
 
-    'providers' =>  \Illuminate\Support\ServiceProvider::defaultProviders()->merge([
+    'providers' => \Illuminate\Support\ServiceProvider::defaultProviders()->merge([
         /*
          * Package Service Providers...
          */
@@ -57,12 +57,12 @@ return [
     ]),
 
     'aliases' => \Illuminate\Support\Facades\Facade::defaultAliases()->merge([
-        'Carbon'       => Carbon::class,
-        'Flash'        => Laracasts\Flash\Flash::class,
-        'Form'         => Collective\Html\FormFacade::class,
-        'Html'         => Collective\Html\HtmlFacade::class,
-        'Theme'        => Igaster\LaravelTheme\Facades\Theme::class,
-        'Yaml'         => Symfony\Component\Yaml\Yaml::class,
+        'Carbon' => Carbon::class,
+        'Flash'  => Laracasts\Flash\Flash::class,
+        'Form'   => Collective\Html\FormFacade::class,
+        'Html'   => Collective\Html\HtmlFacade::class,
+        'Theme'  => Igaster\LaravelTheme\Facades\Theme::class,
+        'Yaml'   => Symfony\Component\Yaml\Yaml::class,
 
         // ENUMS
         'ActiveState' => App\Models\Enums\ActiveState::class,

--- a/config/app.php
+++ b/config/app.php
@@ -54,7 +54,7 @@ return [
         App\Providers\MeasurementsProvider::class,
         App\Providers\ObserverServiceProviders::class,
         App\Providers\RouteServiceProvider::class,
-    ]),
+    ])->toArray(),
 
     'aliases' => \Illuminate\Support\Facades\Facade::defaultAliases()->merge([
         'Carbon' => Carbon::class,
@@ -70,5 +70,5 @@ return [
         'PirepSource' => App\Models\Enums\PirepSource::class,
         'PirepState'  => App\Models\Enums\PirepState::class,
         'PirepStatus' => App\Models\Enums\PirepStatus::class,
-    ]),
+    ])->toArray(),
 ];


### PR DESCRIPTION
This will allow to have all the default providers and aliases of laravel in addition to ours. Some were missing until today (like the aliase Str) which can cause errors with certain dependencies that use it . Also laravel 10 uses this format for its configuration by default.