### PR TITLE
Add settings to disable registration or make it invite-only

### DIFF
--- a/app/Cron/Hourly/ClearExpiredInvites.php
+++ b/app/Cron/Hourly/ClearExpiredInvites.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Cron\Hourly;
+
+use App\Contracts\Listener;
+use App\Events\CronHourly;
+use App\Models\Invite;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Clear any expired invites
+ */
+class ClearExpiredInvites extends Listener
+{
+    /**
+     * @param CronHourly $event
+     */
+    public function handle(CronHourly $event): void
+    {
+        Log::info('Hourly: Removing expired invites');
+        $invites = Invite::all();
+
+        foreach ($invites as $invite) {
+            if ($invite->expires_at && $invite->expires_at->isPast()) {
+                $invite->delete();
+            }
+
+            if ($invite->usage_limit && $invite->usage_count >= $invite->usage_limit) {
+                $invite->delete();
+            }
+        }
+    }
+}

--- a/app/Cron/Hourly/ClearExpiredInvites.php
+++ b/app/Cron/Hourly/ClearExpiredInvites.php
@@ -5,7 +5,6 @@ namespace App\Cron\Hourly;
 use App\Contracts\Listener;
 use App\Events\CronHourly;
 use App\Models\Invite;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 
 /**

--- a/app/Database/migrations/2023_12_27_112456_create_invites_table.php
+++ b/app/Database/migrations/2023_12_27_112456_create_invites_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('invites', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->nullable();
+            $table->longText('token');
+            $table->integer('usage_count')->default(0);
+            $table->integer('usage_limit')->nullable();
+            $table->dateTime('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invites');
+    }
+};

--- a/app/Database/migrations/2023_12_27_112456_create_invites_table.php
+++ b/app/Database/migrations/2023_12_27_112456_create_invites_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class() extends Migration {
     public function up(): void
     {
         Schema::create('invites', function (Blueprint $table) {

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -61,6 +61,20 @@
   options: ''
   type: boolean
   description: Record the user's IP address on register/login
+- key: general.invite_only_registration
+  name: 'Invite Only Registration'
+  group: general
+  value: false
+  options: ''
+  type: boolean
+  description: If checked, only users with an invite can register
+- key: general.disable_registration
+  name: 'Disable registration'
+  group: general
+  value: false
+  options: ''
+  type: boolean
+  description: If checked, registration will be disabled and only admins can add pilots
 - key: captcha.enabled
   name: 'hCaptcha Enabled'
   group: captcha

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -61,20 +61,20 @@
   options: ''
   type: boolean
   description: Record the user's IP address on register/login
-- key: general.invite_only_registration
-  name: 'Invite Only Registration'
+- key: general.invite_only_registrations
+  name: 'Invite Only Registrations'
   group: general
   value: false
   options: ''
   type: boolean
   description: If checked, only users with an invite can register
-- key: general.disable_registration
-  name: 'Disable registration'
+- key: general.disable_registrations
+  name: 'Disable registrations'
   group: general
   value: false
   options: ''
   type: boolean
-  description: If checked, registration will be disabled and only admins can add pilots
+  description: If checked, registrations will be disabled and only admins can add pilots
 - key: captcha.enabled
   name: 'hCaptcha Enabled'
   group: captcha

--- a/app/Http/Controllers/Admin/InviteController.php
+++ b/app/Http/Controllers/Admin/InviteController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Contracts\Controller;
+use App\Http\Requests\CreateInviteRequest;
+use App\Models\Invite;
+use App\Notifications\Messages\InviteLink;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\View\View;
+use Laracasts\Flash\Flash;
+
+class InviteController extends Controller
+{
+    public function index(): RedirectResponse|View
+    {
+        if (!setting('general.invite_only_registration', false)) {
+            Flash::error('Registration is not on invite only');
+            return redirect(route('admin.users.index'));
+        }
+
+        $invites = Invite::all();
+
+        return view('admin.invites.index', [
+            'invites' => $invites,
+        ]);
+    }
+
+    public function create(): RedirectResponse|View
+    {
+        if (!setting('general.invite_only_registration', false)) {
+            Flash::error('Registration is not on invite only');
+            return redirect(route('admin.users.index'));
+        }
+
+        return view('admin.invites.create');
+    }
+
+    public function store(CreateInviteRequest $request): RedirectResponse
+    {
+        if (!setting('general.invite_only_registration', false)) {
+            Flash::error('Registration is not on invite only');
+            return redirect(route('admin.users.index'));
+        }
+
+        $invite = Invite::create([
+            'email'       => $request->get('email'),
+            'token'       => sha1(hrtime(true) . str_random()),
+            'usage_count' => 0,
+            'usage_limit' => !is_null($request->get('email')) ? 1 : $request->get('usage_limit'),
+            'expires_at'  => $request->get('expires_at'),
+        ]);
+
+        if (!is_null($request->get('email')) && get_truth_state($request->get('email_link'))) {
+            Notification::route('mail', $request->get('email'))
+                ->notify(new InviteLink($invite));
+        }
+
+        Flash::success('Invite created successfully. The link is: ' . $invite->link);
+
+        return redirect(route('admin.invites.index'));
+    }
+
+    public function destroy(int $id): RedirectResponse
+    {
+        if (!setting('general.invite_only_registration', false)) {
+            Flash::error('Registration is not on invite only');
+            return redirect(route('admin.users.index'));
+        }
+
+        $invite = Invite::find($id);
+
+        if (!$invite) {
+            Flash::error('Invite not found');
+            return redirect(route('admin.invites.index'));
+        }
+
+        $invite->delete();
+
+        Flash::success('Invite deleted successfully');
+        return redirect(route('admin.invites.index'));
+    }
+
+}

--- a/app/Http/Controllers/Admin/InviteController.php
+++ b/app/Http/Controllers/Admin/InviteController.php
@@ -15,7 +15,7 @@ class InviteController extends Controller
 {
     public function index(): RedirectResponse|View
     {
-        if (!setting('general.invite_only_registration', false)) {
+        if (!setting('general.invite_only_registrations', false)) {
             Flash::error('Registration is not on invite only');
             return redirect(route('admin.users.index'));
         }
@@ -29,7 +29,7 @@ class InviteController extends Controller
 
     public function create(): RedirectResponse|View
     {
-        if (!setting('general.invite_only_registration', false)) {
+        if (!setting('general.invite_only_registrations', false)) {
             Flash::error('Registration is not on invite only');
             return redirect(route('admin.users.index'));
         }
@@ -39,7 +39,7 @@ class InviteController extends Controller
 
     public function store(CreateInviteRequest $request): RedirectResponse
     {
-        if (!setting('general.invite_only_registration', false)) {
+        if (!setting('general.invite_only_registrations', false)) {
             Flash::error('Registration is not on invite only');
             return redirect(route('admin.users.index'));
         }
@@ -64,7 +64,7 @@ class InviteController extends Controller
 
     public function destroy(int $id): RedirectResponse
     {
-        if (!setting('general.invite_only_registration', false)) {
+        if (!setting('general.invite_only_registrations', false)) {
             Flash::error('Registration is not on invite only');
             return redirect(route('admin.users.index'));
         }

--- a/app/Http/Controllers/Admin/InviteController.php
+++ b/app/Http/Controllers/Admin/InviteController.php
@@ -46,7 +46,7 @@ class InviteController extends Controller
 
         $invite = Invite::create([
             'email'       => $request->get('email'),
-            'token'       => sha1(hrtime(true) . str_random()),
+            'token'       => sha1(hrtime(true).str_random()),
             'usage_count' => 0,
             'usage_limit' => !is_null($request->get('email')) ? 1 : $request->get('usage_limit'),
             'expires_at'  => $request->get('expires_at'),
@@ -57,7 +57,7 @@ class InviteController extends Controller
                 ->notify(new InviteLink($invite));
         }
 
-        Flash::success('Invite created successfully. The link is: ' . $invite->link);
+        Flash::success('Invite created successfully. The link is: '.$invite->link);
 
         return redirect(route('admin.invites.index'));
     }
@@ -81,5 +81,4 @@ class InviteController extends Controller
         Flash::success('Invite deleted successfully');
         return redirect(route('admin.invites.index'));
     }
-
 }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -107,7 +107,7 @@ class UserController extends Controller
      */
     public function store(CreateUserRequest $request): RedirectResponse
     {
-        if (!setting('general.disable_registration', false)) {
+        if (!setting('general.disable_registrations', false)) {
             Flash::error('User registration is not disabled');
             return redirect(route('admin.users.index'));
         }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Contracts\Controller;
 use App\Models\Enums\UserState;
+use App\Models\Invite;
 use App\Models\User;
 use App\Models\UserField;
 use App\Models\UserFieldValue;
@@ -53,12 +54,26 @@ class RegisterController extends Controller
     }
 
     /**
-     * @throws \Exception
-     *
+     * @param Request $request
      * @return View
      */
-    public function showRegistrationForm(): View
+    public function showRegistrationForm(Request $request): View
     {
+        if (setting('general.disable_registrations', false)) {
+            abort(403, 'Registrations are disabled');
+        }
+
+        if (setting('general.invite_only_registrations', false)) {
+            if (!$request->has('invite') && !$request->has('token')) {
+                abort(403, 'Registrations are invite only');
+            }
+
+            $invite = Invite::find($request->get('invite'));
+            if (!$invite || $invite->token !== $request->get('token')) {
+                abort(403, 'Invalid invite');
+            }
+        }
+
         $airlines = $this->airlineRepo->selectBoxList();
         $userFields = UserField::where(['show_on_registration' => true, 'active' => true])->get();
 
@@ -69,6 +84,7 @@ class RegisterController extends Controller
             'timezones'  => Timezonelist::toArray(),
             'userFields' => $userFields,
             'hubs_only'  => setting('pilots.home_hubs_only'),
+            'invite'     => $invite ?? null,
             'captcha'    => [
                 'enabled'    => setting('captcha.enabled', env('CAPTCHA_ENABLED', false)),
                 'site_key'   => setting('captcha.site_key', env('CAPTCHA_SITE_KEY')),
@@ -142,6 +158,37 @@ class RegisterController extends Controller
      */
     protected function create(Request $request): User
     {
+        if (setting('general.disable_registrations', false)) {
+            abort(403, 'Registrations are disabled');
+        }
+
+        if (setting('general.invite_only_registrations', false)) {
+            if (!$request->has('invite') && !$request->has('invite_token')) {
+                abort(403, 'Registrations are invite only');
+            }
+
+            $invite = Invite::find($request->get('invite'));
+            if (!$invite || $invite->token !== base64_decode($request->get('invite_token'))) {
+                abort(403, 'Invalid invite');
+            }
+
+            if ($invite->usage_limit && $invite->usage_count >= $invite->usage_limit) {
+                abort(403, 'Invite has been used too many times');
+            }
+
+            if ($invite->expires_at && $invite->expires_at->isPast()) {
+                abort(403, 'Invite has expired');
+            }
+
+            if ($invite->email && $invite->email !== $request->get('email')) {
+                abort(403, 'Invite is for a different email address');
+            }
+
+            $invite->update([
+                'usage_count' => $invite->usage_count + 1,
+            ]);
+        }
+
         // Default options
         $opts = $request->all();
         $opts['password'] = Hash::make($opts['password']);

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -72,6 +72,14 @@ class RegisterController extends Controller
             if (!$invite || $invite->token !== $request->get('token')) {
                 abort(403, 'Invalid invite');
             }
+
+            if ($invite->usage_limit && $invite->usage_count >= $invite->usage_limit) {
+                abort(403, 'Invite has been used too many times');
+            }
+
+            if ($invite->expires_at && $invite->expires_at->isPast()) {
+                abort(403, 'Invite has expired');
+            }
         }
 
         $airlines = $this->airlineRepo->selectBoxList();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -55,6 +55,7 @@ class RegisterController extends Controller
 
     /**
      * @param Request $request
+     *
      * @return View
      */
     public function showRegistrationForm(Request $request): View

--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -317,7 +317,7 @@ class PirepController extends Controller
 
                 $aircraft->subfleet->fares = collect($fares);
             }
-            // TODO: Set more fields from the Simbrief to the PIREP form
+        // TODO: Set more fields from the Simbrief to the PIREP form
         } else {
             $aircraft_list = $this->aircraftList(true);
         }

--- a/app/Http/Requests/CreateInviteRequest.php
+++ b/app/Http/Requests/CreateInviteRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateInviteRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'email'       => 'nullable|string',
+            'usage_limit' => 'nullable|integer',
+            'expires_at'  => 'nullable|date|after:today'
+        ];
+    }
+}

--- a/app/Http/Requests/CreateInviteRequest.php
+++ b/app/Http/Requests/CreateInviteRequest.php
@@ -16,7 +16,7 @@ class CreateInviteRequest extends FormRequest
         return [
             'email'       => 'nullable|string',
             'usage_limit' => 'nullable|integer',
-            'expires_at'  => 'nullable|date|after:today'
+            'expires_at'  => 'nullable|date|after:today',
         ];
     }
 }

--- a/app/Http/Requests/CreateUserRequest.php
+++ b/app/Http/Requests/CreateUserRequest.php
@@ -13,22 +13,15 @@ class CreateUserRequest extends FormRequest
      */
     public function rules(): array
     {
-        $rules = [
+        return [
             'name'            => 'required',
             'email'           => 'required|email|unique:users,email',
             'airline_id'      => 'required',
             'home_airport_id' => 'required',
-            'password'        => 'required|confirmed',
+            'password'        => 'required',
             'timezone'        => 'required',
             'country'         => 'required',
             'transfer_time'   => 'sometimes|integer|min:0',
-            'toc_accepted'    => 'accepted',
         ];
-
-        if (config('captcha.enabled')) {
-            $rules['g-recaptcha-response'] = 'required|captcha';
-        }
-
-        return $rules;
     }
 }

--- a/app/Models/Invite.php
+++ b/app/Models/Invite.php
@@ -3,7 +3,15 @@
 namespace App\Models;
 
 use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
+/**
+ * @property string $email
+ * @property string $token
+ * @property int $usage_count
+ * @property int $usage_limit
+ * @property \Carbon\Carbon $expires_at
+ */
 class Invite extends Model
 {
     public $table = 'invites';
@@ -31,4 +39,11 @@ class Invite extends Model
         'usage_limit' => 'nullable|integer',
         'expires_at'  => 'nullable|datetime'
     ];
+
+    public function link(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value, $attrs) => url('/register?invite='.$attrs['id'].'&token='.$attrs['token'])
+            );
+    }
 }

--- a/app/Models/Invite.php
+++ b/app/Models/Invite.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Contracts\Model;
+
+class Invite extends Model
+{
+    public $table = 'invites';
+
+    protected $fillable = [
+        'email',
+        'token',
+        'usage_count',
+        'usage_limit',
+        'expires_at'
+    ];
+
+    protected $casts = [
+        'email'       => 'string',
+        'token'       => 'string',
+        'usage_count' => 'integer',
+        'usage_limit' => 'integer',
+        'expires_at'  => 'datetime'
+    ];
+
+    public static array $rules = [
+        'email'       => 'nullable|string',
+        'token'       => 'required|string',
+        'usage_count' => 'integer',
+        'usage_limit' => 'nullable|integer',
+        'expires_at'  => 'nullable|datetime'
+    ];
+}

--- a/app/Models/Invite.php
+++ b/app/Models/Invite.php
@@ -6,10 +6,10 @@ use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
 /**
- * @property string $email
- * @property string $token
- * @property int $usage_count
- * @property int $usage_limit
+ * @property string         $email
+ * @property string         $token
+ * @property int            $usage_count
+ * @property int            $usage_limit
  * @property \Carbon\Carbon $expires_at
  */
 class Invite extends Model
@@ -21,7 +21,7 @@ class Invite extends Model
         'token',
         'usage_count',
         'usage_limit',
-        'expires_at'
+        'expires_at',
     ];
 
     protected $casts = [
@@ -29,7 +29,7 @@ class Invite extends Model
         'token'       => 'string',
         'usage_count' => 'integer',
         'usage_limit' => 'integer',
-        'expires_at'  => 'datetime'
+        'expires_at'  => 'datetime',
     ];
 
     public static array $rules = [
@@ -37,13 +37,13 @@ class Invite extends Model
         'token'       => 'required|string',
         'usage_count' => 'integer',
         'usage_limit' => 'nullable|integer',
-        'expires_at'  => 'nullable|datetime'
+        'expires_at'  => 'nullable|datetime',
     ];
 
     public function link(): Attribute
     {
         return Attribute::make(
             get: fn ($value, $attrs) => url('/register?invite='.$attrs['id'].'&token='.$attrs['token'])
-            );
+        );
     }
 }

--- a/app/Notifications/Messages/InviteLink.php
+++ b/app/Notifications/Messages/InviteLink.php
@@ -21,7 +21,7 @@ class InviteLink extends Notification
         parent::__construct();
 
         $this->setMailable(
-            'You have been invited to join ' .config('app.name'),
+            'You have been invited to join '.config('app.name'),
             'notifications.mail.user.invite',
             ['invite' => $invite]
         );

--- a/app/Notifications/Messages/InviteLink.php
+++ b/app/Notifications/Messages/InviteLink.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications\Messages;
+
+use App\Contracts\Notification;
+use App\Models\Invite;
+use App\Notifications\Channels\MailChannel;
+
+class InviteLink extends Notification
+{
+    use MailChannel;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param Invite $invite
+     */
+    public function __construct(
+        private readonly Invite $invite
+    ) {
+        parent::__construct();
+
+        $this->setMailable(
+            'You have been invited to join ' .config('app.name'),
+            'notifications.mail.user.invite',
+            ['invite' => $invite]
+        );
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param $notifiable
+     *
+     * @return array
+     */
+    public function toArray($notifiable): array
+    {
+        return [
+            'invite_id' => $this->invite->id,
+        ];
+    }
+}

--- a/app/Providers/CronServiceProvider.php
+++ b/app/Providers/CronServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Cron\Hourly\ClearExpiredInvites;
 use App\Cron\Hourly\ClearExpiredSimbrief;
 use App\Cron\Hourly\DeletePireps;
 use App\Cron\Hourly\RemoveExpiredBids;
@@ -35,6 +36,7 @@ class CronServiceProvider extends ServiceProvider
             RemoveExpiredBids::class,
             RemoveExpiredLiveFlights::class,
             ClearExpiredSimbrief::class,
+            ClearExpiredInvites::class,
         ],
         CronNightly::class => [
             ApplyExpenses::class,

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -487,6 +487,13 @@ class RouteServiceProvider extends ServiceProvider
 
             Route::resource('users', 'UserController')->middleware('ability:admin,users');
 
+            Route::resource('invites', 'InviteController')->middleware('ability:admin,users')
+                ->except([
+                    'show',
+                    'edit',
+                    'update'
+                ]);
+
             Route::match([
                 'get',
                 'post',

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -491,7 +491,7 @@ class RouteServiceProvider extends ServiceProvider
                 ->except([
                     'show',
                     'edit',
-                    'update'
+                    'update',
                 ]);
 
             Route::match([

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -82,9 +82,10 @@ class UserService extends Service
      * Register a pilot. Also attaches the initial roles
      * required, and then triggers the UserRegistered event
      *
-     * @param array $attrs Array with the user data
-     * @param array $roles List of "display_name" of groups to assign
+     * @param array    $attrs Array with the user data
+     * @param array    $roles List of "display_name" of groups to assign
      * @param int|null $state
+     *
      * @return User
      */
     public function createUser(array $attrs, array $roles = [], ?int $state = null): User
@@ -96,7 +97,7 @@ class UserService extends Service
         // Determine if we want to auto accept
         if ($state === null && setting('pilots.auto_accept') === true) {
             $user->state = UserState::ACTIVE;
-        } else if ($state === null) {
+        } elseif ($state === null) {
             $user->state = UserState::PENDING;
         }
 

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -84,21 +84,19 @@ class UserService extends Service
      *
      * @param array $attrs Array with the user data
      * @param array $roles List of "display_name" of groups to assign
-     *
-     * @throws \Exception
-     *
+     * @param int|null $state
      * @return User
      */
-    public function createUser(array $attrs, array $roles = []): User
+    public function createUser(array $attrs, array $roles = [], ?int $state = null): User
     {
         $user = User::create($attrs);
         $user->api_key = Utils::generateApiKey();
         $user->curr_airport_id = $user->home_airport_id;
 
         // Determine if we want to auto accept
-        if (setting('pilots.auto_accept') === true) {
+        if ($state === null && setting('pilots.auto_accept') === true) {
             $user->state = UserState::ACTIVE;
-        } else {
+        } else if ($state === null) {
             $user->state = UserState::PENDING;
         }
 

--- a/resources/views/admin/invites/create.blade.php
+++ b/resources/views/admin/invites/create.blade.php
@@ -1,0 +1,11 @@
+@extends('admin.app')
+@section('title', 'Add Invite')
+@section('content')
+  <div class="card border-blue-bottom">
+    <div class="content">
+      {{ Form::open(['route' => 'admin.invites.store', 'autofill' => false]) }}
+      @include('admin.invites.fields')
+      {{ Form::close() }}
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/invites/fields.blade.php
+++ b/resources/views/admin/invites/fields.blade.php
@@ -1,0 +1,49 @@
+<div class="row">
+  <div class="form-group col-sm-4">
+    {{ Form::label('email', 'Email:') }}
+    {{ Form::email('email', null, ['class' => 'form-control']) }}
+    <p class="text-danger">{{ $errors->first('email') }}</p>
+    @component('admin.components.info')
+      If empty all emails will be allowed to register using the link.
+    @endcomponent
+  </div>
+
+  <div class="form-group col-sm-4">
+    {{ Form::label('usage_limit', 'Usage limit:') }}
+    {{ Form::number('usage_limit', null, ['class' => 'form-control']) }}
+    <p class="text-danger">{{ $errors->first('usage_limit') }}</p>
+    @component('admin.components.info')
+      If empty there will be no limit on the number of times the link can be used.
+      If an email is provided the limit will be automatically set to 1.
+    @endcomponent
+  </div>
+
+  <div class="form-group col-sm-4">
+    {{ Form::label('expires_at', 'Expiration Date:') }}
+    <input type="datetime-local" class="form-control" name="expires_at" id="expires_at" />
+    <p class="text-danger">{{ $errors->first('expires_at') }}</p>
+    @component('admin.components.info')
+      If empty the link will not expire.
+    @endcomponent
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-6">
+    {{ Form::label('email_link', 'Email Invite Link:') }}
+    <label class="checkbox-inline">
+      {{ Form::hidden('email_link', 0, false) }}
+      {{ Form::checkbox('email_link', 1, null) }}
+    </label>
+    @component('admin.components.info')
+      If checked and an email is provided, the invite will be sent via email.
+    @endcomponent
+  </div>
+
+  <!-- Submit Field -->
+  <div class="form-group col-sm-6">
+    <div class="pull-right">
+      {{ Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) }}
+      <a href="{{ route('admin.userfields.index') }}" class="btn btn-default">Cancel</a>
+    </div></div>
+</div>

--- a/resources/views/admin/invites/index.blade.php
+++ b/resources/views/admin/invites/index.blade.php
@@ -1,0 +1,15 @@
+@extends('admin.app')
+@section('title', 'Invites')
+
+@section('actions')
+  <li><a href="{{ route('admin.invites.create') }}"><i class="ti-plus"></i>Add Invite</a></li>
+@endsection
+
+@section('content')
+  <div class="card border-blue-bottom">
+    <div class="content">
+      @include('admin.invites.table')
+    </div>
+  </div>
+@endsection
+

--- a/resources/views/admin/invites/table.blade.php
+++ b/resources/views/admin/invites/table.blade.php
@@ -1,0 +1,36 @@
+<div class="content table-responsive table-full-width">
+  <table class="table table-hover table-responsive" id="pirepFields-table">
+    <thead>
+    <th>Invite Type</th>
+    <th>Invited Email/Invite Link</th>
+    <th>Usage Count</th>
+    <th>Usage Limit</th>
+    <th>Expires In</th>
+    <th></th>
+    </thead>
+    <tbody>
+    @foreach($invites as $invite)
+      <tr>
+        <td>{{ is_null($invite->email) ? 'Link' : 'Email' }}</td>
+        <td>
+          @if(is_null($invite->email))
+            <a href="{{ $invite->link }}">{{ $invite->link }}</a>
+          @else
+            {{ $invite->email }}
+          @endif
+        </td>
+        <td>{{ $invite->usage_count }}</td>
+        <td>{{ $invite->usage_limit ?? 'No limit' }}</td>
+        <td>{{ $invite->expires_at?->diffForHumans() ?? 'Never' }}
+        <td class="text-right">
+          {{ Form::open(['route' => ['admin.invites.destroy', $invite->id], 'method' => 'delete']) }}
+          {{ Form::button('<i class="fa fa-times"></i>',
+                       ['type' => 'submit', 'class' => 'btn btn-sm btn-danger btn-icon',
+                        'onclick' => "return confirm('Are you sure?')"]) }}
+          {{ Form::close() }}
+        </td>
+      </tr>
+    @endforeach
+    </tbody>
+  </table>
+</div>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -3,9 +3,18 @@
 @section('content')
   <div class="card border-blue-bottom">
     <div class="content">
-      {{ Form::open(['route' => 'admin.airlines.store', 'autocomplete' => false]) }}
-      @include('admin.airlines.fields')
+      {{ Form::open(['route' => 'admin.users.store', 'autocomplete' => false]) }}
+      @include('admin.users.fields')
+
+      <div class="row">
+        <div class="form-group col-sm-12 text-right">
+          {{ Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) }}
+          <a href="{{ route('admin.users.index') }}" class="btn btn-default">Cancel</a>
+        </div>
+      </div>
       {{ Form::close() }}
     </div>
   </div>
 @endsection
+
+@include('admin.users.script')

--- a/resources/views/admin/users/custom_fields.blade.php
+++ b/resources/views/admin/users/custom_fields.blade.php
@@ -1,0 +1,22 @@
+@if($user->fields)
+  <table class="table table-hover">
+    <tr>
+      <td colspan="2"><h5>Custom Fields</h5></td>
+    </tr>
+    {{-- Custom Fields --}}
+    @foreach($user->fields as $field)
+      <tr>
+        <td>{{ $field->field->name }}</td>
+        <td>
+          @if(in_array($field->name, ['IVAO', 'IVAO ID']))
+            <a href='https://www.ivao.aero/Member.aspx?ID={{ $field->value }}' target='_blank'>{{ $field->value }}</a>
+          @elseif(in_array($field->name, ['VATSIM', 'VATSIM CID', 'VATSIM ID']))
+            <a href='https://stats.vatsim.net/search_id.php?id={{ $field->value }}' target='_blank'>{{ $field->value }}</a>
+          @else
+            {{ $field->value }}
+          @endif
+        </td>
+      </tr>
+    @endforeach
+  </table>
+@endif

--- a/resources/views/admin/users/details.blade.php
+++ b/resources/views/admin/users/details.blade.php
@@ -1,0 +1,47 @@
+<table class="table table-hover">
+  <tr>
+    <td colspan="2"><h5>User Details</h5></td>
+  </tr>
+  <tr>
+    <td>Total Flights</td>
+    <td>{{ $user->flights }}</td>
+  </tr>
+  <tr>
+    <td>Flight Time</td>
+    <td>@minutestotime($user->flight_time)</td>
+  </tr>
+  <tr>
+    <td>Registered On</td>
+    <td>{{ show_datetime($user->created_at) }}</td>
+  </tr>
+  <tr>
+    <td>E-Mail Verified On</td>
+    <td>
+      @if(filled($user->email_verified_at))
+        {{ show_datetime($user->email_verified_at) }}
+      @else
+        <span class="btn btn-sm btn-danger mx-1 my-0 p-1">USER E-MAIL NOT VERIFIED !!!</span>
+      @endif
+    </td>
+  </tr>
+  <tr>
+    <td>Last Login</td>
+    <td>
+      @if(filled($user->lastlogin_at))
+        {{ show_datetime($user->lastlogin_at) }}
+      @endif
+    </td>
+  </tr>
+  <tr>
+    <td>IP Address</td>
+    <td>{{ $user->last_ip ?? '-' }}</td>
+  </tr>
+  <tr>
+    <td>@lang('toc.title')</td>
+    <td>{{ $user->toc_accepted ? __('common.yes') : __('common.no') }}</td>
+  </tr>
+  <tr>
+    <td>@lang('profile.opt-in')</td>
+    <td>{{ $user->opt_in ? __('common.yes') : __('common.no') }}</td>
+  </tr>
+</table>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -5,7 +5,31 @@
     <div class="content">
       {{ Form::model($user, ['route' => ['admin.users.update', $user->id], 'method' => 'patch', 'autocomplete' => false]) }}
       @include('admin.users.fields')
+
+      <div class="row">
+        <div class="form-group col-sm-12 text-right">
+          {{-- <a href="{{ route('admin.users.regen_apikey', [$user->id]) }}" class="btn btn-warning" onclick="return confirm('Are you sure? This will reset this user\'s API key.')">New API Key</a> --}}
+          &nbsp;
+          @if (!$user->email_verified_at)
+            <a href="{{ route('admin.users.verify_email', [$user->id]) }}" class="btn btn-danger">Verify email manually</a>
+          @else
+            <a href="{{ route('admin.users.request_email_verification', [$user->id]) }}" class="btn btn-warning">Request new email verification</a>
+          @endif
+
+          {{ Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) }}
+          <a href="{{ route('admin.users.index') }}" class="btn btn-default">Cancel</a>
+        </div>
+      </div>
       {{ Form::close() }}
+
+      <div class="row">
+        <div class="form-group col-sm-6">
+          @include('admin.users.custom_fields')
+        </div>
+        <div class="form-group col-sm-6">
+          @include('admin.users.details')
+        </div>
+      </div>
     </div>
   </div>
 

--- a/resources/views/admin/users/fields.blade.php
+++ b/resources/views/admin/users/fields.blade.php
@@ -43,7 +43,7 @@
   </div>
   <div class="form-group col-sm-1">
     {{ Form::label('transfer_time', 'Transfer Hours:') }}
-    {{ Form::text('transfer_time', \App\Support\Units\Time::minutesToHours($user->transfer_time), ['class' => 'form-control']) }}
+    {{ Form::text('transfer_time', \App\Support\Units\Time::minutesToHours($user?->transfer_time), ['class' => 'form-control']) }}
     <p class="text-danger">{{ $errors->first('transfer_time') }}</p>
   </div>
   <div class="form-group col-sm-3">
@@ -74,7 +74,7 @@
   <div class="form-group col-sm-6">
     @ability('admin', 'admin-user')
       {{ Form::label('roles', 'Roles:') }}
-      {{ Form::select('roles[]', $roles, $user->roles->pluck('id'), ['class' => 'form-control select2', 'placeholder' => 'Select Roles', 'multiple']) }}
+      {{ Form::select('roles[]', $roles, $user?->roles->pluck('id') ?? collect(), ['class' => 'form-control select2', 'placeholder' => 'Select Roles', 'multiple']) }}
     @endability
   </div>
 </div>
@@ -83,96 +83,5 @@
   <div class="form-group col-md-12">
     {{ Form::label('notes', 'Management Notes:') }}
     {{ Form::textarea('notes', null, ['class' => 'form-control', 'rows' => 4, 'autocomplete' => 'off']) }}
-  </div>
-</div>
-
-<div class="row">
-  <div class="form-group col-sm-12 text-right">
-    {{-- <a href="{{ route('admin.users.regen_apikey', [$user->id]) }}" class="btn btn-warning" onclick="return confirm('Are you sure? This will reset this user\'s API key.')">New API Key</a> --}}
-    &nbsp;
-    @if (!$user->email_verified_at)
-      <a href="{{ route('admin.users.verify_email', [$user->id]) }}" class="btn btn-danger">Verify email manually</a>
-    @else
-      <a href="{{ route('admin.users.request_email_verification', [$user->id]) }}" class="btn btn-warning">Request new email verification</a>
-    @endif
-
-    {{ Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) }}
-    <a href="{{ route('admin.users.index') }}" class="btn btn-default">Cancel</a>
-  </div>
-</div>
-
-<div class="row">
-  <div class="form-group col-sm-6">
-    @if($user->fields)
-      <table class="table table-hover">
-        <tr>
-          <td colspan="2"><h5>Custom Fields</h5></td>
-        </tr>
-        {{-- Custom Fields --}}
-        @foreach($user->fields as $field)
-          <tr>
-            <td>{{ $field->field->name }}</td>
-            <td>
-              @if(in_array($field->name, ['IVAO', 'IVAO ID']))
-                <a href='https://www.ivao.aero/Member.aspx?ID={{ $field->value }}' target='_blank'>{{ $field->value }}</a>
-              @elseif(in_array($field->name, ['VATSIM', 'VATSIM CID', 'VATSIM ID']))
-                <a href='https://stats.vatsim.net/search_id.php?id={{ $field->value }}' target='_blank'>{{ $field->value }}</a>
-              @else
-                {{ $field->value }}
-              @endif
-            </td>
-          </tr>
-        @endforeach
-      </table>
-    @endif
-  </div>
-  <div class="form-group col-sm-6">
-    <table class="table table-hover">
-      <tr>
-        <td colspan="2"><h5>User Details</h5></td>
-      </tr>
-      <tr>
-        <td>Total Flights</td>
-        <td>{{ $user->flights }}</td>
-      </tr>
-      <tr>
-        <td>Flight Time</td>
-        <td>@minutestotime($user->flight_time)</td>
-      </tr>
-      <tr>
-        <td>Registered On</td>
-        <td>{{ show_datetime($user->created_at) }}</td>
-      </tr>
-      <tr>
-        <td>E-Mail Verified On</td>
-        <td>
-          @if(filled($user->email_verified_at))
-            {{ show_datetime($user->email_verified_at) }}
-          @else
-            <span class="btn btn-sm btn-danger mx-1 my-0 p-1">USER E-MAIL NOT VERIFIED !!!</span>
-          @endif
-        </td>
-      </tr>
-      <tr>
-        <td>Last Login</td>
-        <td>
-          @if(filled($user->lastlogin_at))
-            {{ show_datetime($user->lastlogin_at) }}
-          @endif
-        </td>
-      </tr>
-      <tr>
-        <td>IP Address</td>
-        <td>{{ $user->last_ip ?? '-' }}</td>
-      </tr>
-      <tr>
-        <td>@lang('toc.title')</td>
-        <td>{{ $user->toc_accepted ? __('common.yes') : __('common.no') }}</td>
-      </tr>
-      <tr>
-        <td>@lang('profile.opt-in')</td>
-        <td>{{ $user->opt_in ? __('common.yes') : __('common.no') }}</td>
-      </tr>
-    </table>
   </div>
 </div>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -5,12 +5,12 @@
   <li>
     <a href="{{ route('admin.userfields.index') }}"></i>Profile Fields</a>
   </li>
-  @if(setting('general.disable_registration', false))
+  @if(setting('general.disable_registrations', false))
       <li>
         <a href="{{ route('admin.users.create') }}">Add User</a>
       </li>
   @endif
-  @if(setting('general.invite_only_registration', false))
+  @if(setting('general.invite_only_registrations', false))
       <li>
         <a href="{{ route('admin.invites.index') }}">Invites</a>
       </li>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -5,6 +5,11 @@
   <li>
     <a href="{{ route('admin.userfields.index') }}"></i>Profile Fields</a>
   </li>
+  @if(setting('general.disable_registration', false))
+      <li>
+        <a href="{{ route('admin.users.create') }}">Add User</a>
+      </li>
+  @endif
   <li>
     <a href="{{ route('admin.users.index') }}?state=0">@lang(UserState::label(UserState::PENDING))</a>
   </li>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -10,6 +10,11 @@
         <a href="{{ route('admin.users.create') }}">Add User</a>
       </li>
   @endif
+  @if(setting('general.invite_only_registration', false))
+      <li>
+        <a href="{{ route('admin.invites.index') }}">Invites</a>
+      </li>
+  @endif
   <li>
     <a href="{{ route('admin.users.index') }}?state=0">@lang(UserState::label(UserState::PENDING))</a>
   </li>

--- a/resources/views/layouts/default/auth/register.blade.php
+++ b/resources/views/layouts/default/auth/register.blade.php
@@ -105,6 +105,11 @@
             @endif
           @endif
 
+          @if($invite)
+            {{ Form::hidden('invite', $invite->id) }}
+            {{ Form::hidden('invite_token', base64_encode($invite->token)) }}
+          @endif
+
           <div>
             @include('auth.toc')
             <br/>

--- a/resources/views/notifications/mail/user/invite.blade.php
+++ b/resources/views/notifications/mail/user/invite.blade.php
@@ -1,0 +1,12 @@
+@component('mail::message')
+  # You have been invited to join {{ config('app.name') }}!
+
+  You can use the link below to register an account with this email address.
+
+  @component('mail::button', ['url' => $invite->link])
+    Register now
+  @endcomponent
+
+  Thanks,<br>
+  Management, {{ config('app.name') }}
+@endcomponent

--- a/tests/RegistrationTest.php
+++ b/tests/RegistrationTest.php
@@ -2,13 +2,17 @@
 
 namespace Tests;
 
+use App\Models\Airline;
+use App\Models\Airport;
 use App\Models\Enums\UserState;
+use App\Models\Invite;
 use App\Models\User;
 use App\Notifications\Messages\AdminUserRegistered;
 use App\Services\UserService;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class RegistrationTest extends TestCase
 {
@@ -41,5 +45,123 @@ class RegistrationTest extends TestCase
 
         Notification::assertSentTo([$admin], AdminUserRegistered::class);
         Notification::assertNotSentTo([$user], AdminUserRegistered::class);
+    }
+
+    protected function getUserData(): array {
+        $airline = Airline::factory()->create();
+        $home = Airport::factory()->create(['hub' => true]);
+
+        return [
+            'name'                  => 'Test User',
+            'email'                 => 'test@phpvms.net',
+            'airline_id'            => $airline->id,
+            'home_airport_id'       => $home->id,
+            'password'              => 'secret',
+            'password_confirmation' => 'secret',
+            'toc_accepted'          => true
+        ];
+    }
+
+    public function testAccessToRegistrationWhenRegistrationDisabled(): void
+    {
+        $this->updateSetting('general.disable_registrations', true);
+
+        $this->expectException(HttpException::class);
+
+        $this->get('/register')
+            ->assertForbidden();
+
+        $this->post('/register', $this->getUserData())
+            ->assertForbidden();
+    }
+
+    public function testAccessWithoutInvite(): void
+    {
+        $this->updateSetting('general.disable_registrations', false);
+        $this->updateSetting('general.invite_only_registrations', true);
+
+        $this->expectException(HttpException::class);
+
+        $this->get('/register')
+            ->assertForbidden();
+
+        $this->post('/register', $this->getUserData())
+            ->assertForbidden();
+    }
+
+    public function testAccessWithValidInvite(): void
+    {
+        $this->updateSetting('general.disable_registrations', false);
+        $this->updateSetting('general.invite_only_registrations', true);
+
+        $invite = Invite::create([
+            'token' => 'test',
+        ]);
+
+        $this->get($invite->link)
+            ->assertOk();
+
+        $userData = array_merge($this->getUserData(), [
+            'invite'       => $invite->id,
+            'invite_token' => base64_encode($invite->token)
+        ]);
+
+        $this->post('/register', $userData)
+            ->assertRedirect('/dashboard');
+    }
+
+    public function testAccessWithInvalidInvite(): void
+    {
+        $this->updateSetting('general.disable_registrations', false);
+        $this->updateSetting('general.invite_only_registrations', true);
+
+        $this->expectException(HttpException::class);
+
+        // Expired invite
+        $expiredInvite = Invite::create([
+            'token'      => 'test',
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $expiredUserData = array_merge($this->getUserData(), [
+            'invite'       => $expiredInvite->id,
+            'invite_token' => base64_encode($expiredInvite->token)
+        ]);
+
+        $this->get($expiredInvite->link)
+            ->assertForbidden();
+
+        $this->post('/register', $expiredUserData)
+            ->assertForbidden();
+
+        // Invalid token
+        $invalidUserData = array_merge($this->getUserData(), [
+            'invite'       => 1,
+            'invite_token' => 'invalid'
+        ]);
+
+        $this->get('/register?invite=1&invite_token=invalid')
+            ->assertForbidden();
+
+        $this->post('/register', $invalidUserData)
+            ->assertForbidden();
+
+        // Invite used too many times
+        $tooUsedInvite = Invite::create([
+            'token'       => 'test',
+            'usage_count' => 1,
+            'usage_limit' => 1,
+        ]);
+
+        $tooUsedUserData = array_merge($this->getUserData(), [
+            'invite'       => $tooUsedInvite->id,
+            'invite_token' => base64_encode($tooUsedInvite->token)
+        ]);
+
+        $this->get($tooUsedInvite->link)
+            ->assertForbidden();
+
+        $this->post('/register', $tooUsedUserData)
+            ->assertForbidden();
     }
 }

--- a/tests/RegistrationTest.php
+++ b/tests/RegistrationTest.php
@@ -47,7 +47,8 @@ class RegistrationTest extends TestCase
         Notification::assertNotSentTo([$user], AdminUserRegistered::class);
     }
 
-    protected function getUserData(): array {
+    protected function getUserData(): array
+    {
         $airline = Airline::factory()->create();
         $home = Airport::factory()->create(['hub' => true]);
 
@@ -58,7 +59,7 @@ class RegistrationTest extends TestCase
             'home_airport_id'       => $home->id,
             'password'              => 'secret',
             'password_confirmation' => 'secret',
-            'toc_accepted'          => true
+            'toc_accepted'          => true,
         ];
     }
 
@@ -103,7 +104,7 @@ class RegistrationTest extends TestCase
 
         $userData = array_merge($this->getUserData(), [
             'invite'       => $invite->id,
-            'invite_token' => base64_encode($invite->token)
+            'invite_token' => base64_encode($invite->token),
         ]);
 
         $this->post('/register', $userData)
@@ -125,7 +126,7 @@ class RegistrationTest extends TestCase
 
         $expiredUserData = array_merge($this->getUserData(), [
             'invite'       => $expiredInvite->id,
-            'invite_token' => base64_encode($expiredInvite->token)
+            'invite_token' => base64_encode($expiredInvite->token),
         ]);
 
         $this->get($expiredInvite->link)
@@ -137,7 +138,7 @@ class RegistrationTest extends TestCase
         // Invalid token
         $invalidUserData = array_merge($this->getUserData(), [
             'invite'       => 1,
-            'invite_token' => 'invalid'
+            'invite_token' => 'invalid',
         ]);
 
         $this->get('/register?invite=1&invite_token=invalid')
@@ -155,7 +156,7 @@ class RegistrationTest extends TestCase
 
         $tooUsedUserData = array_merge($this->getUserData(), [
             'invite'       => $tooUsedInvite->id,
-            'invite_token' => base64_encode($tooUsedInvite->token)
+            'invite_token' => base64_encode($tooUsedInvite->token),
         ]);
 
         $this->get($tooUsedInvite->link)

--- a/tests/RegistrationTest.php
+++ b/tests/RegistrationTest.php
@@ -165,4 +165,27 @@ class RegistrationTest extends TestCase
         $this->post('/register', $tooUsedUserData)
             ->assertForbidden();
     }
+
+    public function testWithInvalidEmail()
+    {
+        $this->updateSetting('general.disable_registrations', false);
+        $this->updateSetting('general.invite_only_registrations', true);
+
+        $this->expectException(HttpException::class);
+        $invite = Invite::create([
+            'email'       => 'invited_email@phpvms.net',
+            'token'       => 'test',
+        ]);
+
+        $userData = array_merge($this->getUserData(), [
+            'invite'       => $invite->id,
+            'invite_token' => base64_encode($invite->token)
+        ]);
+
+        $this->get($invite->link)
+            ->assertOk();
+
+        $this->post('/register', $userData)
+            ->assertForbidden();
+    }
 }

--- a/tests/RegistrationTest.php
+++ b/tests/RegistrationTest.php
@@ -173,13 +173,13 @@ class RegistrationTest extends TestCase
 
         $this->expectException(HttpException::class);
         $invite = Invite::create([
-            'email'       => 'invited_email@phpvms.net',
-            'token'       => 'test',
+            'email' => 'invited_email@phpvms.net',
+            'token' => 'test',
         ]);
 
         $userData = array_merge($this->getUserData(), [
             'invite'       => $invite->id,
-            'invite_token' => base64_encode($invite->token)
+            'invite_token' => base64_encode($invite->token),
         ]);
 
         $this->get($invite->link)


### PR DESCRIPTION
Closes #1308 
Closes #568 

This PR introduces two settings:
- disable_registrations
- invite_only_registrations

If registrations are disabled the registeration page is inaccessible and users can only be created from the admin side.

If the registrations are invite-only the registration page is available only if you have a specific link (with a token) and users can't be created from admin side.

Here are some options for the invites:
- They can have an expiration date, after which the invite no longer works.
- They can have a maximum number of uses.
- They can only allow some emails to register (other emails with this invite will be rejected).
- When creating an email invite, you can automatically send an email with the invite to the invited user.

The expired invites (due to both expiration date and maximum number of uses) are deleted in the cron every hour.

Currently, an invite can only have one email (which allows us to use `<input type="email" ... />` and therefore check for a valid email). However, if necessary, I can allow the addition of several emails (separated by commas) and then send the email with the registration link to multiple people.
