### PR TITLE
Add env config option to set default theme

### DIFF
--- a/config/themes.php
+++ b/config/themes.php
@@ -3,7 +3,7 @@
 return [
     'themes_path'     => resource_path('views/layouts'), // eg: base_path('resources/themes')
     'asset_not_found' => 'LOG_ERROR',
-    'default'         => 'default',
+    'default'         => env('DEFAULT_THEME', 'default'),
     'cache'           => true,
 
     /*


### PR DESCRIPTION
resolves #1776 

This is a workaround to the email issue linked above. It's also a good config option to have for those who need to set the default theme as different from default.