### PR TITLE
Add internal user fields

### DIFF
--- a/app/Database/migrations/2024_05_15_144813_add_internal_to_user_fields.php
+++ b/app/Database/migrations/2024_05_15_144813_add_internal_to_user_fields.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/app/Database/migrations/2024_05_15_144813_add_internal_to_user_fields.php
+++ b/app/Database/migrations/2024_05_15_144813_add_internal_to_user_fields.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_fields', function (Blueprint $table) {
+            $table->boolean('internal')->after('private')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_fields', function (Blueprint $table) {
+            $table->dropColumn('internal');
+        });
+    }
+};

--- a/app/Http/Controllers/Admin/UserFieldController.php
+++ b/app/Http/Controllers/Admin/UserFieldController.php
@@ -32,7 +32,7 @@ class UserFieldController extends Controller
     public function index(Request $request): View
     {
         $this->userFieldRepo->pushCriteria(new RequestCriteria($request));
-        $fields = $this->userFieldRepo->all();
+        $fields = $this->userFieldRepo->where('internal', false)->get();
 
         return view('admin.userfields.index', ['fields' => $fields]);
     }
@@ -99,6 +99,11 @@ class UserFieldController extends Controller
             return redirect(route('admin.userfields.index'));
         }
 
+        if ($field->internal) {
+            Flash::error('You cannot edit an internal user field');
+            return redirect(route('admin.userfields.index'));
+        }
+
         return view('admin.userfields.edit', ['field' => $field]);
     }
 
@@ -121,6 +126,11 @@ class UserFieldController extends Controller
             return redirect(route('admin.userfields.index'));
         }
 
+        if ($field->internal) {
+            Flash::error('You cannot edit an internal user field');
+            return redirect(route('admin.userfields.index'));
+        }
+
         $this->userFieldRepo->update($request->all(), $id);
 
         Flash::success('Field updated successfully.');
@@ -139,6 +149,11 @@ class UserFieldController extends Controller
         $field = $this->userFieldRepo->findWithoutFail($id);
         if (empty($field)) {
             Flash::error('Field not found');
+            return redirect(route('admin.userfields.index'));
+        }
+
+        if ($field->internal) {
+            Flash::error('You cannot delete an internal user field');
             return redirect(route('admin.userfields.index'));
         }
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -84,7 +84,7 @@ class RegisterController extends Controller
         }
 
         $airlines = $this->airlineRepo->selectBoxList();
-        $userFields = UserField::where(['show_on_registration' => true, 'active' => true])->get();
+        $userFields = UserField::where(['show_on_registration' => true, 'active' => true, 'internal' => false])->get();
 
         return view('auth.register', [
             'airports'   => [],
@@ -124,6 +124,7 @@ class RegisterController extends Controller
         $userFields = UserField::where([
             'show_on_registration' => true,
             'required'             => true,
+            'internal'             => false,
             'active'               => true,
         ])->get();
 
@@ -215,7 +216,7 @@ class RegisterController extends Controller
 
         Log::info('User registered: ', $user->toArray());
 
-        $userFields = UserField::where(['show_on_registration' => true, 'active' => true])->get();
+        $userFields = UserField::where(['show_on_registration' => true, 'active' => true, 'internal' => false])->get();
         foreach ($userFields as $field) {
             $field_name = 'field_'.$field->slug;
             UserFieldValue::updateOrCreate([

--- a/app/Http/Controllers/Frontend/ProfileController.php
+++ b/app/Http/Controllers/Frontend/ProfileController.php
@@ -154,7 +154,7 @@ class ProfileController extends Controller
             'avatar'     => 'nullable|mimes:jpeg,png,jpg',
         ];
 
-        $userFields = UserField::where(['show_on_registration' => true, 'required' => true])->get();
+        $userFields = UserField::where(['show_on_registration' => true, 'required' => true, 'internal' => false])->get();
         foreach ($userFields as $field) {
             $rules['field_'.$field->slug] = 'required';
         }
@@ -217,7 +217,7 @@ class ProfileController extends Controller
         }
 
         // Save all of the user fields
-        $userFields = UserField::all();
+        $userFields = UserField::where('internal', false)->get();
         foreach ($userFields as $field) {
             $field_name = 'field_'.$field->slug;
             UserFieldValue::updateOrCreate([

--- a/app/Models/UserField.php
+++ b/app/Models/UserField.php
@@ -23,6 +23,7 @@ class UserField extends Model
         'show_on_registration', // Show on the registration form?
         'required',             // Required to be filled out in registration?
         'private',              // Whether this is shown on the user's public profile
+        'internal',             // Whether this field is for internal use only (e.g. modules)
         'active',
     ];
 
@@ -30,6 +31,7 @@ class UserField extends Model
         'show_on_registration' => 'boolean',
         'required'             => 'boolean',
         'private'              => 'boolean',
+        'internal'             => 'boolean',
         'active'               => 'boolean',
     ];
 

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -36,13 +36,18 @@ class UserRepository extends Repository
      *
      * @return \App\Models\UserField[]|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
      */
-    public function getUserFields(User $user, $only_public_fields = null): Collection
+    public function getUserFields(User $user, $only_public_fields = null, $with_internal_fields = false): Collection
     {
+
+        $fields = UserField::when(!$with_internal_fields, function ($query) {
+            return $query->where('internal', false);
+        });
+
         if (is_bool($only_public_fields)) {
-            $fields = UserField::where(['private' => !$only_public_fields])->get();
-        } else {
-            $fields = UserField::get();
+            $fields = $fields->where(['private' => !$only_public_fields]);
         }
+
+        $fields = $fields->get();
 
         return $fields->map(function ($field, $_) use ($user) {
             foreach ($user->fields as $userFieldValue) {

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -31,14 +31,14 @@ class UserRepository extends Repository
     /**
      * Get all of the fields which has the mapped values
      *
-     * @param User $user
-     * @param bool $only_public_fields Only include the user's public fields
+     * @param User  $user
+     * @param bool  $only_public_fields   Only include the user's public fields
+     * @param mixed $with_internal_fields
      *
      * @return \App\Models\UserField[]|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
      */
     public function getUserFields(User $user, $only_public_fields = null, $with_internal_fields = false): Collection
     {
-
         $fields = UserField::when(!$with_internal_fields, function ($query) {
             return $query->where('internal', false);
         });


### PR DESCRIPTION
This PR adds an "internal" column to the user fields. If a user field is marked as internal, then it cannot be edited by either admins or users. This allows modules to store information about users easily.