### PR TITLE
Add ability to edit news

### DIFF
--- a/app/Events/NewsUpdated.php
+++ b/app/Events/NewsUpdated.php
@@ -7,10 +7,8 @@ use App\Models\News;
 
 class NewsUpdated extends Event
 {
-
     public function __construct(
         public News $news
     ) {
     }
-
 }

--- a/app/Events/NewsUpdated.php
+++ b/app/Events/NewsUpdated.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Events;
+
+use App\Contracts\Event;
+use App\Models\News;
+
+class NewsUpdated extends Event
+{
+
+    public function __construct(
+        public News $news
+    ) {
+    }
+
+}

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -93,6 +93,11 @@ class DashboardController extends Controller
             $attrs['user_id'] = Auth::user()->id;
 
             $this->newsSvc->addNews($attrs);
+        } elseif ($request->isMethod('patch')) {
+            $attrs = $request->post();
+            $attrs['user_id'] = Auth::user()->id;
+
+            $this->newsSvc->updateNews($attrs);
         } elseif ($request->isMethod('delete')) {
             $id = $request->input('news_id');
             $this->newsSvc->deleteNews($id);

--- a/app/Notifications/NotificationEventsHandler.php
+++ b/app/Notifications/NotificationEventsHandler.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Contracts\Listener;
 use App\Events\AwardAwarded;
 use App\Events\NewsAdded;
+use App\Events\NewsUpdated;
 use App\Events\PirepAccepted;
 use App\Events\PirepFiled;
 use App\Events\PirepPrefiled;
@@ -33,6 +34,7 @@ class NotificationEventsHandler extends Listener
     public static $callbacks = [
         AwardAwarded::class      => 'onAwardAwarded',
         NewsAdded::class         => 'onNewsAdded',
+        NewsUpdated::class       => 'onNewsUpdated',
         PirepPrefiled::class     => 'onPirepPrefile',
         PirepStatusChange::class => 'onPirepStatusChange',
         PirepAccepted::class     => 'onPirepAccepted',
@@ -256,6 +258,24 @@ class NotificationEventsHandler extends Listener
      * @param \App\Events\NewsAdded $event
      */
     public function onNewsAdded(NewsAdded $event): void
+    {
+        Log::info('NotificationEvents::onNewsAdded');
+        if (setting('notifications.mail_news', true)) {
+            $this->notifyAllUsers(new Messages\NewsAdded($event->news));
+        }
+
+        /*
+         * Broadcast notifications
+         */
+        Notification::send([$event->news], new Messages\Broadcast\NewsAdded($event->news));
+    }
+
+    /**
+     * Notify all users of a news event, but only the users which have opted in
+     *
+     * @param \App\Events\NewsUpdated $event
+     */
+    public function onNewsUpdated(NewsUpdated $event): void
     {
         Log::info('NotificationEvents::onNewsAdded');
         if (setting('notifications.mail_news', true)) {

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -516,6 +516,7 @@ class RouteServiceProvider extends ServiceProvider
 
             Route::match([
                 'get',
+                'patch',
                 'post',
                 'delete',
             ], 'dashboard/news', ['uses' => 'DashboardController@news'])

--- a/app/Services/NewsService.php
+++ b/app/Services/NewsService.php
@@ -37,10 +37,11 @@ class NewsService extends Service
     /**
      * Update a news
      *
-     * @param  array  $attrs
-     * @return ?News
+     * @param array $attrs
      *
      * @throws ValidatorException
+     *
+     * @return ?News
      */
     public function updateNews(array $attrs): ?News
     {

--- a/app/Services/NewsService.php
+++ b/app/Services/NewsService.php
@@ -29,7 +29,10 @@ class NewsService extends Service
     public function addNews(array $attrs)
     {
         $news = $this->newsRepo->create($attrs);
-        event(new NewsAdded($news));
+
+        if (array_key_exists('send_notifications', $attrs) && get_truth_state($attrs['send_notifications'])) {
+            event(new NewsAdded($news));
+        }
 
         return $news;
     }

--- a/app/Services/NewsService.php
+++ b/app/Services/NewsService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Contracts\Service;
 use App\Events\NewsAdded;
+use App\Events\NewsUpdated;
 use App\Models\News;
 use App\Repositories\NewsRepository;
 use Prettus\Validator\Exceptions\ValidatorException;
@@ -54,7 +55,13 @@ class NewsService extends Service
             return null;
         }
 
-        return $this->newsRepo->update($attrs, $attrs['id']);
+        $news = $this->newsRepo->update($attrs, $attrs['id']);
+
+        if (array_key_exists('send_notifications', $attrs) && get_truth_state($attrs['send_notifications'])) {
+            event(new NewsUpdated($news));
+        }
+
+        return $news;
     }
 
     /**

--- a/app/Services/NewsService.php
+++ b/app/Services/NewsService.php
@@ -4,7 +4,9 @@ namespace App\Services;
 
 use App\Contracts\Service;
 use App\Events\NewsAdded;
+use App\Models\News;
 use App\Repositories\NewsRepository;
+use Prettus\Validator\Exceptions\ValidatorException;
 
 class NewsService extends Service
 {
@@ -30,6 +32,25 @@ class NewsService extends Service
         event(new NewsAdded($news));
 
         return $news;
+    }
+
+    /**
+     * Update a news
+     *
+     * @param  array  $attrs
+     * @return ?News
+     *
+     * @throws ValidatorException
+     */
+    public function updateNews(array $attrs): ?News
+    {
+        $news = $this->newsRepo->find($attrs['id']);
+
+        if (!$news) {
+            return null;
+        }
+
+        return $this->newsRepo->update($attrs, $attrs['id']);
     }
 
     /**

--- a/resources/views/admin/dashboard/news.blade.php
+++ b/resources/views/admin/dashboard/news.blade.php
@@ -1,5 +1,5 @@
 <div id="pjax_news_wrapper">
-  <div class="card border-blue-bottom">
+  <div class="card border-blue-bottom" id="add_news">
     <div class="content">
       <div class="header">
         <h4 class="title">Add News</h4>
@@ -17,6 +17,31 @@
           <tr>
             <td colspan="2" class="text-right">
               {{ Form::button('<i class="fas fa-plus-circle"></i>&nbsp;add', ['type' => 'submit', 'class' => 'btn btn-success btn-s']) }}
+            </td>
+        </table>
+      {{ Form::close() }}
+    </div>
+  </div>
+  <div class="card border-blue-bottom" id="edit_news" style="display:none;">
+    <div class="content">
+      <div class="header">
+        <h4 class="title" id="edit_title">Edit News</h4>
+      </div>
+      {{ Form::open(['route' => 'admin.dashboard.news', 'method' => 'patch', 'class' => 'pjax_news_form']) }}
+        {{ Form::hidden('id', '', ['id' => 'edit_id']) }}
+        <table class="table">
+          <tr>
+            <td>{{ Form::label('subject', 'Subject:') }}</td>
+            <td>{{ Form::text('subject', '', ['id' => 'edit_subject', 'class' => 'form-control'])  }}</td>
+          </tr>
+          <tr>
+            <td>{{ Form::label('body', 'Body:') }}</td>
+            <td>{!! Form::textarea('body', '', ['id' => 'edit_body', 'class' => 'editor']) !!}</td>
+          </tr>
+          <tr>
+            <td colspan="2" class="text-right">
+              <button type="button" class="btn btn-warning btn-s" onclick="closeEdit()">Cancel</button>
+              {{ Form::button('<i class="fas fa-pencil-alt"></i>&nbsp;edit', ['type' => 'submit', 'class' => 'btn btn-success btn-s']) }}
             </td>
         </table>
       {{ Form::close() }}
@@ -43,7 +68,8 @@
               <td>{!! $item->body!!}</td>
               <td>{{ optional($item->user)->name_private }}</td>
               <td>{{ $item->created_at->format('d.M.y') }}</td>
-              <td>
+              <td style="display: flex;gap: .5rem;">
+                <button class="btn btn-primary btn-xs text-small" onclick="editNews({{ $item->toJson() }})">Edit</button>
                 {{ Form::open(['route' => 'admin.dashboard.news', 'method' => 'delete', 'class' => 'pjax_news_form']) }}
                 {{ Form::hidden('news_id', $item->id) }}
                 {{ Form::button('Delete', ['type' => 'submit', 'class' => 'btn btn-danger btn-xs text-small', 'onclick' => "return confirm('Are you sure?')"]) }}
@@ -61,5 +87,21 @@
   <script src="{{ public_asset('assets/vendor/ckeditor4/ckeditor.js') }}"></script>
   <script>
     $(document).ready(function () { CKEDITOR.replace('news_editor'); });
+
+    function editNews(news) {
+      CKEDITOR.replace('edit_body')
+      $('#edit_title').html('Edit News: ' + news.subject);
+      $('#edit_subject').val(news.subject)
+      CKEDITOR.instances.edit_body.setData(news.body)
+      $('#edit_id').val(news.id)
+      $('#add_news').hide();
+      $('#edit_news').show();
+    }
+
+    function closeEdit() {
+      $('#edit_news').hide();
+      $('#add_news').show()
+    }
+
   </script>
 @endsection

--- a/resources/views/admin/dashboard/news.blade.php
+++ b/resources/views/admin/dashboard/news.blade.php
@@ -15,10 +15,19 @@
             <td>{!! Form::textarea('body', '', ['id' => 'news_editor', 'class' => 'editor']) !!}</td>
           </tr>
           <tr>
-            <td colspan="2" class="text-right">
-              {{ Form::button('<i class="fas fa-plus-circle"></i>&nbsp;add', ['type' => 'submit', 'class' => 'btn btn-success btn-s']) }}
-            </td>
         </table>
+        <div style="display:flex; align-items: center; justify-content: space-between;">
+          <div class="checkbox">
+            <label class="checkbox-inline">
+              {{ Form::label('send_notifications', 'Send notifications:') }}
+              <input name="send_notifications" type="hidden" value="0"/>
+              {{ Form::checkbox('send_notifications') }}
+            </label>
+          </div>
+          <div>
+            {{ Form::button('<i class="fas fa-plus-circle"></i>&nbsp;add', ['type' => 'submit', 'class' => 'btn btn-success btn-s']) }}
+          </div>
+        </div>
       {{ Form::close() }}
     </div>
   </div>
@@ -81,13 +90,20 @@
       @endif
     </div>
   </div>
+  <script>
+    $(document).ready(function () { CKEDITOR.replace('news_editor'); });
+    if (typeof $('input').iCheck !== 'undefined') {
+      $('input').iCheck({
+        checkboxClass: 'icheckbox_square-blue',
+        radioClass: 'icheckbox_square-blue'
+      });
+    }
+  </script>
 </div>
 @section('scripts')
   @parent
   <script src="{{ public_asset('assets/vendor/ckeditor4/ckeditor.js') }}"></script>
   <script>
-    $(document).ready(function () { CKEDITOR.replace('news_editor'); });
-
     function editNews(news) {
       CKEDITOR.replace('edit_body')
       $('#edit_title').html('Edit News: ' + news.subject);

--- a/resources/views/admin/dashboard/news.blade.php
+++ b/resources/views/admin/dashboard/news.blade.php
@@ -47,12 +47,20 @@
             <td>{{ Form::label('body', 'Body:') }}</td>
             <td>{!! Form::textarea('body', '', ['id' => 'edit_body', 'class' => 'editor']) !!}</td>
           </tr>
-          <tr>
-            <td colspan="2" class="text-right">
-              <button type="button" class="btn btn-warning btn-s" onclick="closeEdit()">Cancel</button>
-              {{ Form::button('<i class="fas fa-pencil-alt"></i>&nbsp;edit', ['type' => 'submit', 'class' => 'btn btn-success btn-s']) }}
-            </td>
         </table>
+        <div style="display:flex; align-items: center; justify-content: space-between;">
+          <div class="checkbox">
+            <label class="checkbox-inline">
+              {{ Form::label('send_notifications', 'Send notifications:') }}
+              <input name="send_notifications" type="hidden" value="0"/>
+              {{ Form::checkbox('send_notifications') }}
+            </label>
+          </div>
+          <div>
+            <button type="button" class="btn btn-warning btn-s" onclick="closeEdit()">Cancel</button>
+            {{ Form::button('<i class="fas fa-pencil-alt"></i>&nbsp;edit', ['type' => 'submit', 'class' => 'btn btn-success btn-s']) }}
+          </div>
+        </div>
       {{ Form::close() }}
     </div>
   </div>

--- a/tests/NewsTest.php
+++ b/tests/NewsTest.php
@@ -33,9 +33,10 @@ final class NewsTest extends TestCase
         $users_opt_out = User::factory()->count(5)->create(['opt_in' => false]);
 
         $this->newsSvc->addNews([
-            'user_id' => $users_opt_out[0]->id,
-            'subject' => 'News Item',
-            'body'    => 'News!',
+            'user_id'            => $users_opt_out[0]->id,
+            'subject'            => 'News Item',
+            'body'               => 'News!',
+            'send_notifications' => true,
         ]);
 
         Notification::assertSentTo($users_opt_in, NewsAdded::class);


### PR DESCRIPTION
Closes #1813 

This PR adds the ability to edit news from the admin dashboard. However, it does not allow choosing whether to send notifications as mentioned in the issue. Notifications are managed by a listener that only receives the news model, so it wouldn't have access to a potential send email checkbox unless it was stored in the database (which wouldn't be very useful).

Updating news does not send any notifications because the NewsAdded event is not emitted.

This is entirely managed via AJAX

![image](https://github.com/nabeelio/phpvms/assets/41431456/cc7a1a18-47c3-42d6-b616-eaa03bae7729)
![image](https://github.com/nabeelio/phpvms/assets/41431456/6f7b13bc-5a0c-417e-b55c-2e5a884b0bf3)
![image](https://github.com/nabeelio/phpvms/assets/41431456/f02a4aa7-358b-473c-8e57-9f0e8876b01d)

