### PR TITLE
Remove airline name from German translation

### DIFF
--- a/resources/lang/de/auth.php
+++ b/resources/lang/de/auth.php
@@ -9,7 +9,7 @@ return [
     'fullname'                 => 'Username',
     'emailaddress'             => 'E-Mail Addresse',
     'fillcaptcha'              => 'Fülle das Captcha aus',
-    'tocaccept'                => 'Mit dem Registrieren stimmst du den Regeln der CEFO-VA zu.',
+    'tocaccept'                => 'Mit der Registrierung erklären Sie sich mit den Allgemeinen Geschäftsbedingungen einverstanden.',
     'register'                 => 'Registrieren',
     'registrationpending'      => 'Registrierung ausstehend',
     'pendingmessage'           => 'Deine Registrierung ist noch nicht bestätigt. Bitte prüfe deine E-Mails!',


### PR DESCRIPTION
Closes #1610 

Remove the airline name used in the old translation, provide a nameless generic text for the case.