### PR TITLE
Add cargo load factor

### DIFF
--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -235,13 +235,13 @@
   options: ''
   type: number
   description: 'How much the load factor can vary per-flight'
-- key: flights.different_cargo_load_factor
+- key: flights.use_cargo_load_factor
   name: 'Different Cargo Load Factor'
   group: flights
   value: false
   options: ''
   type: boolean
-  description: 'When enabled, v7 will use a different load factor for cargo and passengers fares'
+  description: 'When enabled these values will be used for cargo fares'
 - key: flights.default_cargo_load_factor
   name: 'Cargo Load Factor'
   group: flights

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -213,7 +213,7 @@
   value: true
   options: ''
   type: boolean
-  description: 'When enabled, an aircraft can only be used for one active Bid and Flight/Pirep' 
+  description: 'When enabled, an aircraft can only be used for one active Bid and Flight/Pirep'
 - key: bids.expire_time
   name: 'Expire Time'
   group: bids
@@ -235,6 +235,27 @@
   options: ''
   type: number
   description: 'How much the load factor can vary per-flight'
+- key: flights.different_cargo_load_factor
+  name: 'Different Cargo Load Factor'
+  group: flights
+  value: false
+  options: ''
+  type: boolean
+  description: 'When enabled, v7 will use a different load factor for cargo and passengers fares'
+- key: flights.default_cargo_load_factor
+  name: 'Cargo Load Factor'
+  group: flights
+  value: 32
+  options: ''
+  type: number
+  description: 'The default cargo load factor for a flight, as a percent'
+- key: flights.cargo_load_factor_variance
+  name: 'Cargo Load Factor Variance'
+  group: flights
+  value: 5
+  options: ''
+  type: number
+  description: 'How much the cargo load factor can vary per-flight'
 - key: simbrief.api_key
   name: 'Simbrief API Key'
   group: simbrief

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -150,8 +150,7 @@ class SimBriefController
             $loadmax = 100;
         }
 
-        if (setting('flights.different_cargo_load_factor', false))
-        {
+        if (setting('flights.different_cargo_load_factor', false)) {
             $cgolfactor = $flight->load_factor ?? setting('flights.default_cargo_load_factor');
             $cgolfactorv = $flight->load_factor_variance ?? setting('flights.cargo_load_factor_variance');
 

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -141,13 +141,32 @@ class SimBriefController
         $lfactorv = $flight->load_factor_variance ?? setting('flights.load_factor_variance');
 
         $loadmin = $lfactor - $lfactorv;
-        $loadmin = $loadmin < 0 ? 0 : $loadmin;
+        $loadmin = max($loadmin, 0);
 
         $loadmax = $lfactor + $lfactorv;
-        $loadmax = $loadmax > 100 ? 100 : $loadmax;
+        $loadmax = min($loadmax, 100);
 
         if ($loadmax === 0) {
             $loadmax = 100;
+        }
+
+        if (setting('flights.different_cargo_load_factor', false))
+        {
+            $cgolfactor = $flight->load_factor ?? setting('flights.default_cargo_load_factor');
+            $cgolfactorv = $flight->load_factor_variance ?? setting('flights.cargo_load_factor_variance');
+
+            $cgoloadmin = $cgolfactor - $cgolfactorv;
+            $cgoloadmin = max($cgoloadmin, 0);
+
+            $cgoloadmax = $cgolfactor + $cgolfactorv;
+            $cgoloadmax = min($cgoloadmax, 100);
+
+            if ($cgoloadmax === 0) {
+                $cgoloadmax = 100;
+            }
+        } else {
+            $cgoloadmin = $loadmin;
+            $cgoloadmax = $loadmax;
         }
 
         // Load fares for passengers
@@ -195,7 +214,7 @@ class SimBriefController
                 continue;
             }
 
-            $count = ceil((($fare->capacity - $tbagload) * rand($loadmin, $loadmax)) / 100);
+            $count = ceil((($fare->capacity - $tbagload) * rand($cgoloadmin, $cgoloadmax)) / 100);
             $tcargoload += $count;
             $cargo_load_sheet[] = [
                 'id'       => $fare->id,

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -150,7 +150,7 @@ class SimBriefController
             $loadmax = 100;
         }
 
-        if (setting('flights.different_cargo_load_factor', false)) {
+        if (setting('flights.use_cargo_load_factor ', false)) {
             $cgolfactor = $flight->load_factor ?? setting('flights.default_cargo_load_factor');
             $cgolfactorv = $flight->load_factor_variance ?? setting('flights.cargo_load_factor_variance');
 


### PR DESCRIPTION
If enabled, this will allow a different load factor for cargo than for passengers by default. If a flight contains a custom load factor, then this custom load factor will take precedence over the default passenger/cargo load factor, and we will have a loading percentage in the same range for both passengers and cargo. If the flight does not contain a custom load factor, then we revert to the default settings, with (if enabled) a different range for the passenger load factor and the cargo load factor.