### PR TITLE
Map LastPirepID in Legacy PirepImporter

### DIFF
--- a/app/Services/LegacyImporter/PirepImporter.php
+++ b/app/Services/LegacyImporter/PirepImporter.php
@@ -136,6 +136,12 @@ class PirepImporter extends BaseImporter
                 $count++;
             }
 
+            if ($pirep->user && $pirep->state === PirepState::ACCEPTED) {
+                $pirep->user->update([
+                    'last_pirep_id' => $pirep->id,
+                ]);
+            }
+
             if (!$pirep->airline || !$pirep->airline->journal) {
                 continue;
             }


### PR DESCRIPTION
This PR updates the user's `last_pirep_id` when importing PIREPs from v5.