### PR TITLE
Fix web cron

### DIFF
--- a/app/Http/Controllers/Api/MaintenanceController.php
+++ b/app/Http/Controllers/Api/MaintenanceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Console\Cron;
+use App\Console\Kernel;
 use App\Contracts\Controller;
 use App\Exceptions\CronInvalid;
 use Illuminate\Http\JsonResponse;
@@ -24,6 +25,15 @@ class MaintenanceController extends Controller
         if (empty($cron_id) || $id !== $cron_id) {
             throw new CronInvalid();
         }
+
+        // Create a console kernel instance
+        $consoleKernel = app()->make(Kernel::class);
+
+        // Run a null artisan thing just so Laravel internals can be setup properly
+        $status = $consoleKernel->handle(
+            new \Symfony\Component\Console\Input\ArgvInput(),
+            new \Symfony\Component\Console\Output\NullOutput()
+        );
 
         $cron = app(Cron::class);
         $run = $cron->run();


### PR DESCRIPTION
As in `bin/cron.php` (see below), we need to create a fake console kernel and initialize it.

We are using a fake scheduler to run our cron jobs because some users don't have `proc_open` and can't use the real laravel scheduler. This fake scheduler calls console commands under the hood, which is why we need a console kernel. Normally, a console kernel isn't created for HTTP requests (only an HTTP kernel is created), so we need to initialize it manually.

https://github.com/nabeelio/phpvms/blob/677f3d5c89d02ea1b6d914430568cd27517bf9ec/bin/cron#L18-L30