### PR TITLE
Update FlightService > Duplicate Flight Check

### DIFF
--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -239,7 +239,10 @@ class FlightService extends Service
         // If this list is > 0, then this has a duplicate
         $found_flights = $found_flights->filter(function ($value, $key) use ($flight) {
             return $flight->route_code === $value->route_code
-                && $flight->route_leg === $value->route_leg;
+                && $flight->route_leg === $value->route_leg
+                && $flight->dpt_airport_id === $value->dpt_airport_id
+                && $flight->arr_airport_id === $value->arr_airport_id
+                && $flight->days === $value->days;
         });
 
         return !($found_flights->count() === 0);

--- a/tests/FlightTest.php
+++ b/tests/FlightTest.php
@@ -45,10 +45,13 @@ class FlightTest extends TestCase
         $this->assertFalse($this->flightSvc->isFlightDuplicate($flight));
 
         $flight_dupe = new Flight([
-            'airline_id'    => $flight->airline_id,
-            'flight_number' => $flight->flight_number,
-            'route_code'    => $flight->route_code,
-            'route_leg'     => $flight->route_leg,
+            'airline_id'     => $flight->airline_id,
+            'flight_number'  => $flight->flight_number,
+            'route_code'     => $flight->route_code,
+            'route_leg'      => $flight->route_leg,
+            'dpt_airport_id' => $flight->dpt_airport_id,
+            'arr_airport_id' => $flight->arr_airport_id,
+            'days'           => $flight->days,
         ]);
 
         $this->assertTrue($this->flightSvc->isFlightDuplicate($flight_dupe));
@@ -56,29 +59,38 @@ class FlightTest extends TestCase
         // same flight but diff airline shouldn't be a dupe
         $new_airline = Airline::factory()->create();
         $flight_dupe = new Flight([
-            'airline_id'    => $new_airline->airline_id,
-            'flight_number' => $flight->flight_number,
-            'route_code'    => $flight->route_code,
-            'route_leg'     => $flight->route_leg,
+            'airline_id'     => $new_airline->airline_id,
+            'flight_number'  => $flight->flight_number,
+            'route_code'     => $flight->route_code,
+            'route_leg'      => $flight->route_leg,
+            'dpt_airport_id' => $flight->dpt_airport_id,
+            'arr_airport_id' => $flight->arr_airport_id,
+            'days'           => $flight->days,
         ]);
 
         $this->assertFalse($this->flightSvc->isFlightDuplicate($flight_dupe));
 
         // add another flight with a code
         $flight_leg = Flight::factory()->create([
-            'airline_id'    => $flight->airline_id,
-            'flight_number' => $flight->flight_number,
-            'route_code'    => 'A',
+            'airline_id'     => $flight->airline_id,
+            'flight_number'  => $flight->flight_number,
+            'route_code'     => 'A',
+            'dpt_airport_id' => $flight->dpt_airport_id,
+            'arr_airport_id' => $flight->arr_airport_id,
+            'days'           => $flight->days,
         ]);
 
         $this->assertFalse($this->flightSvc->isFlightDuplicate($flight_leg));
 
         // Add both a route and leg
         $flight_leg = Flight::factory()->create([
-            'airline_id'    => $flight->airline_id,
-            'flight_number' => $flight->flight_number,
-            'route_code'    => 'A',
-            'route_leg'     => 1,
+            'airline_id'     => $flight->airline_id,
+            'flight_number'  => $flight->flight_number,
+            'route_code'     => 'A',
+            'route_leg'      => 1,
+            'dpt_airport_id' => $flight->dpt_airport_id,
+            'arr_airport_id' => $flight->arr_airport_id,
+            'days'           => $flight->days,
         ]);
 
         $this->assertFalse($this->flightSvc->isFlightDuplicate($flight_leg));


### PR DESCRIPTION
A flight should NOT be marked as duplicate unless;

* Airline
* Flight Number
* Route Code
* Route Leg Number
* Origin
* Destination
* Scheduled Days

are identical with another flight.

We can import flights with same numbers but with different origins and destinations, but can not edit them in admin due to very limited "duplicate check".

Imagine you have a flight schedule as below;

TK1 AYT-DUS
TK1 DUS-BER
TK2 BER-AYT

You can import this as expected, but can not edit TK1 because v7 thinks it has a duplicate.

PR extends the check properly to consider origin, destination and weekdays.