### PR TITLE
API Optimizations

### DIFF
--- a/app/Http/Controllers/Api/PirepController.php
+++ b/app/Http/Controllers/Api/PirepController.php
@@ -438,7 +438,7 @@ class PirepController extends Controller
     {
         $pirep = Pirep::find($id);
         $transactions = $this->journalRepo->getAllForObject($pirep);
-        return JournalTransactionResource::collection($transactions);
+        return JournalTransactionResource::collection($transactions['transactions']);
     }
 
     /**

--- a/app/Http/Controllers/Api/PirepController.php
+++ b/app/Http/Controllers/Api/PirepController.php
@@ -172,7 +172,6 @@ class PirepController extends Controller
     public function get(string $id): PirepResource
     {
         $with = [
-            'acars',
             'aircraft',
             'arr_airport',
             'dpt_airport',

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -100,7 +100,7 @@ class UserController extends Controller
     public function bids(Request $request)
     {
         $user_id = $this->getUserId($request);
-        $user = $this->userSvc->getUser($user_id);
+        $user = $this->userSvc->getUser($user_id, false);
         if ($user === null) {
             throw new UserNotFound();
         }
@@ -130,8 +130,17 @@ class UserController extends Controller
             $this->bidSvc->removeBid($flight, $user);
         }
 
+        $relations = [
+            'subfleets',
+            'simbrief_aircraft'
+        ];
+
+        if ($request->has('with')) {
+            $relations = explode(',', $request->input('with', ''));
+        }
+
         // Return the flights they currently have bids on
-        $bids = $this->bidSvc->findBidsForUser($user);
+        $bids = $this->bidSvc->findBidsForUser($user, $relations);
 
         return BidResource::collection($bids);
     }

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -132,7 +132,7 @@ class UserController extends Controller
 
         $relations = [
             'subfleets',
-            'simbrief_aircraft'
+            'simbrief_aircraft',
         ];
 
         if ($request->has('with')) {

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -176,7 +176,7 @@ class UserController extends Controller
             throw new UserNotFound();
         }
 
-        $subfleets = $this->userSvc->getAllowableSubfleets($user);
+        $subfleets = $this->userSvc->getAllowableSubfleets($user, true);
 
         return SubfleetResource::collection($subfleets);
     }

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -214,6 +214,7 @@ class UserController extends Controller
         $this->pirepRepo->pushCriteria(new WhereCriteria($request, $where));
 
         $pireps = $this->pirepRepo
+            ->with(['airline', 'dpt_airport', 'arr_airport'])
             ->orderBy('created_at', 'desc')
             ->paginate();
 

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -79,7 +79,7 @@ class UserController extends Controller
      */
     public function get(int $id): UserResource
     {
-        $user = $this->userSvc->getUser($id);
+        $user = $this->userSvc->getUser($id, false);
         if ($user === null) {
             throw new UserNotFound();
         }

--- a/app/Http/Resources/Rank.php
+++ b/app/Http/Resources/Rank.php
@@ -17,7 +17,7 @@ class Rank extends Resource
     {
         return [
             'name'      => $this->name,
-            'subfleets' => Subfleet::collection($this->subfleets),
+            'subfleets' => Subfleet::collection($this->whenLoaded('subfleets')),
         ];
     }
 }

--- a/app/Http/Resources/SimBrief.php
+++ b/app/Http/Resources/SimBrief.php
@@ -32,7 +32,7 @@ class SimBrief extends Resource
             // Invalid fare data
         }
 
-        $data['subfleet'] = new BidSubfleet($this->aircraft->subfleet, $this->aircraft, $fares);
+        $data['subfleet'] = new BidSubfleet($this->whenLoaded('aircraft.subfleet'), $this->whenLoaded('aircraft'), $fares);
 
         return $data;
     }

--- a/app/Http/Resources/SimBrief.php
+++ b/app/Http/Resources/SimBrief.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
+use Illuminate\Http\Resources\MissingValue;
 
 /**
  * @mixin \App\Models\SimBrief
@@ -32,7 +33,9 @@ class SimBrief extends Resource
             // Invalid fare data
         }
 
-        $data['subfleet'] = new BidSubfleet($this->whenLoaded('aircraft.subfleet'), $this->whenLoaded('aircraft'), $fares);
+        if (!($this->whenLoaded('aircraft') instanceof MissingValue)) {
+            $data['subfleet'] = new BidSubfleet($this->aircraft->subfleet, $this->aircraft, $fares);
+        }
 
         return $data;
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -650,7 +650,7 @@ class RouteServiceProvider extends ServiceProvider
                 Route::post('pireps/{pirep_id}/acars/events', 'AcarsController@acars_events');
                 Route::post('pireps/{pirep_id}/acars/logs', 'AcarsController@acars_logs');
 
-                Route::get('settings', 'SettingsController@index');
+                // Route::get('settings', 'SettingsController@index');
 
                 // This is the info of the user whose token is in use
                 Route::get('user', 'UserController@index');

--- a/app/Services/BidService.php
+++ b/app/Services/BidService.php
@@ -72,7 +72,7 @@ class BidService extends Service
      * Find all of the bids for a given user
      *
      * @param \App\Models\User $user
-     * @param array $relations
+     * @param array            $relations
      *
      * @return Bid[]
      */
@@ -89,36 +89,36 @@ class BidService extends Service
             },
         ];
 
-         foreach ($relations as $relation) {
-             $with = array_merge($with, match ($relation) {
-                 'subfleets' => [
-                     'flight.subfleets',
-                     'flight.subfleets.aircraft',
-                     'flight.subfleets.aircraft.bid',
-                     'flight.subfleets.fares',
-                 ],
-                 'simbrief_aircraft' => [
-                     'flight.simbrief.aircraft',
-                     'flight.simbrief.aircraft.subfleet',
-                     'flight.simbrief.aircraft.subfleet.fares',
-                 ],
-                 default => [],
-             });
-         }
+        foreach ($relations as $relation) {
+            $with = array_merge($with, match ($relation) {
+                'subfleets' => [
+                    'flight.subfleets',
+                    'flight.subfleets.aircraft',
+                    'flight.subfleets.aircraft.bid',
+                    'flight.subfleets.fares',
+                ],
+                'simbrief_aircraft' => [
+                    'flight.simbrief.aircraft',
+                    'flight.simbrief.aircraft.subfleet',
+                    'flight.simbrief.aircraft.subfleet.fares',
+                ],
+                default => [],
+            });
+        }
 
         $bids = Bid::with($with)->where(['user_id' => $user->id])->get();
 
-         if (in_array('subfleets', $relations, true)) {
-             foreach ($bids as $bid) {
-                 if ($bid->aircraft) {
-                     $bid->flight->subfleets = $this->flightSvc->getSubfleetsForBid($bid);
-                 } else {
-                     $bid->flight = $this->flightSvc->filterSubfleets($user, $bid->flight, $bid);
-                 }
+        if (in_array('subfleets', $relations, true)) {
+            foreach ($bids as $bid) {
+                if ($bid->aircraft) {
+                    $bid->flight->subfleets = $this->flightSvc->getSubfleetsForBid($bid);
+                } else {
+                    $bid->flight = $this->flightSvc->filterSubfleets($user, $bid->flight, $bid);
+                }
 
-                 $bid->flight = $this->fareSvc->getReconciledFaresForFlight($bid->flight);
-             }
-         }
+                $bid->flight = $this->fareSvc->getReconciledFaresForFlight($bid->flight);
+            }
+        }
 
         return $bids;
     }

--- a/app/Services/BidService.php
+++ b/app/Services/BidService.php
@@ -110,7 +110,7 @@ class BidService extends Service
 
          if (in_array('subfleets', $relations, true)) {
              foreach ($bids as $bid) {
-                 if (!empty($bid->aircraft)) {
+                 if ($bid->aircraft) {
                      $bid->flight->subfleets = $this->flightSvc->getSubfleetsForBid($bid);
                  } else {
                      $bid->flight = $this->flightSvc->filterSubfleets($user, $bid->flight, $bid);

--- a/app/Services/BidService.php
+++ b/app/Services/BidService.php
@@ -72,37 +72,53 @@ class BidService extends Service
      * Find all of the bids for a given user
      *
      * @param \App\Models\User $user
+     * @param array $relations
      *
      * @return Bid[]
      */
-    public function findBidsForUser(User $user): Collection|array|null
+    public function findBidsForUser(User $user, array $relations): Collection|array|null
     {
         $with = [
             'aircraft',
             'flight',
+            'flight.airline',
             'flight.fares',
+            'flight.field_values',
             'flight.simbrief' => function ($query) use ($user) {
                 $query->where('user_id', $user->id);
             },
-            'flight.simbrief.aircraft',
-            'flight.simbrief.aircraft.subfleet',
-            'flight.subfleets',
-            'flight.subfleets.aircraft',
-            'flight.subfleets.aircraft.bid',
-            'flight.subfleets.fares',
         ];
+
+         foreach ($relations as $relation) {
+             $with = array_merge($with, match ($relation) {
+                 'subfleets' => [
+                     'flight.subfleets',
+                     'flight.subfleets.aircraft',
+                     'flight.subfleets.aircraft.bid',
+                     'flight.subfleets.fares',
+                 ],
+                 'simbrief_aircraft' => [
+                     'flight.simbrief.aircraft',
+                     'flight.simbrief.aircraft.subfleet',
+                     'flight.simbrief.aircraft.subfleet.fares',
+                 ],
+                 default => [],
+             });
+         }
 
         $bids = Bid::with($with)->where(['user_id' => $user->id])->get();
 
-        foreach ($bids as $bid) {
-            if (!empty($bid->aircraft)) {
-                $bid->flight->subfleets = $this->flightSvc->getSubfleetsForBid($bid);
-            } else {
-                $bid->flight = $this->flightSvc->filterSubfleets($user, $bid->flight, $bid);
-            }
+         if (in_array('subfleets', $relations, true)) {
+             foreach ($bids as $bid) {
+                 if (!empty($bid->aircraft)) {
+                     $bid->flight->subfleets = $this->flightSvc->getSubfleetsForBid($bid);
+                 } else {
+                     $bid->flight = $this->flightSvc->filterSubfleets($user, $bid->flight, $bid);
+                 }
 
-            $bid->flight = $this->fareSvc->getReconciledFaresForFlight($bid->flight);
-        }
+                 $bid->flight = $this->fareSvc->getReconciledFaresForFlight($bid->flight);
+             }
+         }
 
         return $bids;
     }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -373,7 +373,7 @@ class UserService extends Service
 
         $subfleetsQuery = $this->subfleetRepo->when($restrict_rank || $restrict_type, function ($query) use ($restricted_to) {
             return $query->whereIn('id', $restricted_to);
-        })->with(['aircraft', 'fares']);
+        })->with(['aircraft', 'aircraft.bid', 'fares']);
 
         if ($paginate) {
             /* @var Collection $subfleets */

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -349,7 +349,7 @@ class UserService extends Service
      *
      * @return Collection
      */
-    public function getAllowableSubfleets($user)
+    public function getAllowableSubfleets($user, bool $paginate = false)
     {
         $restrict_rank = setting('pireps.restrict_aircraft_to_rank', true);
         $restrict_type = setting('pireps.restrict_aircraft_to_typerating', false);
@@ -371,10 +371,17 @@ class UserService extends Service
             $restrict_type = false;
         }
 
-        // @var Collection $subfleets
-        $subfleets = $this->subfleetRepo->when($restrict_rank || $restrict_type, function ($query) use ($restricted_to) {
+        $subfleetsQuery = $this->subfleetRepo->when($restrict_rank || $restrict_type, function ($query) use ($restricted_to) {
             return $query->whereIn('id', $restricted_to);
-        })->with('aircraft')->get();
+        })->with('aircraft');
+
+        if ($paginate) {
+            /* @var Collection $subfleets */
+            $subfleets = $subfleetsQuery->paginate();
+        } else {
+            /* @var Collection $subfleets */
+            $subfleets = $subfleetsQuery->get();
+        }
 
         // Map the subfleets with the proper fare information
         return $subfleets->transform(function ($sf, $key) {

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -373,7 +373,7 @@ class UserService extends Service
 
         $subfleetsQuery = $this->subfleetRepo->when($restrict_rank || $restrict_type, function ($query) use ($restricted_to) {
             return $query->whereIn('id', $restricted_to);
-        })->with('aircraft');
+        })->with(['aircraft', 'fares']);
 
         if ($paginate) {
             /* @var Collection $subfleets */

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -54,15 +54,21 @@ class UserService extends Service
     /**
      * Find the user and return them with all of the data properly attached
      *
-     * @param $user_id
+     * @param int $user_id
      *
      * @return User|null
      */
-    public function getUser($user_id): ?User
+    public function getUser(int $user_id, bool $with_subfleets = true): ?User
     {
+        $with = ['airline', 'bids', 'rank'];
+
+        if ($with_subfleets) {
+            $with[] = 'rank.subfleets';
+        }
+
         /** @var User $user */
         $user = $this->userRepo
-            ->with(['airline', 'bids', 'rank'])
+            ->with($with)
             ->find($user_id);
 
         if (empty($user)) {
@@ -73,9 +79,11 @@ class UserService extends Service
             return null;
         }
 
-        // Load the proper subfleets to the rank
-        $user->rank->subfleets = $this->getAllowableSubfleets($user);
-        $user->subfleets = $user->rank->subfleets;
+        if ($with_subfleets) {
+            // Load the proper subfleets to the rank
+            $user->rank->subfleets = $this->getAllowableSubfleets($user);
+            $user->subfleets = $user->rank->subfleets;
+        }
 
         return $user;
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -342,12 +342,14 @@ final class ApiTest extends TestCase
         $this->assertEquals($body['zfw'], $aircraft->zfw);
     }
 
+    /*
     public function testGetAllSettings(): void
     {
         $this->user = User::factory()->create();
         $res = $this->get('/api/settings')->assertStatus(200);
         $settings = $res->json();
     }
+    */
 
     public function testGetUser(): void
     {

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -153,18 +153,6 @@ final class UserTest extends TestCase
         $subfleetAFromApi = collect($body)->firstWhere('id', $subfleetA['subfleet']->id);
         $this->assertEquals($subfleetAFromApi['fares'][0]['price'], $overrides['price']);
         $this->assertEquals($subfleetAFromApi['fares'][0]['capacity'], $overrides['capacity']);
-
-        // Read the user's profile and make sure that subfleet C is not part of this
-        // Should only return a single subfleet (subfleet A)
-        $resp = $this->get('/api/user', [], $user);
-        $resp->assertStatus(200);
-
-        $body = $resp->json('data');
-        $subfleets = $body['rank']['subfleets'];
-
-        $this->assertEquals(1, count($subfleets));
-        $this->assertEquals($subfleets[0]['fares'][0]['price'], $overrides['price']);
-        $this->assertEquals($subfleets[0]['fares'][0]['capacity'], $overrides['capacity']);
     }
 
     /**


### PR DESCRIPTION
This PR adds various optimizations for the API, particularly in the case of large databases (as discussed with Nabeel).

Firstly, we remove certain unnecessary relationships, such as subfleets when searching for flights. To maintain backward compatibility, these relationships are still present on the default route; we've just added a query string that allows them to be removed or to include only specific ones (check which ones by endpoint). `?with=` allows all of them to be removed, for example, `?with=subfleets` allows loading only those related to subfleets.

Next, we've added eager loading in some places where it was missing.

Additionally, this PR fixes a bug in the endpoint that retrieves the finances of a PIREP (an error in the resource).

Finally, it disables the settings endpoint, which exposed all application settings in plain text, including some that are sensitive and should not be exposed or accessible by all users.