### PR TITLE
Fix module cache

### DIFF
--- a/app/Support/Modules/DatabaseActivator.php
+++ b/app/Support/Modules/DatabaseActivator.php
@@ -85,17 +85,24 @@ class DatabaseActivator implements ActivatorInterface
         try {
             if (app()->environment('production')) {
                 $cache = config('cache.keys.MODULES');
-                $modules = Cache::remember($cache['key'], $cache['time'], function () {
-                    \App\Models\Module::all();
+                $retVal = Cache::remember($cache['key'], $cache['time'], function () {
+                    $modules = \App\Models\Module::select('name', 'enabled')->get();
+
+                    $retValCache = [];
+                    foreach ($modules as $i) {
+                        $retValCache[$i->name] = $i->enabled;
+                    }
+
+                    return $retValCache;
                 });
             } else {
-                $modules = \App\Models\Module::all();
-            }
-            $retVal = [];
-            foreach ($modules as $i) {
-                $retVal[$i->name] = $i->enabled;
-            }
+                $modules = \App\Models\Module::select('name', 'enabled')->get();
 
+                $retVal = [];
+                foreach ($modules as $i) {
+                    $retVal[$i->name] = $i->enabled;
+                }
+            }
             return $retVal;
         } catch (Exception $e) {
             return [];

--- a/config/modules.php
+++ b/config/modules.php
@@ -176,9 +176,9 @@ return [
             'cache-lifetime' => 60 * 60 * 24 * 7, // 1 week
         ],
         'database' => [
-            'class' => DatabaseActivator::class,
+            'class'          => DatabaseActivator::class,
             'statuses-file'  => config_path('modules_statuses.json'),
-            'cache-key' => 'activator.installed',
+            'cache-key'      => 'activator.installed',
             'cache-lifetime' => 60 * 60 * 24 * 7, // 1 week
         ],
     ],

--- a/config/modules.php
+++ b/config/modules.php
@@ -152,8 +152,9 @@ return [
     */
     'cache' => [
         'enabled'  => true,
+        'driver'   => env('CACHE_DRIVER', 'file'),
         'key'      => 'phpvms-modules',
-        'lifetime' => 0,
+        'lifetime' => 60,
     ],
     /*
     |--------------------------------------------------------------------------
@@ -172,10 +173,13 @@ return [
             'class'          => FileActivator::class,
             'statuses-file'  => config_path('modules_statuses.json'),
             'cache-key'      => 'activator.installed',
-            'cache-lifetime' => 0,
+            'cache-lifetime' => 60 * 60 * 24 * 7, // 1 week
         ],
         'database' => [
             'class' => DatabaseActivator::class,
+            'statuses-file'  => config_path('modules_statuses.json'),
+            'cache-key' => 'activator.installed',
+            'cache-lifetime' => 60 * 60 * 24 * 7, // 1 week
         ],
     ],
 ];


### PR DESCRIPTION
This will resolve the issue of bad caching for specific keys, preventing errors (misses) that occur each time we try to access these keys. With this fix, the keys will now be cached correctly.

Regarding the problem of module cache files not being deleted when the cache is cleared, I delved deeper into the package responsible for managing modules. It appears that these files are created directly within the package by overriding certain core methods of Laravel. Consequently, the Laravel core is unaware of these files (and therefore can't delete them) because they are generated at the module level.

Here are two potential solutions (I can include them in this PR):

1. Manually delete files containing _module.php in the MaintenanceController.
2. Create a command specifically for deleting files containing _module.php and then invoke this command within the MaintenanceController.