### PR TITLE
Update Flight Resource

### DIFF
--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -44,6 +44,7 @@ class Flight extends Resource
         $res = parent::toArray($request);
 
         // Display flight callsign if pilot ident usage is not forced by VA
+        // Check if there is a callsign too
         if (!empty($this->callsign) && !setting('simbrief.callsign', true)) {
             $res['ident'] = $this->atc.' | '.$this->ident;
         } else {

--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -45,8 +45,7 @@ class Flight extends Resource
 
         // Display flight callsign if pilot ident usage is not forced by VA
         if (!setting('simbrief.callsign', true)) {
-            $callsign = !empty($this->callsign) ? $this->airline->icao.$this->callsign : $this->airline->icao.$this->flight_number;
-            $res['ident'] = $callsign.' | '.$this->ident;
+            $res['ident'] = $this->atc.' | '.$this->ident;
         } else {
             $res['ident'] = $this->ident;
         }

--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -44,7 +44,7 @@ class Flight extends Resource
         $res = parent::toArray($request);
 
         // Display flight callsign if pilot ident usage is not forced by VA
-        if (!setting('simbrief.callsign', true)) {
+        if (!empty($this->callsign) && !setting('simbrief.callsign', true)) {
             $res['ident'] = $this->atc.' | '.$this->ident;
         } else {
             $res['ident'] = $this->ident;

--- a/app/Http/Resources/Flight.php
+++ b/app/Http/Resources/Flight.php
@@ -43,7 +43,13 @@ class Flight extends Resource
     {
         $res = parent::toArray($request);
 
-        $res['ident'] = $this->ident;
+        // Display flight callsign if pilot ident usage is not forced by VA
+        if (!setting('simbrief.callsign', true)) {
+            $callsign = !empty($this->callsign) ? $this->airline->icao.$this->callsign : $this->airline->icao.$this->flight_number;
+            $res['ident'] = $callsign.' | '.$this->ident;
+        } else {
+            $res['ident'] = $this->ident;
+        }
 
         if (empty($res['load_factor'])) {
             $res['load_factor'] = setting('flights.default_load_factor');

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -21,6 +21,7 @@ use Kyslik\ColumnSortable\Sortable;
 /**
  * @property string     id
  * @property mixed      ident
+ * @property mixed      atc
  * @property Airline    airline
  * @property int        airline_id
  * @property mixed      flight_number
@@ -194,6 +195,26 @@ class Flight extends Model
                 }
 
                 return $flight_id;
+            }
+        );
+    }
+
+    /**
+     * Get the flight atc callsign, JBU1900 or JBU8FK
+     */
+    public function atc(): Attribute
+    {
+        return Attribute::make(
+            get: function ($_, $attrs) {
+                $flight_atc = optional($this->airline)->icao;
+
+                if (!empty($this->callsign)) {
+                    $flight_atc .= $this->callsign;
+                } else {
+                    $flight_atc .= $this->flight_number;
+                }
+
+                return $flight_atc;
             }
         );
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property string           api_key
  * @property mixed            timezone
  * @property string           ident
+ * @property string           atc
  * @property string           curr_airport_id
  * @property string           home_airport_id
  * @property string           avatar
@@ -182,6 +183,23 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
                 ) : optional($this->airline)->icao;
 
                 return $ident_code.str_pad($attrs['pilot_id'], $length, '0', STR_PAD_LEFT);
+            }
+        );
+    }
+
+    /**
+     * Format the pilot atc callsign, either return alphanumeric callsign or ident
+     *
+     * @return Attribute
+     */
+    public function atc(): Attribute
+    {
+        return Attribute::make(
+            get: function ($_, $attrs) {
+                $ident_code = filled(setting('pilots.id_code')) ? setting('pilots.id_code') : optional($this->airline)->icao;
+                $atc = filled($attrs['callsign']) ? $ident_code.$attrs['callsign'] : $ident_code.$attrs['pilot_id'];
+
+                return $atc;
             }
         );
     }

--- a/resources/views/layouts/default/flights/show.blade.php
+++ b/resources/views/layouts/default/flights/show.blade.php
@@ -8,6 +8,9 @@
         <div class="col-12">
           <h2>
             {{ $flight->ident }}
+            @if(filled($flight->callsign) && !setting('simbrief.callsign', true))
+              {{ '| '. $flight->atc }}
+            @endif
             @if ($acars_plugin && $bid)
               <a href="vmsacars:bid/{{$bid->id}}" class="btn btn-info btn-sm float-right">Load in vmsACARS</a>
             @elseif ($acars_plugin)
@@ -56,10 +59,10 @@
                 <td>{{ $flight->route }}</td>
               </tr>
             @endif
-            @if(filled($flight->callsign))
+            @if(filled($flight->callsign) && !setting('simbrief.callsign', true))
               <tr>
                 <td>@lang('flights.callsign')</td>
-                <td>{{ $flight->airline->icao }} {{ $flight->callsign }}</td>
+                <td>{{ $flight->atc }}</td>
               </tr>
             @endif
             @if(filled($flight->notes))

--- a/resources/views/layouts/default/flights/table.blade.php
+++ b/resources/views/layouts/default/flights/table.blade.php
@@ -26,6 +26,9 @@
                     style="max-width: 80px; width: 100%; height: auto;"/>
               @endif
               {{ $flight->ident }}
+              @if(filled($flight->callsign) && !setting('simbrief.callsign', true))
+                {{ '| '. $flight->atc }}
+              @endif
             </a>
           </h5>
         </div>
@@ -63,9 +66,9 @@
           (<a href="{{route('frontend.airports.show', ['id' => $flight->arr_airport_id])}}">{{$flight->arr_airport_id}}</a>)
           @if($flight->arr_time), {{ $flight->arr_time }}@endif
           <br/>
-          @if(filled($flight->callsign))
+          @if(filled($flight->callsign) && !setting('simbrief.callsign', true))
             <span class="title">{{ strtoupper(__('flights.callsign')) }}&nbsp;</span>
-            {{ $flight->airline->icao }} {{ $flight->callsign }}
+            {{ $flight->atc }}
             <br/>
           @endif
           @if($flight->distance)


### PR DESCRIPTION
Closes #1607 

Adds callsign to flight ident, by checking simbrief callsign option.

When mentioned option is enabled, pilots will be forced to use their idents as callsign, so displaying a flight's callsign will be meaningless and confusing pilots. But when that option is not enabled, pilots should be able to see and use a flight's assigned callsign.

Callsign is either the flight number itself or a special alphanumeric string defined by airline per flight.