### PR TITLE
OAuth improvements

### DIFF
--- a/app/Database/factories/UserFactory.php
+++ b/app/Database/factories/UserFactory.php
@@ -50,6 +50,7 @@ class UserFactory extends Factory
             'state'             => UserState::ACTIVE,
             'remember_token'    => $this->faker->unique()->text(5),
             'email_verified_at' => now(),
+            'avatar'            => '',
         ];
     }
 }

--- a/app/Database/migrations/2023_12_24_091030_drop_user_oauth_tokens_foreign_keys.php
+++ b/app/Database/migrations/2023_12_24_091030_drop_user_oauth_tokens_foreign_keys.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class() extends Migration {
     public function up(): void
     {
         Schema::table('user_oauth_tokens', function (Blueprint $table) {

--- a/app/Database/migrations/2023_12_24_091030_drop_user_oauth_tokens_foreign_keys.php
+++ b/app/Database/migrations/2023_12_24_091030_drop_user_oauth_tokens_foreign_keys.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_oauth_tokens', function (Blueprint $table) {
+            $foreignKeys = Schema::getForeignKeys('user_oauth_tokens');
+
+            foreach ($foreignKeys as $foreignKey) {
+                if (in_array('user_id', $foreignKey['columns'], true)) {
+                    $table->dropForeign(['user_id']);
+                    break;
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -84,17 +84,22 @@ class OAuthController extends Controller
 
         if ($user) {
             $tokens = UserOAuthToken::updateOrCreate([
-                'user_id'  => $user->id,
+                'user_id' => $user->id,
                 'provider' => $provider,
             ], [
-                'token'             => $providerUser->token,
-                'refresh_token'     => $providerUser->refreshToken,
+                'token' => $providerUser->token,
+                'refresh_token' => $providerUser->refreshToken,
                 'last_refreshed_at' => now(),
             ]);
 
             Auth::login($user);
 
             return redirect(route('frontend.dashboard.index'));
+        }
+
+        if (User::where('email', $providerUser->getEmail())->exists()) {
+            flash()->error('An account with this email already exists. Please login with your email and password and link your account.');
+            return redirect(url('/login'));
         }
 
         $attrs = [

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -141,7 +141,7 @@ class OAuthController extends Controller
         }
 
         $user->update([
-            $provider.'_id' => null,
+            $provider.'_id' => '',
         ]);
 
         flash()->success(ucfirst($provider).' account unlinked!');

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -77,6 +77,10 @@ class OAuthController extends Controller
                 'last_refreshed_at' => now(),
             ]);
 
+            if ($provider === 'discord') {
+                $this->userSvc->retrieveDiscordPrivateChannelId($user);
+            }
+
             flash()->success(ucfirst($provider).' account linked!');
 
             return redirect(route('frontend.profile.index'));
@@ -129,6 +133,10 @@ class OAuthController extends Controller
 
             Auth::login($user);
 
+            if ($provider === 'discord') {
+                $this->userSvc->retrieveDiscordPrivateChannelId($user);
+            }
+
             return redirect(route('frontend.dashboard.index'));
         }
 
@@ -148,6 +156,12 @@ class OAuthController extends Controller
         $user->update([
             $provider.'_id' => '',
         ]);
+
+        if ($provider === 'discord' && $user->discord_private_channel_id) {
+            $user->update([
+                'discord_private_channel_id' => ''
+            ]);
+        }
 
         flash()->success(ucfirst($provider).' account unlinked!');
 

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -92,7 +92,7 @@ class OAuthController extends Controller
 
             if (setting('general.record_user_ip', true)) {
                 $user->update([
-                    'last_ip'   => $request->ip(),
+                    'last_ip' => $request->ip(),
                 ]);
             }
 

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -3,15 +3,11 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Contracts\Controller;
-use App\Models\Airline;
-use App\Models\Airport;
 use App\Models\User;
 use App\Models\UserOAuthToken;
 use App\Services\UserService;
-use App\Support\Utils;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
 use Laravel\Socialite\Facades\Socialite;
 
 class OAuthController extends Controller

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -159,7 +159,7 @@ class OAuthController extends Controller
 
         if ($provider === 'discord' && $user->discord_private_channel_id) {
             $user->update([
-                'discord_private_channel_id' => ''
+                'discord_private_channel_id' => '',
             ]);
         }
 

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -84,11 +84,11 @@ class OAuthController extends Controller
 
         if ($user) {
             $tokens = UserOAuthToken::updateOrCreate([
-                'user_id' => $user->id,
+                'user_id'  => $user->id,
                 'provider' => $provider,
             ], [
-                'token' => $providerUser->token,
-                'refresh_token' => $providerUser->refreshToken,
+                'token'             => $providerUser->token,
+                'refresh_token'     => $providerUser->refreshToken,
                 'last_refreshed_at' => now(),
             ]);
 

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -87,12 +87,12 @@ class OAuthController extends Controller
         if ($user) {
             $user->update([
                 $provider.'_id' => $providerUser->getId(),
+                'lastlogin_at'  => now(),
             ]);
 
             if (setting('general.record_user_ip', true)) {
                 $user->update([
-                    'last_ip'      => $request->ip(),
-                    'lastlogin_at' => now(),
+                    'last_ip'   => $request->ip(),
                 ]);
             }
 

--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -317,7 +317,7 @@ class PirepController extends Controller
 
                 $aircraft->subfleet->fares = collect($fares);
             }
-            // TODO: Set more fields from the Simbrief to the PIREP form
+        // TODO: Set more fields from the Simbrief to the PIREP form
         } else {
             $aircraft_list = $this->aircraftList(true);
         }

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -18,6 +18,7 @@ class User extends Resource
             'name'          => $this->name_private,
             'name_private'  => $this->name_private,
             'avatar'        => $this->resolveAvatarUrl(),
+            'discord_id'    => $this->discord_id,
             'rank_id'       => $this->rank_id,
             'home_airport'  => $this->home_airport_id,
             'curr_airport'  => $this->curr_airport_id,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,7 +260,9 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
     {
         return Attribute::make(
             get: function ($_, $attrs) {
-                echo 'Debugging $attrs: '.print_r($attrs, true).'\n';
+                if (!array_key_exists('avatar', $attrs)) {
+                    dd($attrs);
+                }
 
                 if (!$attrs['avatar']) {
                     return null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -123,7 +123,6 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
         'api_key',
         'email',
         'name',
-        'discord_id',
         'discord_private_channel_id',
         'password',
         'last_ip',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,6 +260,9 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
     {
         return Attribute::make(
             get: function ($_, $attrs) {
+
+                echo 'Debugging $attrs: ' . print_r($attrs, true) . '\n';
+
                 if (!$attrs['avatar']) {
                     return null;
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,10 +260,6 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
     {
         return Attribute::make(
             get: function ($_, $attrs) {
-                if (!array_key_exists('avatar', $attrs)) {
-                    dd($attrs);
-                }
-
                 if (!$attrs['avatar']) {
                     return null;
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,8 +260,7 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
     {
         return Attribute::make(
             get: function ($_, $attrs) {
-
-                echo 'Debugging $attrs: ' . print_r($attrs, true) . '\n';
+                echo 'Debugging $attrs: '.print_r($attrs, true).'\n';
 
                 if (!$attrs['avatar']) {
                     return null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,7 +260,6 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
     {
         return Attribute::make(
             get: function ($_, $attrs) {
-                dd($attrs);
                 if (!$attrs['avatar']) {
                     return null;
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,6 +260,7 @@ class User extends Authenticatable implements LaratrustUser, MustVerifyEmail
     {
         return Attribute::make(
             get: function ($_, $attrs) {
+                dd($attrs);
                 if (!$attrs['avatar']) {
                     return null;
                 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -614,7 +614,7 @@ class UserService extends Service
         try {
             $httpClient = new Client();
 
-            $response = $httpClient->post( 'https://discord.com/api/users/@me/channels', [
+            $response = $httpClient->post('https://discord.com/api/users/@me/channels', [
                 'headers' => [
                     'Authorization' => 'Bot '.config('services.discord.bot_token'),
                 ],
@@ -628,9 +628,9 @@ class UserService extends Service
                 'discord_private_channel_id' => $privateChannel,
             ]);
         } catch (\Exception $e) {
-            Log::error('Discord OAuth Error: ' . $e->getMessage());
+            Log::error('Discord OAuth Error: '.$e->getMessage());
         } catch (GuzzleException $e) {
-            Log::error('Discord OAuth Error: ' . $e->getMessage());
+            Log::error('Discord OAuth Error: '.$e->getMessage());
         }
     }
 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -24,6 +24,8 @@ use App\Repositories\UserRepository;
 use App\Support\Units\Time;
 use App\Support\Utils;
 use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Hash;
@@ -601,5 +603,34 @@ class UserService extends Service
         $user->refresh();
 
         return $user;
+    }
+
+    public function retrieveDiscordPrivateChannelId(User $user): void
+    {
+        if (is_null(config('services.discord.bot_token'))) {
+            return;
+        }
+
+        try {
+            $httpClient = new Client();
+
+            $response = $httpClient->post( 'https://discord.com/api/users/@me/channels', [
+                'headers' => [
+                    'Authorization' => 'Bot '.config('services.discord.bot_token'),
+                ],
+                'json' => [
+                    'recipient_id' => $user->discord_id,
+                ],
+            ]);
+
+            $privateChannel = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR)['id'];
+            $user->update([
+                'discord_private_channel_id' => $privateChannel,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Discord OAuth Error: ' . $e->getMessage());
+        } catch (GuzzleException $e) {
+            Log::error('Discord OAuth Error: ' . $e->getMessage());
+        }
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -36,6 +36,7 @@ return [
         'redirect'      => '/oauth/discord/callback',
 
         // optional
+        'bot_token'                => env('DISCORD_BOT_TOKEN', null),
         'allow_gif_avatars'        => (bool) env('DISCORD_AVATAR_GIF', true),
         'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
     ],

--- a/config/services.php
+++ b/config/services.php
@@ -36,7 +36,6 @@ return [
         'redirect'      => '/oauth/discord/callback',
 
         // optional
-        'token'                    => env('DISCORD_BOT_TOKEN', null),
         'allow_gif_avatars'        => (bool) env('DISCORD_AVATAR_GIF', true),
         'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
     ],

--- a/resources/views/layouts/default/auth/login_layout.blade.php
+++ b/resources/views/layouts/default/auth/login_layout.blade.php
@@ -22,6 +22,7 @@
 
 <!-- End Navbar -->
 <div class="page-header">
+@include('flash::message')
 
   <div class="container">
     @yield('content')

--- a/resources/views/layouts/default/auth/register.blade.php
+++ b/resources/views/layouts/default/auth/register.blade.php
@@ -139,12 +139,6 @@
           </table>
 
           <div style="width: 100%; text-align: right; padding-top: 20px;">
-            @if(config('services.discord.enabled'))
-              <a href="{{ route('oauth.redirect', ['provider' => 'discord']) }}" class="btn" style="background-color:#738ADB;">
-                @lang('auth.loginwith', ['provider' => 'Discord'])
-              </a>
-            @endif
-
             {{ Form::submit(__('auth.register'), [
                 'id' => 'register_button',
                 'class' => 'btn btn-primary',

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -28,7 +28,7 @@ class OAuthTest extends TestCase
                 'getId'     => 123456789,
                 'getName'   => 'OAuth user',
                 'getEmail'  => 'oauth.user@phpvms.net',
-                'getAvatar' => 'https://en.gravatar.com/userimage',
+                'getAvatar' => 'https://en.gravatar.com/userimage/12856995/aa6c0527a723abfd5fb9e246f0ff8af4.png',
             ]);
 
         $abstractUser->token = 'token';

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use App\Models\Airline;
-use App\Models\Airport;
 use App\Models\User;
 use App\Models\UserOAuthToken;
 use Illuminate\Support\Facades\Auth;
@@ -15,22 +13,22 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class OAuthTest extends TestCase
 {
-
     /** @var array|string[] The drivers we want to test */
     protected array $drivers = ['discord'];
 
     /**
      * Simulate what would be returned by the OAuth provider
+     *
      * @return LegacyMockInterface|MockInterface
      */
     protected function getMockedProvider(): LegacyMockInterface|MockInterface
     {
         $abstractUser = \Mockery::mock('Laravel\Socialite\Two\User')
             ->allows([
-                'getId'           => 123456789,
-                'getName'         => 'OAuth user',
-                'getEmail'        => 'oauth.user@phpvms.net',
-                'getAvatar'       => 'https://en.gravatar.com/userimage',
+                'getId'     => 123456789,
+                'getName'   => 'OAuth user',
+                'getEmail'  => 'oauth.user@phpvms.net',
+                'getAvatar' => 'https://en.gravatar.com/userimage',
             ]);
 
         $abstractUser->token = 'token';
@@ -44,12 +42,13 @@ class OAuthTest extends TestCase
 
     /**
      * Try to link a logged-in user to an OAuth account from profile
+     *
      * @return void
      */
     public function testLinkAccountFromProfile(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
         ]);
         Auth::login($user);
@@ -74,14 +73,15 @@ class OAuthTest extends TestCase
 
     /**
      * Try to link a non-logged-in user from the login page using its email
+     *
      * @return void
      */
     public function testLinkAccountFromLogin(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
+            'name'  => 'OAuth user',
             'email' => 'oauth.user@phpvms.net',
-            ]);
+        ]);
 
         foreach ($this->drivers as $driver) {
             Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());
@@ -103,22 +103,23 @@ class OAuthTest extends TestCase
 
     /**
      * Try to log in an already linked user
+     *
      * @return void
      */
     public function testLoginWithLinkedAccount(): void
     {
         $user = User::factory()->create([
-            'name' => 'OAuth user',
-            'email' => 'oauth.user@phpvms.net',
+            'name'       => 'OAuth user',
+            'email'      => 'oauth.user@phpvms.net',
             'discord_id' => 123456789,
         ]);
 
         foreach ($this->drivers as $driver) {
             UserOAuthToken::create([
-                'user_id' => $user->id,
-                'provider'  => $driver,
-                'token' => 'token',
-                'refresh_token' => 'refresh_token',
+                'user_id'           => $user->id,
+                'provider'          => $driver,
+                'token'             => 'token',
+                'refresh_token'     => 'refresh_token',
                 'last_refreshed_at' => now(),
             ]);
 
@@ -141,6 +142,7 @@ class OAuthTest extends TestCase
 
     /**
      * Try to log in someone not in DB
+     *
      * @return void
      */
     public function testNoAccountFound()
@@ -155,13 +157,14 @@ class OAuthTest extends TestCase
 
     /**
      * Try to unlink an account from profile
+     *
      * @return void
      */
     public function testUnlinkAccount(): void
     {
         $user = User::factory()->create([
-            'name'        => 'OAuth user',
-            'email'       => 'oauth.user@phpvms.net',
+            'name'  => 'OAuth user',
+            'email' => 'oauth.user@phpvms.net',
         ]);
 
         foreach ($this->drivers as $driver) {
@@ -181,6 +184,7 @@ class OAuthTest extends TestCase
 
     /**
      * Try to access a non-existing provider callback
+     *
      * @return void
      */
     public function testNonExistingProvider(): void
@@ -196,6 +200,7 @@ class OAuthTest extends TestCase
 
     /**
      * Try to access a disabled provider callback
+     *
      * @return void
      */
     public function testDisabledProvider(): void

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -16,6 +16,15 @@ class OAuthTest extends TestCase
     /** @var array|string[] The drivers we want to test */
     protected array $drivers = ['discord'];
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ($this->drivers as $driver) {
+            Config::set('services.'.$driver.'.enabled', true);
+        }
+    }
+
     /**
      * Simulate what would be returned by the OAuth provider
      *

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Tests;
+
+use App\Models\Airline;
+use App\Models\Airport;
+use App\Models\User;
+use App\Models\UserOAuthToken;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Laravel\Socialite\Facades\Socialite;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class OAuthTest extends TestCase
+{
+
+    /** @var array|string[] The drivers we want to test */
+    protected array $drivers = ['discord'];
+
+    /**
+     * Simulate what would be returned by the OAuth provider
+     * @return LegacyMockInterface|MockInterface
+     */
+    protected function getMockedProvider(): LegacyMockInterface|MockInterface
+    {
+        $abstractUser = \Mockery::mock('Laravel\Socialite\Two\User')
+            ->allows([
+                'getId'           => 123456789,
+                'getName'         => 'OAuth user',
+                'getEmail'        => 'oauth.user@phpvms.net',
+                'getAvatar'       => 'https://en.gravatar.com/userimage',
+            ]);
+
+        $abstractUser->token = 'token';
+        $abstractUser->refreshToken = 'refresh_token';
+
+        return \Mockery::mock('Laravel\Socialite\Contracts\Provider')
+            ->allows([
+                'user' => $abstractUser,
+            ]);
+    }
+
+    /**
+     * Try to link a logged-in user to an OAuth account from profile
+     * @return void
+     */
+    public function testLinkAccountFromProfile(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'OAuth user',
+            'email' => 'oauth.user@phpvms.net',
+        ]);
+        Auth::login($user);
+
+        foreach ($this->drivers as $driver) {
+            Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());
+
+            $this->get(route('oauth.callback', ['provider' => $driver]))
+                ->assertRedirect(route('frontend.profile.index'));
+
+            $user->refresh();
+            $this->assertEquals(123456789, $user->{$driver.'_id'});
+
+            $tokens = $user->oauth_tokens()->where('provider', $driver)->first();
+
+            $this->assertNotNull($tokens);
+            $this->assertEquals('token', $tokens->token);
+            $this->assertEquals('refresh_token', $tokens->refresh_token);
+            $this->assertTrue($tokens->last_refreshed_at->diffInSeconds(now()) <= 2);
+        }
+    }
+
+    /**
+     * Try to link a non-logged-in user from the login page using its email
+     * @return void
+     */
+    public function testLinkAccountFromLogin(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'OAuth user',
+            'email' => 'oauth.user@phpvms.net',
+            ]);
+
+        foreach ($this->drivers as $driver) {
+            Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());
+
+            $this->get(route('oauth.callback', ['provider' => $driver]))
+                ->assertRedirect(route('frontend.dashboard.index'));
+
+            $user->refresh();
+            $this->assertEquals(123456789, $user->{$driver.'_id'});
+
+            $tokens = $user->oauth_tokens()->where('provider', $driver)->first();
+
+            $this->assertNotNull($tokens);
+            $this->assertEquals('token', $tokens->token);
+            $this->assertEquals('refresh_token', $tokens->refresh_token);
+            $this->assertTrue($tokens->last_refreshed_at->diffInSeconds(now()) <= 2);
+        }
+    }
+
+    /**
+     * Try to log in an already linked user
+     * @return void
+     */
+    public function testLoginWithLinkedAccount(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'OAuth user',
+            'email' => 'oauth.user@phpvms.net',
+            'discord_id' => 123456789,
+        ]);
+
+        foreach ($this->drivers as $driver) {
+            UserOAuthToken::create([
+                'user_id' => $user->id,
+                'provider'  => $driver,
+                'token' => 'token',
+                'refresh_token' => 'refresh_token',
+                'last_refreshed_at' => now(),
+            ]);
+
+            Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());
+
+            $this->get(route('oauth.callback', ['provider' => $driver]))
+                ->assertRedirect(route('frontend.dashboard.index'));
+
+            $user->refresh();
+            $this->assertEquals(123456789, $user->{$driver.'_id'});
+
+            $tokens = $user->oauth_tokens()->where('provider', $driver)->first();
+
+            $this->assertNotNull($tokens);
+            $this->assertEquals('token', $tokens->token);
+            $this->assertEquals('refresh_token', $tokens->refresh_token);
+            $this->assertTrue($tokens->last_refreshed_at->diffInSeconds(now()) <= 2);
+        }
+    }
+
+    /**
+     * Try to log in someone not in DB
+     * @return void
+     */
+    public function testNoAccountFound()
+    {
+        foreach ($this->drivers as $driver) {
+            Socialite::shouldReceive('driver')->with($driver)->andReturn($this->getMockedProvider());
+
+            $this->get(route('oauth.callback', ['provider' => $driver]))
+                ->assertRedirect(url('/login'));
+        }
+    }
+
+    /**
+     * Try to unlink an account from profile
+     * @return void
+     */
+    public function testUnlinkAccount(): void
+    {
+        $user = User::factory()->create([
+            'name'        => 'OAuth user',
+            'email'       => 'oauth.user@phpvms.net',
+        ]);
+
+        foreach ($this->drivers as $driver) {
+            $user->update([
+                $driver.'_id' => 123456789,
+            ]);
+
+            Auth::login($user);
+
+            $this->get(route('oauth.logout', ['provider' => $driver]))
+                ->assertRedirect(route('frontend.profile.index'));
+
+            $user->refresh();
+            $this->assertEmpty($user->{$driver.'_id'});
+        }
+    }
+
+    /**
+     * Try to access a non-existing provider callback
+     * @return void
+     */
+    public function testNonExistingProvider(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->get(route('oauth.redirect', ['provider' => 'aze']))
+            ->assertStatus(404);
+
+        $this->get(route('oauth.callback', ['provider' => 'aze']))
+            ->assertStatus(404);
+    }
+
+    /**
+     * Try to access a disabled provider callback
+     * @return void
+     */
+    public function testDisabledProvider(): void
+    {
+        $originalConfigValue = config('services.discord.enabled');
+        Config::set('services.discord.enabled', false);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->get(route('oauth.redirect', ['provider' => 'discord']))
+            ->assertStatus(404);
+        $this->get(route('oauth.callback', ['provider' => 'discord']))
+            ->assertStatus(404);
+
+        Config::set('services.discord.enabled', $originalConfigValue);
+    }
+}


### PR DESCRIPTION
Drop the foreign key if the migration managed to create it without error.

Do not create a new account via OAuth if the provider's email is already in the database. However, we do not link the account either for security reasons.

![image](https://github.com/nabeelio/phpvms/assets/41431456/e06af7ce-0c43-4899-8f50-3aa56decce4b)
