### PR TITLE
Add ability to add multiple ranks to a subfleet at once

### DIFF
--- a/app/Http/Controllers/Admin/SubfleetController.php
+++ b/app/Http/Controllers/Admin/SubfleetController.php
@@ -527,8 +527,10 @@ class SubfleetController extends Controller
 
         // associate rank with the subfleet
         if ($request->isMethod('post')) {
-            $rank = $this->rankRepo->find($request->input('rank_id'));
-            $this->fleetSvc->addSubfleetToRank($subfleet, $rank);
+            foreach ($request->input('rank_ids') as $rank_id) {
+                $rank = $this->rankRepo->find($rank_id);
+                $this->fleetSvc->addSubfleetToRank($subfleet, $rank);
+            }
         } // override definitions
         elseif ($request->isMethod('put')) {
             $override = [];

--- a/resources/views/admin/subfleets/ranks.blade.php
+++ b/resources/views/admin/subfleets/ranks.blade.php
@@ -57,11 +57,10 @@
                         'method' => 'post',
                         'class' => 'modify_rank form-inline'])
         }}
-        {{ Form::select('rank_id', $avail_ranks, null, [
-                'placeholder' => 'Select Rank',
-                'class' => 'ac-fare-dropdown form-control input-lg select2',
-
-            ])
+        <label for="rank_ids">Add ranks:</label>
+        {{ Form::select('rank_ids[]', $avail_ranks, null, [
+                'multiple' => 'multiple',
+                'class' => 'select2 form-control input-lg'])
         }}
         {{ Form::button('<i class="glyphicon glyphicon-plus"></i> add',
                          ['type' => 'submit',


### PR DESCRIPTION
Just as we can add multiple subfleets to a rank at once, we'll now be able to add multiple ranks to a subfleet at once.

![image](https://github.com/user-attachments/assets/99b1c9b4-5001-4ffd-a3ba-97843be2bfbc)
