### PR TITLE
Add Latest Awards Widget

### DIFF
--- a/app/Widgets/LatestAwards.php
+++ b/app/Widgets/LatestAwards.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Widgets;
+
+use App\Contracts\Widget;
+use App\Models\UserAward;
+
+class LatestAwards extends Widget
+{
+    protected $config = ['count' => 5];
+
+    public function run()
+    {
+        $latest_awards = UserAward::with(['award', 'user'])->orderby('created_at', 'desc')->take($this->config['count'])->get();
+
+        return view('widgets.latest_awards', [
+            'config' => $this->config,
+            'awards' => $latest_awards,
+        ]);
+    }
+}

--- a/resources/views/layouts/default/widgets/latest_awards.blade.php
+++ b/resources/views/layouts/default/widgets/latest_awards.blade.php
@@ -1,0 +1,22 @@
+@if($awards->count() > 0)
+  <div class="card border-blue-bottom">
+    <div class="card-body">
+      <table class="table">
+        <tr>
+          <td>Ident</td>
+          <td>Name</td>
+          <td>Award</td>
+          <td>Date</td>
+        </tr>
+        @foreach($awards as $a)
+          <tr>
+            <td>{{ optional($a->user)->ident }}</td>
+            <td>{{ optional($a->user)->name_private }}</td>
+            <td>{{ optional($a->award)->name }}</td>
+            <td>{{ $a->created_at->format('d.M.Y H:i') }}</td>
+          </tr>
+        @endforeach
+      </table>
+    </div>
+  </div>
+@endif


### PR DESCRIPTION
A simple widget for displaying latest awards issued to pilots.

By default it is set to get 5 records, which can be changed by passing in a config value like other widgets.

```blade
 // Default usage
@widget('LatestAwards')
// Usage example for increased count
@widget('LatestAwards', ['count' => 10])
```

Does **not** need `Auth` and can be placed anywhere.