### PR TITLE
Fix token columns type for OAuth

### DIFF
--- a/app/Database/migrations/2024_07_02_164640_update_tokens_in_user_oauth_tokens.php
+++ b/app/Database/migrations/2024_07_02_164640_update_tokens_in_user_oauth_tokens.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_oauth_tokens', function (Blueprint $table) {
+            $table->text('token')->change();
+            $table->text('refresh_token')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_oauth_tokens', function (Blueprint $table) {
+            $table->string('token')->change();
+            $table->string('refresh_token')->change();
+        });
+    }
+};

--- a/app/Database/migrations/2024_07_02_164640_update_tokens_in_user_oauth_tokens.php
+++ b/app/Database/migrations/2024_07_02_164640_update_tokens_in_user_oauth_tokens.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class() extends Migration {
     public function up(): void
     {
         Schema::table('user_oauth_tokens', function (Blueprint $table) {


### PR DESCRIPTION
In the first implementation of OAuth, I forgot to account for the fact that tokens could be longer than 191 characters and thus not fit in a string... Since we're not using them at the moment, it's not a big problem, but if we ever want to use them, people who linked their accounts before this fix will need to unlink and then relink them.