### PR TITLE
Recommend using Laravel scheduler when proc_open is available

### DIFF
--- a/app/Services/CronService.php
+++ b/app/Services/CronService.php
@@ -34,9 +34,16 @@ class CronService extends Service
             $php_exec .= ' -d register_argc_argv=On';
         }
 
+        $command = base_path('bin/cron');
+
+        // If the server has proc_open then use the default laravel scheduler
+        if (function_exists('proc_open')) {
+            $command = base_path('artisan schedule:run');
+        }
+
         $path = [
             $php_exec,
-            base_path('bin/cron'),
+            $command,
         ];
 
         return implode(' ', $path);


### PR DESCRIPTION
Since I only have VPS setups that have `proc_open`, I can't test and confirm that it displays the command with `/bin/cron` on an installation that doesn't have it.

@FatihKoz , I understand that you have servers without `proc_open`. Could you test this PR when you have a moment? Basically, in Admin > Maintenance, there is an example command to run for the cron. You should check if this example correctly shows the command `/bin/cron` on a server that doesn't have `proc_open`. On a server that does have it, it should show `artisan schedule:run`.