### PR TITLE
Add new fields to Aircraft Model

### DIFF
--- a/app/Database/migrations/2023_12_17_181350_add_fields_to_aircraft.php
+++ b/app/Database/migrations/2023_12_17_181350_add_fields_to_aircraft.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up()
+    {
+        if (!Schema::hasColumns('aircraft', ['selcal', 'dow', 'mlw', 'simbrief_type'])) {
+            Schema::table('aircraft', function (Blueprint $table) {
+                $table->string('selcal', 5)->nullable()->after('hex_code');
+                $table->unsignedDecimal('dow', 8, 2)->nullable()->after('selcal');
+                $table->unsignedDecimal('mlw', 8, 2)->nullable()->after('mtow');
+                $table->string('simbrief_type', 25)->nullable()->after('zfw');
+            });
+        }
+    }
+};

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -29,15 +29,19 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  * @property string   registration
  * @property string   fin
  * @property int      flight_time
+ * @property float    dow
+ * @property float    mlw
  * @property float    mtow
  * @property float    zfw
  * @property string   hex_code
+ * @property string   selcal
  * @property Airport  airport
  * @property Airport  hub
  * @property Airport  home
  * @property Subfleet subfleet
  * @property int      status
  * @property int      state
+ * @property string   simbrief_type
  * @property Carbon   landing_time
  * @property float    fuel_onboard
  * @property Bid      bid
@@ -63,13 +67,17 @@ class Aircraft extends Model
         'registration',
         'fin',
         'hex_code',
+        'selcal',
         'landing_time',
         'flight_time',
+        'dow',
+        'mlw',
         'mtow',
         'zfw',
         'fuel_onboard',
         'status',
         'state',
+        'simbrief_type',
     ];
 
     /**
@@ -78,6 +86,8 @@ class Aircraft extends Model
     protected $casts = [
         'flight_time'  => 'float',
         'fuel_onboard' => FuelCast::class,
+        'dow'          => 'float',
+        'mlw'          => 'float',
         'mtow'         => 'float',
         'state'        => 'integer',
         'subfleet_id'  => 'integer',
@@ -88,13 +98,17 @@ class Aircraft extends Model
      * Validation rules
      */
     public static $rules = [
-        'fin'          => 'nullable',
-        'mtow'         => 'nullable|numeric',
-        'name'         => 'required',
-        'registration' => 'required',
-        'status'       => 'required',
-        'subfleet_id'  => 'required',
-        'zfw'          => 'nullable|numeric',
+        'name'          => 'required',
+        'registration'  => 'required',
+        'fin'           => 'nullable',
+        'selcal'        => 'nullable',
+        'status'        => 'required',
+        'subfleet_id'   => 'required',
+        'dow'           => 'nullable|numeric',
+        'zfw'           => 'nullable|numeric',
+        'mtow'          => 'nullable|numeric',
+        'mlw'           => 'nullable|numeric',
+        'simbrief_type' => 'nullable',
     ];
 
     public $sortable = [
@@ -107,11 +121,15 @@ class Aircraft extends Model
         'registration',
         'fin',
         'hex_code',
+        'selcal',
         'landing_time',
         'flight_time',
+        'dow',
         'mtow',
+        'mlw',
         'zfw',
         'fuel_onboard',
+        'simbrief_type',
         'status',
         'state',
     ];

--- a/app/Services/ImportExport/AircraftImporter.php
+++ b/app/Services/ImportExport/AircraftImporter.php
@@ -22,18 +22,22 @@ class AircraftImporter extends ImportExport
      * Should match the database fields, for the most part
      */
     public static $columns = [
-        'subfleet'     => 'required',
-        'iata'         => 'nullable',
-        'icao'         => 'nullable',
-        'hub_id'       => 'nullable',
-        'airport_id'   => 'nullable',
-        'name'         => 'required',
-        'registration' => 'required',
-        'fin'          => 'nullable',
-        'hex_code'     => 'nullable',
-        'mtow'         => 'nullable|numeric',
-        'zfw'          => 'nullable|numeric',
-        'status'       => 'nullable',
+        'subfleet'      => 'required',
+        'iata'          => 'nullable',
+        'icao'          => 'nullable',
+        'hub_id'        => 'nullable',
+        'airport_id'    => 'nullable',
+        'name'          => 'required',
+        'registration'  => 'required',
+        'fin'           => 'nullable',
+        'hex_code'      => 'nullable',
+        'selcal'        => 'nullable',
+        'dow'           => 'nullable|numeric',
+        'zfw'           => 'nullable|numeric',
+        'mtow'          => 'nullable|numeric',
+        'mlw'           => 'nullable|numeric',
+        'status'        => 'nullable',
+        'simbrief_type' => 'nullable',
     ];
 
     /**
@@ -83,8 +87,15 @@ class AircraftImporter extends ImportExport
         // Just set its state right now as parked
         $row['state'] = AircraftState::PARKED;
 
-        // Check FIN and set to null if it is blank
+        // Check fields and set to null if they are blank
+        // Somehow they got empty strings instead of null without this!
         $row['fin'] = blank($row['fin']) ? null : $row['fin'];
+        $row['dow'] = blank($row['dow']) ? null : $row['dow'];
+        $row['zfw'] = blank($row['zfw']) ? null : $row['zfw'];
+        $row['mtow'] = blank($row['mtow']) ? null : $row['mtow'];
+        $row['mlw'] = blank($row['mlw']) ? null : $row['mlw'];
+        $row['selcal'] = blank($row['selcal']) ? null : $row['selcal'];
+        $row['simbrief_type'] = blank($row['simbrief_type']) ? null : $row['simbrief_type'];
 
         // Try to add or update
         try {

--- a/resources/views/admin/aircraft/fields.blade.php
+++ b/resources/views/admin/aircraft/fields.blade.php
@@ -1,9 +1,7 @@
 <div class="row">
   <div class="col-sm-12">
     <div class="form-container">
-      <h6><i class="fas fa-clock"></i>
-        &nbsp;Subfleet and Status
-      </h6>
+      <h6><i class="fas fa-clock"></i>&nbsp;Subfleet and Status</h6>
       <div class="form-container-body row">
         <div class="form-group col-sm-3">
           {{ Form::label('subfleet_id', 'Subfleet:') }}
@@ -41,66 +39,89 @@
   <div class="col-12">
     <div class="form-container">
       <h6>
-          <span style="float:right">
-              View list of
-              <a href="https://en.wikipedia.org/wiki/List_of_ICAO_aircraft_type_designators"
-                 target="_blank">IATA and ICAO Type Designators</a>
-          </span>
         <i class="fas fa-plane"></i>&nbsp;Aircraft Information
+        <span style="float:right">
+          View list of
+          <a href="https://en.wikipedia.org/wiki/List_of_ICAO_aircraft_type_designators" target="_blank">IATA and ICAO Type Designators</a>
+        </span>
       </h6>
       <div class="form-container-body">
-
         <div class="row">
-          <div class="form-group col-sm-12">
+          <div class="form-group col-sm-3">
             {{ Form::label('name', 'Name:') }}&nbsp;<span class="required">*</span>
             {{ Form::text('name', null, ['class' => 'form-control']) }}
             <p class="text-danger">{{ $errors->first('name') }}</p>
           </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('registration', 'Registration:') }}&nbsp;<span class="required">*</span>
+            {{ Form::text('registration', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('registration') }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('fin', 'FIN:') }}
+            {{ Form::text('fin', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('fin') }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('selcal', 'SELCAL:') }}
+            {{ Form::text('selcal', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('selcal') }}</p>
+          </div>
         </div>
-
         <div class="row">
           <div class="form-group col-sm-3">
             {{ Form::label('iata', 'IATA:') }}
             {{ Form::text('iata', null, ['class' => 'form-control']) }}
             <p class="text-danger">{{ $errors->first('iata') }}</p>
           </div>
-
           <div class="form-group col-sm-3">
             {{ Form::label('icao', 'ICAO:') }}
             {{ Form::text('icao', null, ['class' => 'form-control']) }}
             <p class="text-danger">{{ $errors->first('icao') }}</p>
           </div>
-
           <div class="form-group col-sm-3">
-            {{ Form::label('registration', 'Registration:') }}
-            {{ Form::text('registration', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('registration') }}</p>
-          </div>
-
-          <div class="form-group col-sm-3">
-            {{ Form::label('fin', 'FIN:') }}
-            {{ Form::text('fin', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('fin') }}</p>
+            {{ Form::label('simbrief_type', 'SimBrief Type:') }}
+            {{ Form::text('simbrief_type', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('simbrief_type') }}</p>
           </div>
         </div>
-
-        <div class="row">
-          <div class="form-group col-sm-6">
-            {{ Form::label('mtow', 'Max Takeoff Weight (MTOW):') }}
-            {{ Form::text('mtow', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('mtow') }}</p>
-          </div>
-          <div class="form-group col-sm-6">
-            {{ Form::label('zfw', 'Zero Fuel Weight (ZFW):') }}
-            {{ Form::text('zfw', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('zfw') }}</p>
-          </div>
-        </div>
-
       </div>
     </div>
   </div>
 </div>
+
+<div class="row">
+  <div class="col-12">
+    <div class="form-container">
+      <h6><i class="fas fa-plane"></i>&nbsp;Certified Weights</h6>
+      <div class="form-container-body">
+        <div class="row">
+          <div class="form-group col-sm-3">
+            {{ Form::label('dow', 'Dry Operating Weight (DOW/OEW):') }}
+            {{ Form::number('dow', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('dow') }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('zfw', 'Max Zero Fuel Weight (MZFW):') }}
+            {{ Form::number('zfw', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('zfw') }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('mtow', 'Max Takeoff Weight (MTOW):') }}
+            {{ Form::number('mtow', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('mtow') }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('mlw', 'Max Landing Weight (MLW):') }}
+            {{ Form::number('mlw', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('mlw') }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="row">
   <!-- Submit Field -->
   <div class="form-group col-sm-12">

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -18,7 +18,13 @@
                     <div class="col-sm-4">
                       <label for="type">Type</label>
                       <input type="text" class="form-control" value="{{ $aircraft->icao }}" maxlength="4" disabled>
-                      <input type="hidden" name="type" value="{{ $aircraft->subfleet->simbrief_type ?? $aircraft->icao }}">
+                      @if(filled($aircraft->simbrief_type))
+                        <input type="hidden" name="type" value="{{ $aircraft->simbrief_type }}">
+                      @elseif(filled($aircraft->subfleet->simbrief_type))
+                        <input type="hidden" name="type" value="{{ $aircraft->subfleet->simbrief_type }}">
+                      @else
+                        <input type="hidden" name="type" value="{{ $aircraft->icao }}">
+                      @endif
                     </div>
                     <div class="col-sm-4">
                       <label for="reg">Registration</label>
@@ -149,7 +155,7 @@
               <input type="hidden" id="date" name="date" maxlength="9">
               <input type="hidden" id="deph" name="deph" maxlength="2">
               <input type="hidden" id="depm" name="depm" maxlength="2">
-              <input type="hidden" name="selcal" value="BK-FS">
+              <input type="hidden" name="selcal" value="{{ $aircraft->selcal ?? 'FK-NS'}}">
               <input type="hidden" name="planformat" value="lido">
               <input type="hidden" name="omit_sids" value="0">
               <input type="hidden" name="omit_stars" value="0">

--- a/tests/data/aircraft-update.csv
+++ b/tests/data/aircraft-update.csv
@@ -1,3 +1,3 @@
-subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,mtow,zfw,status
-A32X,A320,320,,,A320-211,N309US,780DH,,,,S
-74X,747 400,, ,,,
+subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,selcal,dow,zfw,mtow,mlw,status,simbrief_type
+A32X,A320,320,,,A320-211,N309US,780DH,,,,,,,S,
+74X,747 400,, ,,,,,,,,,,,,

--- a/tests/data/aircraft.csv
+++ b/tests/data/aircraft.csv
@@ -1,3 +1,3 @@
-subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,mtow,zfw,status
-A32X,A320,320,,,A320-211,N309US,780DH,,,,A
-74X,747 400,,, ,,
+subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,selcal,dow,zfw,mtow,mlw,status,simbrief_type
+A32X,A320,320,,,A320-211,N309US,780DH,,,,,,,A,
+74X,747 400,,, ,,,,,,,,,,,

--- a/tests/data/aircraft_empty_cols.csv
+++ b/tests/data/aircraft_empty_cols.csv
@@ -1,3 +1,3 @@
-subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,mtow,zfw,status
-A32X,A320-211,,,N309US,,,,
- , B744-GE,,, N304,,,,
+subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,selcal,dow,zfw,mtow,mlw,status,simbrief_type
+A32X,A320-211,,,N309US,,,,,,,,,,,
+ , B744-GE,,, N304,,,,,,,,,,,


### PR DESCRIPTION
* DOW : Dry Operating Weight (or Operating Empty Weight)
* MLW : Maximum Landing Weight
* SELCAL : Selective Calling System Code
* SimBrief Type / as like in subfleet but for individual aircraft

All fields are optional, both admin (aircraft > fields) and frontend (flights > simbrief_form) blades updated for new fields.

![image](https://github.com/nabeelio/phpvms/assets/74361521/4960fdc6-39c6-4d5e-89d5-f6d654a96dcc)

**Important : Export / Import content is changed, old files may not be compatible for direct import anymore.**

Changes may come in handy for internal development and enhanced SimBrief integrations done by admins/airline devs.