### PR TITLE
Fix aircraft's flight time when rejecting a pirep

### DIFF
--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -692,15 +692,15 @@ class PirepService extends Service
             $this->userSvc->adjustFlightCount($user, -1);
             $this->userSvc->calculatePilotRank($user);
             $pirep->user->refresh();
+
+            $pirep->aircraft->flight_time -= $pirep->flight_time;
+            $pirep->aircraft->save();
         }
 
         // Change the status
         $pirep->state = PirepState::REJECTED;
         $pirep->save();
         $pirep->refresh();
-
-        $pirep->aircraft->flight_time -= $pirep->flight_time;
-        $pirep->aircraft->save();
 
         Log::info('PIREP '.$pirep->id.' state change to REJECTED');
 


### PR DESCRIPTION
The `reject` method of the `PirepService` now decreases the flight time only if the PIREP was previously accepted.

Closes #1852 



