### PR TITLE
Allow verification settings for smtp via env

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -4,13 +4,16 @@ return [
     'default' => env('MAIL_MAILER', 'smtp'),
     'mailers' => [
         'smtp' => [
-            'transport'  => 'smtp',
-            'host'       => env('MAIL_HOST', 'smtp.mailgun.org'),
-            'port'       => env('MAIL_PORT', 587),
-            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
-            'username'   => env('MAIL_USERNAME'),
-            'password'   => env('MAIL_PASSWORD'),
-            'timeout'    => null,
+            'transport'         => 'smtp',
+            'host'              => env('MAIL_HOST', 'smtp.mailgun.org'),
+            'port'              => env('MAIL_PORT', 587),
+            'encryption'        => env('MAIL_ENCRYPTION', 'tls'),
+            'username'          => env('MAIL_USERNAME'),
+            'password'          => env('MAIL_PASSWORD'),
+            'timeout'           => null,
+            'verify_peer'       => env('MAIL_VERIFY_PEER', true),
+            'verify_peer_name'  => env('MAIL_VERIFY_PEER_NAME', true),
+            'allow_self_signed' => env('MAIL_ALLOW_SELF_SIGNED', false),
         ],
 
         'ses' => [


### PR DESCRIPTION
On some VPS services with some control panels installed, outgoing mail verification may fail due to self signed certificates and peer verification.

To overcome this, these settings must be turned off and we should be able to change them in `.env` when needed.

