### PR TITLE
Improve LatestPireps Widget

### DIFF
--- a/app/Widgets/LatestPireps.php
+++ b/app/Widgets/LatestPireps.php
@@ -24,13 +24,15 @@ class LatestPireps extends Widget
         $pirepRepo = app(PirepRepository::class);
 
         $pireps = $pirepRepo
-            ->with(['airline', 'aircraft'])
-            ->whereNotInOrder('state', [
-                PirepState::CANCELLED,
+            ->with(['airline', 'aircraft', 'user'])
+            ->whereNotIn('state', [
                 PirepState::DRAFT,
                 PirepState::IN_PROGRESS,
-            ], 'submitted_at', 'desc')
-            ->recent($this->config['count']);
+                PirepState::CANCELLED,
+            ])
+            ->orderBy('submitted_at', 'desc')
+            ->take($this->config['count'])
+            ->get();
 
         return view('widgets.latest_pireps', [
             'config' => $this->config,


### PR DESCRIPTION
Closes #1695 

Using `whereNotInOrder()` along with `recent()` somehow is not generating the expected result. Thus switched to more classic eloquent query, separated `whereNotIn()` and used `orderBy()` along with `take()`.

Also added the user model to eager loading.

PS: Admin > Pireps index controller should also use `submitted_at` field to sort the pireps for admins/staff, using `created_at` there creates confusion. This is handled in another PR thus not present here.