### PR TITLE
Add Laravel Backup

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -51,10 +51,11 @@ class Kernel extends ConsoleKernel
         $schedule->command(Monthly::class)->monthlyOn(1);
 
         // When spatie-backups runs
-        /*if (config('backup.backup.enabled', false) === true) {
-            $schedule->command('backup:clean')->daily()->at('01:00');
-            $schedule->command('backup:run')->daily()->at('02:00');
-        }*/
+        if (config('backup.backup.enabled', false) === true) {
+            $schedule->command('backup:run')->daily()->at('01:00');
+            $schedule->command('backup:clean')->daily()->at('01:20');
+            $schedule->command('backup:monitor')->daily()->at('01:30');
+        }
 
         // Update the last time the cron was run
         /** @var CronService $cronSvc */

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-bcmath": "*",
         "ext-pdo": "*",
         "ext-intl": "*",
+        "ext-zip": "*",
         "fisharebest/ext-calendar": "^2.5",
         "symfony/flex": "^1.0",
         "symfony/polyfill-iconv": "~1.22.0",
@@ -80,7 +81,8 @@
         "staudenmeir/eloquent-has-many-deep": "1.18.0",
         "spatie/laravel-ignition": "^2.0",
         "kyslik/column-sortable": "^6.5",
-        "jlorente/laravel-data-migrations": "^2.0"
+        "jlorente/laravel-data-migrations": "^2.0",
+        "spatie/laravel-backup": "*"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2563608f7f005e90a1c1da153a340c99",
+    "content-hash": "a9512075f12b10b29d564c074041cb42",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -7050,6 +7050,69 @@
             "time": "2023-06-28T12:59:17+00:00"
         },
         {
+            "name": "spatie/db-dumper",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "bbd5ae0f331d47e6534eb307e256c11a65c8e24a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/bbd5ae0f331d47e6534eb307e256c11a65c8e24a",
+                "reference": "bbd5ae0f331d47e6534eb307e256c11a65c8e24a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "symfony/process": "^5.0|^6.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.22"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/db-dumper/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-06-27T08:34:52+00:00"
+        },
+        {
             "name": "spatie/flare-client-php",
             "version": "1.4.3",
             "source": {
@@ -7203,6 +7266,105 @@
             "time": "2023-09-19T15:29:52+00:00"
         },
         {
+            "name": "spatie/laravel-backup",
+            "version": "8.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-backup.git",
+                "reference": "b79f790cc856e67cce012abf34bf1c9035085dc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/b79f790cc856e67cce012abf34bf1c9035085dc1",
+                "reference": "b79f790cc856e67cce012abf34bf1c9035085dc1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zip": "^1.14.0",
+                "illuminate/console": "^10.10.0",
+                "illuminate/contracts": "^10.10.0",
+                "illuminate/events": "^10.10.0",
+                "illuminate/filesystem": "^10.10.0",
+                "illuminate/notifications": "^10.10.0",
+                "illuminate/support": "^10.10.0",
+                "league/flysystem": "^3.0",
+                "php": "^8.1",
+                "spatie/db-dumper": "^3.0",
+                "spatie/laravel-package-tools": "^1.6.2",
+                "spatie/laravel-signal-aware-command": "^1.2",
+                "spatie/temporary-directory": "^2.0",
+                "symfony/console": "^6.0",
+                "symfony/finder": "^6.0"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0",
+                "ext-pcntl": "*",
+                "laravel/slack-notification-channel": "^2.5",
+                "league/flysystem-aws-s3-v3": "^2.0|^3.0",
+                "mockery/mockery": "^1.4",
+                "nunomaduro/larastan": "^2.1",
+                "orchestra/testbench": "^8.0",
+                "pestphp/pest": "^1.20",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.1"
+            },
+            "suggest": {
+                "laravel/slack-notification-channel": "Required for sending notifications via Slack"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Backup\\BackupServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Helpers/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Backup\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel package to backup your application",
+            "homepage": "https://github.com/spatie/laravel-backup",
+            "keywords": [
+                "backup",
+                "database",
+                "laravel-backup",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-backup/issues",
+                "source": "https://github.com/spatie/laravel-backup/tree/8.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/spatie",
+                    "type": "github"
+                },
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "other"
+                }
+            ],
+            "time": "2023-11-20T08:21:45+00:00"
+        },
+        {
             "name": "spatie/laravel-ignition",
             "version": "2.3.1",
             "source": {
@@ -7293,6 +7455,201 @@
                 }
             ],
             "time": "2023-10-09T12:55:26+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "cc7c991555a37f9fa6b814aa03af73f88026a83d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/cc7c991555a37f9fa6b814aa03af73f88026a83d",
+                "reference": "cc7c991555a37f9fa6b814aa03af73f88026a83d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.28|^10.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^7.7|^8.0",
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^9.5.24",
+                "spatie/pest-plugin-test-time": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.16.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-23T09:04:39+00:00"
+        },
+        {
+            "name": "spatie/laravel-signal-aware-command",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-signal-aware-command.git",
+                "reference": "46cda09a85aef3fd47fb73ddc7081f963e255571"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-signal-aware-command/zipball/46cda09a85aef3fd47fb73ddc7081f963e255571",
+                "reference": "46cda09a85aef3fd47fb73ddc7081f963e255571",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.35|^9.0|^10.0",
+                "php": "^8.0",
+                "spatie/laravel-package-tools": "^1.4.3"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.2",
+                "ext-pcntl": "*",
+                "nunomaduro/collision": "^5.3|^6.0",
+                "orchestra/testbench": "^6.16|^7.0|^8.0",
+                "pestphp/pest-plugin-laravel": "^1.3",
+                "phpunit/phpunit": "^9.5",
+                "spatie/laravel-ray": "^1.17"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\SignalAwareCommand\\SignalAwareCommandServiceProvider"
+                    ],
+                    "aliases": {
+                        "Signal": "Spatie\\SignalAwareCommand\\Facades\\Signal"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\SignalAwareCommand\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Handle signals in artisan commands",
+            "homepage": "https://github.com/spatie/laravel-signal-aware-command",
+            "keywords": [
+                "laravel",
+                "laravel-signal-aware-command",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-signal-aware-command/issues",
+                "source": "https://github.com/spatie/laravel-signal-aware-command/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-01-14T21:10:59+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "efc258c9f4da28f0c7661765b8393e4ccee3d19c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/efc258c9f4da28f0c7661765b8393e4ccee3d19c",
+                "reference": "efc258c9f4da28f0c7661765b8393e4ccee3d19c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-25T07:13:36+00:00"
         },
         {
             "name": "spatie/valuestore",

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,0 +1,337 @@
+<?php
+
+return [
+
+    'backup' => [
+
+        /*
+         * The name of this application. You can use this name to monitor
+         * the backups.
+         */
+        'name' => env('APP_NAME', 'laravel-backup'),
+
+        'source' => [
+
+            'files' => [
+
+                /*
+                 * The list of directories and files that will be included in the backup.
+                 */
+                'include' => [
+                    base_path(),
+                ],
+
+                /*
+                 * These directories and files will be excluded from the backup.
+                 *
+                 * Directories used by the backup process will automatically be excluded.
+                 */
+                'exclude' => [
+                    base_path('vendor'),
+                    base_path('node_modules'),
+                ],
+
+                /*
+                 * Determines if symlinks should be followed.
+                 */
+                'follow_links' => true,
+
+                /*
+                 * Determines if it should avoid unreadable folders.
+                 */
+                'ignore_unreadable_directories' => false,
+
+                /*
+                 * This path is used to make directories in resulting zip-file relative
+                 * Set to `null` to include complete absolute path
+                 * Example: base_path()
+                 */
+                'relative_path' => null,
+            ],
+
+            /*
+             * The names of the connections to the databases that should be backed up
+             * MySQL, PostgreSQL, SQLite and Mongo databases are supported.
+             *
+             * The content of the database dump may be customized for each connection
+             * by adding a 'dump' key to the connection settings in config/database.php.
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'excludeTables' => [
+             *                'table_to_exclude_from_backup',
+             *                'another_table_to_exclude'
+             *            ]
+             *       ],
+             * ],
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,
+             *       ],
+             * ],
+             *
+             * For a complete list of available customization options, see https://github.com/spatie/db-dumper
+             */
+            'databases' => [
+                'mysql',
+            ],
+        ],
+
+        /*
+         * The database dump can be compressed to decrease disk space usage.
+         *
+         * Out of the box Laravel-backup supplies
+         * Spatie\DbDumper\Compressors\GzipCompressor::class.
+         *
+         * You can also create custom compressor. More info on that here:
+         * https://github.com/spatie/db-dumper#using-compression
+         *
+         * If you do not want any compressor at all, set it to null.
+         */
+        'database_dump_compressor' => \Spatie\DbDumper\Compressors\GzipCompressor::class,
+
+        /*
+         * If specified, the database dumped file name will contain a timestamp (e.g.: 'Y-m-d-H-i-s').
+         */
+        'database_dump_file_timestamp_format' => null,
+
+        /*
+         * The file extension used for the database dump files.
+         *
+         * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
+         * The file extension should be specified without a leading .
+         */
+        'database_dump_file_extension' => 'gzip',
+
+        'destination' => [
+            /*
+             * The compression algorithm to be used for creating the zip archive.
+             *
+             * If backing up only database, you may choose gzip compression for db dump and no compression at zip.
+             *
+             * Some common algorithms are listed below:
+             * ZipArchive::CM_STORE (no compression at all; set 0 as compression level)
+             * ZipArchive::CM_DEFAULT
+             * ZipArchive::CM_DEFLATE
+             * ZipArchive::CM_BZIP2
+             * ZipArchive::CM_XZ
+             *
+             * For more check https://www.php.net/manual/zip.constants.php and confirm it's supported by your system.
+             */
+            'compression_method' => ZipArchive::CM_DEFAULT,
+
+            /*
+             * The compression level corresponding to the used algorithm; an integer between 0 and 9.
+             *
+             * Check supported levels for the chosen algorithm, usually 1 means the fastest and weakest compression,
+             * while 9 the slowest and strongest one.
+             *
+             * Setting of 0 for some algorithms may switch to the strongest compression.
+             */
+            'compression_level' => 9,
+
+            /*
+             * The filename prefix used for the backup zip file.
+             */
+            'filename_prefix' => '',
+
+            /*
+             * The disk names on which the backups will be stored.
+             */
+            'disks' => explode(',', env('BACKUP_DISKS', 'local')),
+        ],
+
+        /*
+         * The directory where the temporary files will be stored.
+         */
+        'temporary_directory' => storage_path('app/backup-temp'),
+
+        /*
+         * The password to be used for archive encryption.
+         * Set to `null` to disable encryption.
+         */
+        'password' => env('BACKUP_ARCHIVE_PASSWORD'),
+
+        /*
+         * The encryption algorithm to be used for archive encryption.
+         * You can set it to `null` or `false` to disable encryption.
+         *
+         * When set to 'default', we'll use ZipArchive::EM_AES_256 if it is
+         * available on your system.
+         */
+        'encryption' => 'default',
+
+        /**
+         * The number of attempts, in case the backup command encounters an exception
+         */
+        'tries' => 1,
+
+        /**
+         * The number of seconds to wait before attempting a new backup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+    /*
+     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * For Slack you need to install laravel/slack-notification-channel.
+     *
+     * You can also use your own notification classes, just make sure the class is named after one of
+     * the `Spatie\Backup\Notifications\Notifications` classes.
+     */
+    'notifications' => [
+
+        'notifications' => [
+            \Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
+
+            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
+        ],
+
+        /*
+         * Here you can specify the notifiable to which the notifications should be sent. The default
+         * notifiable will use the variables specified in this config file.
+         */
+        'notifiable' => \Spatie\Backup\Notifications\Notifiable::class,
+
+        'mail' => [
+            'to' => env('BACKUP_NOTIFICATIONS_MAIL_TO', 'your@example.com'),
+
+            'from' => [
+                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'name' => env('MAIL_FROM_NAME', 'Example'),
+            ],
+        ],
+
+        'slack' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is set to null the default channel of the webhook will be used.
+             */
+            'channel' => null,
+
+            'username' => null,
+
+            'icon' => null,
+
+        ],
+
+        'discord' => [
+            'webhook_url' => env('BACKUP_DISCORD_WEBHOOK_URL', ''),
+
+            /*
+             * If this is an empty string, the name field on the webhook will be used.
+             */
+            'username' => env('BACKUP_DISCORD_USERNAME', ''),
+
+            /*
+             * If this is an empty string, the avatar on the webhook will be used.
+             */
+            'avatar_url' => env('BACKUP_DISCORD_AVATAR_URL', ''),
+        ],
+    ],
+
+    /*
+     * Here you can specify which backups should be monitored.
+     * If a backup does not meet the specified requirements the
+     * UnHealthyBackupWasFound event will be fired.
+     */
+    'monitor_backups' => [
+        [
+            'name' => env('APP_NAME', 'laravel-backup'),
+            'disks' => explode(',', env('BACKUP_DISKS', 'local')),
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+
+        /*
+        [
+            'name' => 'name of the second app',
+            'disks' => ['local', 's3'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+        */
+    ],
+
+    'cleanup' => [
+        /*
+         * The strategy that will be used to cleanup old backups. The default strategy
+         * will keep all backups for a certain amount of days. After that period only
+         * a daily backup will be kept. After that period only weekly backups will
+         * be kept and so on.
+         *
+         * No matter how you configure it the default strategy will never
+         * delete the newest backup.
+         */
+        'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
+
+        'default_strategy' => [
+
+            /*
+             * The number of days for which backups must be kept.
+             */
+            'keep_all_backups_for_days' => 7,
+
+            /*
+             * After the "keep_all_backups_for_days" period is over, the most recent backup
+             * of that day will be kept. Older backups within the same day will be removed.
+             * If you create backups only once a day, no backups will be removed yet.
+             */
+            'keep_daily_backups_for_days' => 16,
+
+            /*
+             * After the "keep_daily_backups_for_days" period is over, the most recent backup
+             * of that week will be kept. Older backups within the same week will be removed.
+             * If you create backups only once a week, no backups will be removed yet.
+             */
+            'keep_weekly_backups_for_weeks' => 8,
+
+            /*
+             * After the "keep_weekly_backups_for_weeks" period is over, the most recent backup
+             * of that month will be kept. Older backups within the same month will be removed.
+             */
+            'keep_monthly_backups_for_months' => 4,
+
+            /*
+             * After the "keep_monthly_backups_for_months" period is over, the most recent backup
+             * of that year will be kept. Older backups within the same year will be removed.
+             */
+            'keep_yearly_backups_for_years' => 2,
+
+            /*
+             * After cleaning up the backups remove the oldest backup until
+             * this amount of megabytes has been reached.
+             */
+            'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
+        ],
+
+        /**
+         * The number of attempts, in case the cleanup command encounters an exception
+         */
+        'tries' => 1,
+
+        /**
+         * The number of seconds to wait before attempting a new cleanup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+];

--- a/config/backup.php
+++ b/config/backup.php
@@ -10,6 +10,8 @@ return [
          */
         'name' => env('APP_NAME', 'laravel-backup'),
 
+        'enabled' => env('BACKUP_ENABLED', false),
+
         'source' => [
 
             'files' => [

--- a/config/backup.php
+++ b/config/backup.php
@@ -195,9 +195,9 @@ return [
             \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
             \Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification::class        => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
 
-            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification::class   => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
-            \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
-            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification::class  => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification::class   => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', '')),
+            \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', '')),
+            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification::class  => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', '')),
         ],
 
         /*

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     'backup' => [
 
         /*
@@ -192,13 +191,13 @@ return [
     'notifications' => [
 
         'notifications' => [
-            \Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification::class         => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
             \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
-            \Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification::class => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification::class        => explode(',', env('BACKUP_FAILED_NOTIFICATIONS_CHANNELS', 'mail')),
 
-            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification::class   => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
             \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
-            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification::class => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
+            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification::class  => explode(',', env('BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS', 'mail')),
         ],
 
         /*
@@ -212,7 +211,7 @@ return [
 
             'from' => [
                 'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-                'name' => env('MAIL_FROM_NAME', 'Example'),
+                'name'    => env('MAIL_FROM_NAME', 'Example'),
             ],
         ],
 
@@ -252,10 +251,10 @@ return [
      */
     'monitor_backups' => [
         [
-            'name' => env('APP_NAME', 'laravel-backup'),
-            'disks' => explode(',', env('BACKUP_DISKS', 'local')),
+            'name'          => env('APP_NAME', 'laravel-backup'),
+            'disks'         => explode(',', env('BACKUP_DISKS', 'local')),
             'health_checks' => [
-                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class          => 1,
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
             ],
         ],


### PR DESCRIPTION
This PR adds `spatie/laravel-backup` which will allow admins to backup their database. Here are some important setting that can be set in the .env:

-`BACKUP_ENABLED`: true/false (default)
-`BACKUP_DISKS`: comma-separated, local by default. Create disks in `config/filesystems.php`.
-`BACKUP_ARCHIVE_PASSWORD`: AES256 encryption password if set. empty/null = disabled (default)
-`BACKUP_FAILED_NOTIFICATIONS_CHANNELS`: `mail` (default), `discord`, `mail,discord`, or empty.
-`BACKUP_SUCCEED_NOTIFICATIONS_CHANNELS`: `mail`, `discord`, `mail,discord`, or empty (default)
-`BACKUP_NOTIFICATIONS_MAIL_TO`: Email for notifications.
-`BACKUP_DISCORD_WEBHOOK_URL`: Discord webhook URL.
-`BACKUP_DISCORD_USERNAME`/`BACKUP_DISCORD_AVATAR_URL`: Discord customization.
