### PR TITLE
Fix new user removal

### DIFF
--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -148,7 +148,7 @@ class UserService extends Service
             $user->state = UserState::DELETED;
             $user->save();
         } else {
-            $user->delete();
+            $user->forceDelete();
         }
     }
 


### PR DESCRIPTION
When a user registers, and does not comply with e-mail validation, or somehow does not send any pireps, or admin decides to remove the record (test user, wrong registration etc) deleting from admin panel causes a `softdelete` by design.

This should be a `forceDelete` instead to remove the record permanently.

_If a user has pireps, implemented v7 "soft delete" logic works fine as it changes fields and keeps the record_