### PR TITLE
Update RankImport.php

### DIFF
--- a/app/Services/LegacyImporter/LedgerImporter.php
+++ b/app/Services/LegacyImporter/LedgerImporter.php
@@ -43,7 +43,7 @@ class LedgerImporter extends BaseImporter
                 continue;
             }
 
-            $pilot_pay = Money::createFromAmount($row->amount * 100);
+            $pilot_pay = Money::createFromAmount($row->amount);
             $memo = 'Pilot payment';
 
             $financeSvc->debitFromJournal(

--- a/app/Services/LegacyImporter/RankImport.php
+++ b/app/Services/LegacyImporter/RankImport.php
@@ -17,8 +17,8 @@ class RankImport extends BaseImporter
         $rows = $this->db->readRows($this->table, $this->idField, $start);
         foreach ($rows as $row) {
             $rank = Rank::updateOrCreate(['name' => $row->rank], [
-                'image_url'           => $row->rankimage,
-                'hours'               => $row->minhours,
+                'image_url'            => $row->rankimage,
+                'hours'                => $row->minhours,
                 'acars_base_pay_rate'  => $row->payrate,
                 'manual_base_pay_rate' => $row->payrate,
             ]);

--- a/app/Services/LegacyImporter/RankImport.php
+++ b/app/Services/LegacyImporter/RankImport.php
@@ -19,8 +19,8 @@ class RankImport extends BaseImporter
             $rank = Rank::updateOrCreate(['name' => $row->rank], [
                 'image_url'           => $row->rankimage,
                 'hours'               => $row->minhours,
-                'acars_base_payrate'  => $row->payrate,
-                'manual_base_payrate' => $row->payrate,
+                'acars_base_pay_rate'  => $row->payrate,
+                'manual_base_pay_rate' => $row->payrate,
             ]);
 
             $this->idMapper->addMapping('ranks', $row->rankid, $rank->id);


### PR DESCRIPTION
v7 'ranks' table shows 
'acars_base_pay_rate'
'manual_base_pay_rate'

Leagacy importer shows
'acars_base_payrate'
'manual_base_payrate'

This correction will allow legacy import of the associated rank payrate from previous versions to v7.