### PR TITLE
Run artifact/release jobs only on main repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
     name: 'Create release package'
     needs: [build]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'nabeelio/phpvms' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/'))
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -215,7 +215,7 @@ jobs:
     name: 'Create Release'
     needs: artifacts
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'nabeelio/phpvms' && startsWith(github.ref, 'refs/tags/')
     steps:
 
       - name: Download artifact from build job


### PR DESCRIPTION
This should disable jobs related to artifacts and releases in the CI/CD pipeline when pushing to a fork (since these jobs aren't supposed to run on a fork).

This should work as expected, as we've used it before. However, after merging, please verify that all jobs are running correctly.

