### PR TITLE
fix getNextAvailablePilotId

### DIFF
--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -175,7 +175,7 @@ class UserService extends Service
      */
     public function getNextAvailablePilotId(): int
     {
-        return (int) User::max('pilot_id') + 1;
+        return (int) User::withTrashed()->max('pilot_id') + 1;
     }
 
     /**


### PR DESCRIPTION
If the last user to have created an account is deleted then the next one will have an error duplicating a unique key for the pilot id because until now the method to get the next pilot id did not take into account deleted accounts . With this update we take the max pilot id of both deleted and active accounts and we increment it for the next pilot id