### PR TITLE
Added Type Rating Based Search

### DIFF
--- a/app/Repositories/Criteria/WhereCriteria.php
+++ b/app/Repositories/Criteria/WhereCriteria.php
@@ -56,7 +56,17 @@ class WhereCriteria implements CriteriaInterface
                 $model = $model
                     ->with($relation)
                     ->whereHas($relation, function (Builder $query) use ($criterea) {
-                        $query->where($criterea);
+                        if (!isset($criterea['method'])) {
+                            $query->where($criterea);
+                        } else {
+                            if ($criterea['method'] == 'where') {
+                                $query->where($criterea['query']);
+                            }
+                            if ($criterea['method'] == 'whereIn') {
+                                $query->whereIn($criterea['query']['key'], $criterea['query']['values']);
+                            }
+                        }
+
                     });
             }
         }

--- a/app/Repositories/Criteria/WhereCriteria.php
+++ b/app/Repositories/Criteria/WhereCriteria.php
@@ -66,7 +66,6 @@ class WhereCriteria implements CriteriaInterface
                                 $query->whereIn($criterea['query']['key'], $criterea['query']['values']);
                             }
                         }
-
                     });
             }
         }

--- a/app/Repositories/FlightRepository.php
+++ b/app/Repositories/FlightRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Contracts\Repository;
 use App\Models\Flight;
+use App\Models\Typerating;
 use App\Repositories\Criteria\WhereCriteria;
 use Illuminate\Http\Request;
 use Prettus\Repository\Contracts\CacheableInterface;
@@ -148,6 +149,19 @@ class FlightRepository extends Repository implements CacheableInterface
         if ($request->filled('subfleet_id')) {
             $relations['subfleets'] = [
                 'subfleets.id' => $request->input('subfleet_id'),
+            ];
+        }
+
+        if ($request->filled('type_rating_id')) {
+            $type = Typerating::find($request->input('type_rating_id'));
+            $subfleet_ids = $type->subfleets()->select('id');
+
+            $relations['subfleets'] = [
+                'method' => 'whereIn',
+                'query'  => [
+                    'key'    => 'subfleets.id',
+                    'values' => $subfleet_ids,
+                ]
             ];
         }
 

--- a/app/Repositories/FlightRepository.php
+++ b/app/Repositories/FlightRepository.php
@@ -161,7 +161,7 @@ class FlightRepository extends Repository implements CacheableInterface
                 'query'  => [
                     'key'    => 'subfleets.id',
                     'values' => $subfleet_ids,
-                ]
+                ],
             ];
         }
 


### PR DESCRIPTION
closes #1851

This adds Type Rating based search to the Flight Repository.

Upon testing at a larger community with many airlines, aircraft, and subfleets, it was found to be inefficient.

This PR, while it can be pulled, needs a bit more work, and I'm requesting help here to make the code more efficient before we merge.