### PR TITLE
Update FlightController (Default sort order fix)

### DIFF
--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -151,7 +151,7 @@ class FlightController extends Controller
             ->when($filter_by_user, function ($query) use ($allowed_flights) {
                 return $query->whereIn('id', $allowed_flights);
             })
-            ->sortable('flight_number', 'route_code', 'route_leg')
+            ->sortable('flight_number')->orderBy('route_code')->orderBy('route_leg')
             ->paginate();
 
         $saved_flights = [];


### PR DESCRIPTION
Sorting with `sortable()` does not support multiple columns for default output, thus additional `orderBy()` usage is required for initial/default sorting to get expected results on page load (like admin controller)

![image](https://github.com/nabeelio/phpvms/assets/74361521/db62ec4e-cc8e-4163-af22-607e47c49c3d)
