### PR TITLE
Add Discord OAuth

### DIFF
--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -19,9 +19,9 @@ class OAuthController extends Controller
     {
         $user = Socialite::driver('discord')->user();
 
-        if ($user->id) {
+        if ($user->getId()) {
             Auth::user()?->update([
-                'discord_id' => $user->id,
+                'discord_id' => $user->getId(),
             ]);
 
             flash()->success('Discord account linked!');

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -9,7 +9,6 @@ use Laravel\Socialite\Facades\Socialite;
 
 class OAuthController extends Controller
 {
-
     public function redirectToDiscordProvider(): RedirectResponse
     {
         return Socialite::driver('discord')->scopes(['identify'])->redirect();

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -22,12 +22,12 @@ class OAuthController extends Controller
 
         if ($user->getId()) {
             // Let's retrieve the private_channel_id
-            if (!is_null(env('DISCORD_BOT_TOKEN'))) {
+            if (!is_null(config('services.discord.token'))) {
                 try {
                     $httpClient = new Client();
                     $response = $httpClient->request('POST', 'https://discord.com/api/users/@me/channels', [
                         'headers' => [
-                            'Authorization' => 'Bot '.env('DISCORD_BOT_TOKEN'),
+                            'Authorization' => 'Bot '.config('services.discord.token'),
                         ],
                         'json' => [
                             'recipient_id' => $user->getId(),

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
-use function PHPUnit\Framework\isNull;
 
 class OAuthController extends Controller
 {
@@ -22,14 +21,13 @@ class OAuthController extends Controller
         $user = Socialite::driver('discord')->user();
 
         if ($user->getId()) {
-
             // Let's retrieve the private_channel_id
             if (!is_null(env('DISCORD_BOT_TOKEN'))) {
                 try {
                     $httpClient = new Client();
                     $response = $httpClient->request('POST', 'https://discord.com/api/users/@me/channels', [
                         'headers' => [
-                            'Authorization' => 'Bot ' . env('DISCORD_BOT_TOKEN')
+                            'Authorization' => 'Bot '.env('DISCORD_BOT_TOKEN'),
                         ],
                         'json' => [
                             'recipient_id' => $user->getId(),
@@ -38,7 +36,7 @@ class OAuthController extends Controller
 
                     $privateChannel = json_decode($response->getBody()->getContents(), true)['id'];
                 } catch (\Exception $e) {
-                    Log::error('Discord OAuth Error: ' .$e->getMessage());
+                    Log::error('Discord OAuth Error: '.$e->getMessage());
                     $privateChannel = null;
                 }
             }

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Contracts\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Socialite\Facades\Socialite;
+
+class OAuthController extends Controller
+{
+
+    public function redirectToDiscordProvider(): RedirectResponse
+    {
+        return Socialite::driver('discord')->scopes(['identify'])->redirect();
+    }
+
+    public function handleDiscordProviderCallback(): RedirectResponse
+    {
+        $user = Socialite::driver('discord')->user();
+
+        if ($user->id) {
+            Auth::user()?->update([
+                'discord_id' => $user->id,
+            ]);
+
+            flash()->success('Discord account linked!');
+        } else {
+            flash()->error('Unable to link Discord account!');
+        }
+
+        return redirect()->route('frontend.profile.index');
+    }
+
+    public function logoutDiscordProvider(): RedirectResponse
+    {
+        Auth::user()?->update([
+            'discord_id' => null,
+        ]);
+
+        flash()->success('Discord account unlinked!');
+
+        return redirect()->route('frontend.profile.index');
+    }
+}

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -3,9 +3,12 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Contracts\Controller;
+use GuzzleHttp\Client;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
+use function PHPUnit\Framework\isNull;
 
 class OAuthController extends Controller
 {
@@ -19,8 +22,30 @@ class OAuthController extends Controller
         $user = Socialite::driver('discord')->user();
 
         if ($user->getId()) {
+
+            // Let's retrieve the private_channel_id
+            if (!is_null(env('DISCORD_BOT_TOKEN'))) {
+                try {
+                    $httpClient = new Client();
+                    $response = $httpClient->request('POST', 'https://discord.com/api/users/@me/channels', [
+                        'headers' => [
+                            'Authorization' => 'Bot ' . env('DISCORD_BOT_TOKEN')
+                        ],
+                        'json' => [
+                            'recipient_id' => $user->getId(),
+                        ],
+                    ]);
+
+                    $privateChannel = json_decode($response->getBody()->getContents(), true)['id'];
+                } catch (\Exception $e) {
+                    Log::error('Discord OAuth Error: ' .$e->getMessage());
+                    $privateChannel = null;
+                }
+            }
+
             Auth::user()?->update([
-                'discord_id' => $user->getId(),
+                'discord_id'                 => $user->getId(),
+                'discord_private_channel_id' => $privateChannel ?? null,
             ]);
 
             flash()->success('Discord account linked!');
@@ -34,7 +59,8 @@ class OAuthController extends Controller
     public function logoutDiscordProvider(): RedirectResponse
     {
         Auth::user()?->update([
-            'discord_id' => null,
+            'discord_id'                 => null,
+            'discord_private_channel_id' => null,
         ]);
 
         flash()->success('Discord account unlinked!');

--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -177,16 +177,6 @@ class ProfileController extends Controller
             $req_data['password'] = Hash::make($req_data['password']);
         }
 
-        // Find out the user's private channel id
-        /*
-        // TODO: Uncomment when Discord API functionality is enabled
-        if ($request->filled('discord_id')) {
-            $discord_id = $request->post('discord_id');
-            if ($discord_id !== $user->discord_id) {
-                $req_data['discord_private_channel_id'] = Discord::getPrivateChannelId($discord_id);
-            }
-        }*/
-
         if ($request->hasFile('avatar')) {
             if ($user->avatar !== null) {
                 Storage::delete($user->avatar);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -63,7 +63,6 @@ class EventServiceProvider extends ServiceProvider
             \SocialiteProviders\Discord\DiscordExtendSocialite::class.'@handle',
         ],
 
-
     ];
 
     protected $subscribe = [

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -57,6 +57,13 @@ class EventServiceProvider extends ServiceProvider
         ],
 
         ProfileUpdated::class => [],
+
+        // For discord OAuth
+        \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+            \SocialiteProviders\Discord\DiscordExtendSocialite::class.'@handle',
+        ],
+
+
     ];
 
     protected $subscribe = [

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Laravel\Socialite\Facades\Socialite;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -169,6 +170,17 @@ class RouteServiceProvider extends ServiceProvider
                 Route::get('livemap', 'LiveMapController@index')->name('livemap.index');
 
                 Route::get('lang/{lang}', 'LanguageController@switchLang')->name('lang.switch');
+            });
+
+            Route::group([
+                'namespace' => 'Auth',
+                'prefix' => 'auth',
+                'as'     => 'auth.',
+                'middleware' => 'auth'
+            ], function () {
+                Route::get('discord/redirect', 'OAuthController@redirectToDiscordProvider')->name('discord.redirect');
+                Route::get('discord/callback', 'OAuthController@handleDiscordProviderCallback')->name('discord.callback');
+                Route::get('discord/logout', 'OAuthController@logoutDiscordProvider')->name('discord.logout');
             });
 
             Route::get('/logout', 'Auth\LoginController@logout')->name('auth.logout');

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
-use Laravel\Socialite\Facades\Socialite;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -173,10 +172,10 @@ class RouteServiceProvider extends ServiceProvider
             });
 
             Route::group([
-                'namespace' => 'Auth',
-                'prefix' => 'auth',
-                'as'     => 'auth.',
-                'middleware' => 'auth'
+                'namespace'  => 'Auth',
+                'prefix'     => 'auth',
+                'as'         => 'auth.',
+                'middleware' => 'auth',
             ], function () {
                 Route::get('discord/redirect', 'OAuthController@redirectToDiscordProvider')->name('discord.redirect');
                 Route::get('discord/callback', 'OAuthController@handleDiscordProviderCallback')->name('discord.callback');

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,9 @@
         "spatie/laravel-ignition": "^2.0",
         "kyslik/column-sortable": "^6.5",
         "jlorente/laravel-data-migrations": "^2.0",
-        "spatie/laravel-backup": "*"
+        "spatie/laravel-backup": "*",
+        "laravel/socialite": "^5.11",
+        "socialiteproviders/discord": "^4.2"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9512075f12b10b29d564c074041cb42",
+    "content-hash": "bd7667018fe08f5646d542a0ca8923ae",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -3812,6 +3812,76 @@
             "time": "2023-07-14T13:56:28+00:00"
         },
         {
+            "name": "laravel/socialite",
+            "version": "v5.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/socialite.git",
+                "reference": "4f6a8af6f3f7c18da03d19842dd0514315501c10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/4f6a8af6f3f7c18da03d19842dd0514315501c10",
+                "reference": "4f6a8af6f3f7c18da03d19842dd0514315501c10",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+                "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+                "league/oauth1-client": "^1.10.1",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.0|^9.3|^10.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Socialite\\SocialiteServiceProvider"
+                    ],
+                    "aliases": {
+                        "Socialite": "Laravel\\Socialite\\Facades\\Socialite"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Socialite\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel wrapper around OAuth 1 & OAuth 2 libraries.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "laravel",
+                "oauth"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/socialite/issues",
+                "source": "https://github.com/laravel/socialite"
+            },
+            "time": "2023-12-02T18:22:36+00:00"
+        },
+        {
             "name": "laravel/ui",
             "version": "v4.2.2",
             "source": {
@@ -4562,6 +4632,82 @@
                 }
             ],
             "time": "2023-10-17T14:13:20+00:00"
+        },
+        {
+            "name": "league/oauth1-client",
+            "version": "v1.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth1-client.git",
+                "reference": "d6365b901b5c287dd41f143033315e2f777e1167"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth1-client/zipball/d6365b901b5c287dd41f143033315e2f777e1167",
+                "reference": "d6365b901b5c287dd41f143033315e2f777e1167",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "guzzlehttp/psr7": "^1.7|^2.0",
+                "php": ">=7.1||>=8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "mockery/mockery": "^1.3.3",
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5||9.5"
+            },
+            "suggest": {
+                "ext-simplexml": "For decoding XML-based responses."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev",
+                    "dev-develop": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth1\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Corlett",
+                    "email": "bencorlett@me.com",
+                    "homepage": "http://www.webcomm.com.au",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OAuth 1.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "bitbucket",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth1",
+                "single sign on",
+                "trello",
+                "tumblr",
+                "twitter"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth1-client/issues",
+                "source": "https://github.com/thephpleague/oauth1-client/tree/v1.10.1"
+            },
+            "time": "2022-04-15T14:02:14+00:00"
         },
         {
             "name": "madnest/madzipper",
@@ -6986,6 +7132,130 @@
             },
             "abandoned": true,
             "time": "2016-05-28T13:26:32+00:00"
+        },
+        {
+            "name": "socialiteproviders/discord",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SocialiteProviders/Discord.git",
+                "reference": "c71c379acfdca5ba4aa65a3db5ae5222852a919c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SocialiteProviders/Discord/zipball/c71c379acfdca5ba4aa65a3db5ae5222852a919c",
+                "reference": "c71c379acfdca5ba4aa65a3db5ae5222852a919c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "socialiteproviders/manager": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\Discord\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christopher Eklund",
+                    "email": "eklundchristopher@gmail.com"
+                }
+            ],
+            "description": "Discord OAuth2 Provider for Laravel Socialite",
+            "keywords": [
+                "discord",
+                "laravel",
+                "oauth",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "docs": "https://socialiteproviders.com/discord",
+                "issues": "https://github.com/socialiteproviders/providers/issues",
+                "source": "https://github.com/socialiteproviders/providers"
+            },
+            "time": "2023-07-24T23:28:47+00:00"
+        },
+        {
+            "name": "socialiteproviders/manager",
+            "version": "v4.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SocialiteProviders/Manager.git",
+                "reference": "df5e45b53d918ec3d689f014d98a6c838b98ed96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SocialiteProviders/Manager/zipball/df5e45b53d918ec3d689f014d98a6c838b98ed96",
+                "reference": "df5e45b53d918ec3d689f014d98a6c838b98ed96",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+                "laravel/socialite": "~5.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "phpunit/phpunit": "^6.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "SocialiteProviders\\Manager\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\Manager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andy Wendt",
+                    "email": "andy@awendt.com"
+                },
+                {
+                    "name": "Anton Komarev",
+                    "email": "a.komarev@cybercog.su"
+                },
+                {
+                    "name": "Miguel Piedrafita",
+                    "email": "soy@miguelpiedrafita.com"
+                },
+                {
+                    "name": "atymic",
+                    "email": "atymicq@gmail.com",
+                    "homepage": "https://atymic.dev"
+                }
+            ],
+            "description": "Easily add new or override built-in providers in Laravel Socialite.",
+            "homepage": "https://socialiteproviders.com",
+            "keywords": [
+                "laravel",
+                "manager",
+                "oauth",
+                "providers",
+                "socialite"
+            ],
+            "support": {
+                "issues": "https://github.com/socialiteproviders/manager/issues",
+                "source": "https://github.com/socialiteproviders/manager"
+            },
+            "time": "2023-08-27T23:46:34+00:00"
         },
         {
             "name": "spatie/backtrace",
@@ -14064,7 +14334,8 @@
         "ext-simplexml": "*",
         "ext-bcmath": "*",
         "ext-pdo": "*",
-        "ext-intl": "*"
+        "ext-intl": "*",
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/config/app.php
+++ b/config/app.php
@@ -39,6 +39,7 @@ return [
         Prettus\Repository\Providers\RepositoryServiceProvider::class,
         Igaster\LaravelTheme\themeServiceProvider::class,
         Nwidart\Modules\LaravelModulesServiceProvider::class,
+        SocialiteProviders\Manager\ServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/config/services.php
+++ b/config/services.php
@@ -30,12 +30,12 @@ return [
     ],
 
     'discord' => [
-        'client_id' => env('DISCORD_CLIENT_ID'),
+        'client_id'     => env('DISCORD_CLIENT_ID'),
         'client_secret' => env('DISCORD_CLIENT_SECRET'),
-        'redirect' => env('DISCORD_REDIRECT_URI'),
+        'redirect'      => env('DISCORD_REDIRECT_URI'),
 
         // optional
-        'allow_gif_avatars' => (bool)env('DISCORD_AVATAR_GIF', true),
+        'allow_gif_avatars'        => (bool) env('DISCORD_AVATAR_GIF', true),
         'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
     ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,7 @@ return [
         'redirect'      => '/auth/discord/callback',
 
         // optional
+        'token'                    => env('DISCORD_BOT_TOKEN', null),
         'allow_gif_avatars'        => (bool) env('DISCORD_AVATAR_GIF', true),
         'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
     ],

--- a/config/services.php
+++ b/config/services.php
@@ -28,4 +28,14 @@ return [
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
+
+    'discord' => [
+        'client_id' => env('DISCORD_CLIENT_ID'),
+        'client_secret' => env('DISCORD_CLIENT_SECRET'),
+        'redirect' => env('DISCORD_REDIRECT_URI'),
+
+        // optional
+        'allow_gif_avatars' => (bool)env('DISCORD_AVATAR_GIF', true),
+        'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
+    ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -32,7 +32,7 @@ return [
     'discord' => [
         'client_id'     => env('DISCORD_CLIENT_ID'),
         'client_secret' => env('DISCORD_CLIENT_SECRET'),
-        'redirect'      => env('DISCORD_REDIRECT_URI'),
+        'redirect'      => '/auth/discord/callback',
 
         // optional
         'allow_gif_avatars'        => (bool) env('DISCORD_AVATAR_GIF', true),

--- a/resources/views/layouts/default/profile/fields.blade.php
+++ b/resources/views/layouts/default/profile/fields.blade.php
@@ -26,21 +26,6 @@
       </tr>
 
       <tr>
-        <td>Discord ID <span class="small">
-            <a href="https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-" target="_blank">
-              How to find your ID</a></span>
-        </td>
-        <td>
-          <div class="input-group form-group-no-border{{ $errors->has('discord_id') ? ' has-danger' : '' }}">
-            {{ Form::text('discord_id', null, ['class' => 'form-control']) }}
-          </div>
-          @if ($errors->has('discord_id'))
-            <p class="text-danger">{{ $errors->first('discord_id') }}</p>
-          @endif
-        </td>
-      </tr>
-
-      <tr>
         <td>{{ __('common.airline') }}</td>
         <td>
           <div class="input-group form-group-no-border{{ $errors->has('airline') ? ' has-danger' : '' }}">

--- a/resources/views/layouts/default/profile/index.blade.php
+++ b/resources/views/layouts/default/profile/index.blade.php
@@ -139,6 +139,13 @@
              onclick="alert('Copy or Save to \'My Documents/phpVMS\'')">ACARS Config</a>
           &nbsp;
           @endif
+
+          @if(env('DISCORD_OAUTH_ENABLED', false) && !$user->discord_id)
+            <a href="{{ route('auth.discord.redirect') }}" class="btn" style="background-color:#738ADB;">Link Discord Account</a>
+          @elseif(env('DISCORD_OAUTH_ENABLED', false))
+            <a href="{{ route('auth.discord.logout') }}" class="btn" style="background-color:#738ADB;">Unlink Discord Account</a>
+          @endif
+
           <a href="{{ route('frontend.profile.regen_apikey') }}" class="btn btn-warning"
              onclick="return confirm('Are you sure? This will reset your API key!')">@lang('profile.newapikey')</a>
           &nbsp;


### PR DESCRIPTION
Closes #1684 

We'll have to explain in the docs how to setup this.
You need to create an OAuth application in Discord's Developer Portal (like for RichPresence in VMSAcars, you can use the same app). https://discord.com/developers/applications

Then set these variables in `.env`

```
DISCORD_OAUTH_ENABLED=true
DISCORD_CLIENT_ID={your_client_id}
DISCORD_CLIENT_SECRET={your_client_secret}
```

I couldn't find `private_channel_id` in the Discord docs so I don't know what this field is in the users table and how to fill it. In addition the OAuth connection that I establish has an expiration time but since we don't want to connect the user but just retrieve their id I do not store the tokens to reconnect because we need to send a single request to discord. If we want to make requests to Discord at other places in the code, we must take these tokens into account.

> Having the user's access token allows your application to make certain requests to the API on their behalf, restricted to whatever scopes were requested.

The access token / refresh token actually allow you to interact completely with the Discord API. For example, we can make the user join a server and automatically give him a specific role/nickname. So it could be useful to store them but I didn't really want to change the structure of the table not knowing what you want to do with the discord integration in the future.

This OAuth is based on `laravel/socialite` which allows us to easily addother providers to do OAuth with others webapps if necessary.
