### PR TITLE
hotfix: remove DB constraints in Discord OAuth

### DIFF
--- a/app/Database/migrations/2023_12_15_154815_create_user_oauth_tokens_table.php
+++ b/app/Database/migrations/2023_12_15_154815_create_user_oauth_tokens_table.php
@@ -18,11 +18,6 @@ return new class() extends Migration {
             $table->string('refresh_token');
             $table->dateTime('last_refreshed_at')->nullable();
             $table->timestamps();
-
-            $table->foreign('user_id')
-                ->references('id')
-                ->on('users')
-                ->cascadeOnDelete();
         });
     }
 


### PR DESCRIPTION
The migration sometimes fails on certain environments because of this constraint