### PR TITLE
fix: Add Image to PirepStatusChange Discord Event

### DIFF
--- a/app/Notifications/Messages/Broadcast/PirepStatusChanged.php
+++ b/app/Notifications/Messages/Broadcast/PirepStatusChanged.php
@@ -99,6 +99,7 @@ class PirepStatusChanged extends Notification implements ShouldQueue
             ->title($title)
             ->description($pirep->user->discord_id ? 'Flight by <@'.$pirep->user->discord_id.'>' : '')
             ->thumbnail(['url' => $user_avatar])
+            ->image(['url' => $pirep->airline->logo])
             ->author([
                 'name' => $pirep->user->ident.' - '.$pirep->user->name_private,
                 'url'  => route('frontend.profile.show', [$pirep->user_id]),


### PR DESCRIPTION
This fixes a bug where Discord doesn't accept a empty image array anymore with the PirepStatusChanged event.