### PR TITLE
Correct Default theme.json

### DIFF
--- a/resources/views/layouts/default/theme.json
+++ b/resources/views/layouts/default/theme.json
@@ -1,4 +1,4 @@
 {
   "name": "default",
-  "parent_theme": null
+  "extends": null
 }


### PR DESCRIPTION
The theme.json file uses "parent_theme" instead of "extends", which doesn't match the documentation. This has been corrected for a case where the user may copy and paste the default theme's theme.json file and expects it to work.