### PR TITLE
Use queue for listeners

### DIFF
--- a/app/Listeners/AwardHandler.php
+++ b/app/Listeners/AwardHandler.php
@@ -5,6 +5,8 @@ namespace App\Listeners;
 use App\Contracts\Listener;
 use App\Events\ProcessAward;
 use App\Models\Award;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
  * Look for and run any of the award classes. Don't modify this.
@@ -12,8 +14,10 @@ use App\Models\Award;
  *
  * @url http://docs.phpvms.net/customizing/awards
  */
-class AwardHandler extends Listener
+class AwardHandler extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     /** The events and the callback */
     public static $callbacks = [
         ProcessAward::class => 'processAward',

--- a/app/Listeners/BidEventHandler.php
+++ b/app/Listeners/BidEventHandler.php
@@ -5,12 +5,16 @@ namespace App\Listeners;
 use App\Contracts\Listener;
 use App\Events\PirepFiled;
 use App\Services\BidService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
  * Do stuff with bids - like if a PIREP is accepted, then remove the bid
  */
-class BidEventHandler extends Listener
+class BidEventHandler extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     public static $callbacks = [
         PirepFiled::class => 'onPirepFiled',
     ];

--- a/app/Listeners/DiversionHandler.php
+++ b/app/Listeners/DiversionHandler.php
@@ -7,9 +7,13 @@ use App\Events\CronNightly;
 use App\Events\PirepFiled;
 use App\Services\FlightService;
 use App\Services\PirepService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class DiversionHandler extends Listener
+class DiversionHandler extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     public static $callbacks = [
         PirepFiled::class  => 'onPirepFiled',
         CronNightly::class => 'onCronNightly',

--- a/app/Listeners/ExpenseListener.php
+++ b/app/Listeners/ExpenseListener.php
@@ -6,9 +6,13 @@ use App\Contracts\Listener;
 use App\Events\Expenses;
 use App\Models\Enums\ExpenseType;
 use App\Models\Expense;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class ExpenseListener extends Listener
+class ExpenseListener extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * Return a list of additional expenses
      *

--- a/app/Listeners/FareListener.php
+++ b/app/Listeners/FareListener.php
@@ -6,9 +6,13 @@ use App\Contracts\Listener;
 use App\Events\Fares;
 use App\Models\Enums\FareType;
 use App\Models\Fare;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class FareListener extends Listener
+class FareListener extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * Return a list of additional fares/income items
      *

--- a/app/Listeners/FinanceEventHandler.php
+++ b/app/Listeners/FinanceEventHandler.php
@@ -6,13 +6,17 @@ use App\Contracts\Listener;
 use App\Events\PirepAccepted;
 use App\Events\PirepRejected;
 use App\Services\Finance\PirepFinanceService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
  * Subscribe for events that we do some financial processing for
  * This includes when a PIREP is accepted, or rejected
  */
-class FinanceEventHandler extends Listener
+class FinanceEventHandler extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     public static $callbacks = [
         PirepAccepted::class => 'onPirepAccept',
         PirepRejected::class => 'onPirepReject',

--- a/app/Listeners/PirepEventsHandler.php
+++ b/app/Listeners/PirepEventsHandler.php
@@ -4,12 +4,16 @@ namespace App\Listeners;
 
 use App\Contracts\Listener;
 use App\Events\PirepPrefiled;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
  * Handler for PIREP events
  */
-class PirepEventsHandler extends Listener
+class PirepEventsHandler extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     /** The events and the callback */
     public static $callbacks = [
         PirepPrefiled::class => 'onPirepPrefile',

--- a/app/Listeners/UserStateListener.php
+++ b/app/Listeners/UserStateListener.php
@@ -6,9 +6,13 @@ use App\Contracts\Listener;
 use App\Events\PirepFiled;
 use App\Events\UserStateChanged;
 use App\Models\Enums\UserState;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class UserStateListener extends Listener
+class UserStateListener extends Listener implements ShouldQueue
 {
+    use Queueable;
+
     public function handle(PirepFiled $event): void
     {
         // Check the user state, set them to ACTIVE if on leave


### PR DESCRIPTION
As discussed, this PR enables the use of queues for various listeners related to the dispatch of a PIREP. It's important to note that I couldn't find a way to enqueue all listeners for an event, so this won't work for modules. Therefore, I recommend module developers also use queues for their listeners.

Implementing queues allows us to perform certain tasks in the background asynchronously, resulting in significantly reduced processing times for end-users.

Additionally, there's no need to add the `shouldQueue` interface for notifications, as they are already queued. This is because the `App\Contracts\Notification` contract, which they all extend, already implements the `ShouldQueue` interface.
