### PR TITLE
Update Backup Config

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -28,8 +28,12 @@ return [
                  * Directories used by the backup process will automatically be excluded.
                  */
                 'exclude' => [
-                    base_path('vendor'),
+                    // base_path('vendor'),
                     base_path('node_modules'),
+                    base_path('bootstrap/cache/*'),
+                    base_path('storage/framework/cache/*'),
+                    base_path('storage/framework/sessions/*'),
+                    base_path('storage/framework/views/*'),
                 ],
 
                 /*

--- a/config/backup.php
+++ b/config/backup.php
@@ -29,7 +29,7 @@ return [
                  */
                 'exclude' => [
                     // base_path('vendor'),
-                    base_path('node_modules'),
+                    // base_path('node_modules'),
                     base_path('bootstrap/cache/*'),
                     base_path('storage/framework/cache/*'),
                     base_path('storage/framework/sessions/*'),


### PR DESCRIPTION
Backups should contain the vendors, in case of a restore not having them in the backup would cause trouble (for normal users)

Also we do not need to have application cache folder contents in the backup, having them can cause `ZipArchive::close() Can't open file` exception when any of the cached files got deleted during backup.

Proposed config keeps the folders, skips the contents during manifest/backup creation.