### PR TITLE
Move SESSION_CONNECTION to .env

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -20,7 +20,7 @@ return [
     'expire_on_close' => false,
     'encrypt'         => false,
     'files'           => storage_path('framework/sessions'),
-    'connection'      => 'mysql',
+    'connection'      => env('SESSION_CONNECTION', 'mysql'),
     'table'           => 'sessions',
     'store'           => null,
     'lottery'         => [1, 100],

--- a/resources/stubs/installer/config.stub
+++ b/resources/stubs/installer/config.stub
@@ -108,7 +108,7 @@ return [
     // Overrides config/session.php
     'session' => [
         'driver' => 'file',
-        'connection' => 'mysql',
+        'connection' => env('SESSION_CONNECTION', 'mysql'),
         'lifetime' => 60 * 24,  # 24 hours
     ],
 ];


### PR DESCRIPTION
This PR allows the use of Redis (or anything else) for sessions by adding the following lines to the .env file:
```
SESSION_DRIVER=redis
SESSION_CONNECTION=default
```

