### PR TITLE
Fix install error (country selection)

### DIFF
--- a/resources/views/system/installer/install/steps/step3-user.blade.php
+++ b/resources/views/system/installer/install/steps/step3-user.blade.php
@@ -56,8 +56,8 @@
                             <td>
                                 <div class="form-group">
                                     <select name="airline_country" class="form-control select2">
-                                        @foreach ($countries as $country)
-                                            <option value="{{ $country }}">{{ $country }}</option>
+                                        @foreach ($countries as $code => $name)
+                                            <option value="{{ $code }}">{{ $name }}</option>
                                         @endforeach
                                     </select>
                                     @include('system.installer.flash/check_error', [


### PR DESCRIPTION
Airport selection dropdown loop was faulty, it was passing in the country full name for the code field, thus failing on new installs.