### PR TITLE
Replace Auth Failed Message for User Account Missing

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -86,7 +86,7 @@ class LoginController extends Controller
                     $user = $this->userSvc->findUserByPilotId($value);
                 } catch (PilotIdNotFound $ex) {
                     Log::warning('Error logging in, pilot_id not found, id='.$value);
-                    $fail('Pilot not found');
+                    $fail(__('auth.failed'));
                     return;
                 }
 


### PR DESCRIPTION
Having a different error message for a user account missing, and username/password being incorrect is a considerable security issue, because this could be a vector to fish for valid accounts.