### PR TITLE
Check Stat and Rank Change Before Dispatching Notifications

### DIFF
--- a/app/Notifications/NotificationEventsHandler.php
+++ b/app/Notifications/NotificationEventsHandler.php
@@ -291,7 +291,7 @@ class NotificationEventsHandler extends Listener
         /*
          * Broadcast notifications
          */
-        if (setting('notifications.discord_user_rank_changed', true) && $event->stat_name === 'rank' && $event->user->rank_id != $event->old_value->id) {
+        if (setting('notifications.discord_user_rank_changed', true) && $event->stat_name === 'rank') {
             Notification::send([$event->user], new Messages\Broadcast\UserRankChanged($event->user));
         }
     }

--- a/app/Notifications/NotificationEventsHandler.php
+++ b/app/Notifications/NotificationEventsHandler.php
@@ -291,7 +291,7 @@ class NotificationEventsHandler extends Listener
         /*
          * Broadcast notifications
          */
-        if (setting('notifications.discord_user_rank_changed', true)) {
+        if (setting('notifications.discord_user_rank_changed', true) && $event->stat_name === 'rank' && $event->user->rank_id != $event->old_value->id) {
             Notification::send([$event->user], new Messages\Broadcast\UserRankChanged($event->user));
         }
     }


### PR DESCRIPTION
No need to spam discord when the rank is not changed and the dispatched event is not related to ranks at all.

_Being tested on 3 live servers, do not merge directly_