### PR TITLE
Proper fix for Discord Notifications

### DIFF
--- a/app/Notifications/Channels/Discord/DiscordMessage.php
+++ b/app/Notifications/Channels/Discord/DiscordMessage.php
@@ -149,6 +149,10 @@ class DiscordMessage
             'timestamp'   => Carbon::now('UTC'),
         ];
 
+        if (empty($embeds['image'])) {
+            unset($embeds['image']);
+        }
+
         if (!empty($this->fields)) {
             $embeds['fields'] = $this->fields;
         }


### PR DESCRIPTION
Simply unset the empty image array from embeds instead of adding the logo to all notifications.