### PR TITLE
Search Flights By Type Rating and Aircraft ICAO Type Code

### DIFF
--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -129,7 +129,7 @@ class FlightController extends Controller
             // Build aircraft icao codes array from complete fleet
             $icao_codes = Aircraft::groupBy('icao')->orderBy('icao')->pluck('icao')->toArray();
             // Build type ratings collection from all active ratings
-            $type_ratings = Typerating::where('active', 1)->select('id', 'type')->orderBy('type')->get();
+            $type_ratings = Typerating::where('active', 1)->select('id', 'name', 'type')->orderBy('type')->get();
         }
 
         // Get only used Flight Types for the search form

--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Contracts\Controller;
+use App\Models\Aircraft;
 use App\Models\Bid;
 use App\Models\Enums\FlightType;
 use App\Models\Flight;
+use App\Models\Typerating;
 use App\Repositories\AirlineRepository;
 use App\Repositories\AirportRepository;
 use App\Repositories\Criteria\WhereCriteria;
@@ -78,7 +80,7 @@ class FlightController extends Controller
 
         /** @var \App\Models\User $user */
         $user = Auth::user();
-        $user->loadMissing('current_airport');
+        $user->loadMissing(['current_airport', 'typeratings']);
 
         if (setting('pilots.restrict_to_company')) {
             $where['airline_id'] = $user->airline_id;
@@ -117,10 +119,17 @@ class FlightController extends Controller
                 ->toArray();
             // Get flight_id's of open (non restricted) flights
             $open_flights = Flight::withCount('subfleets')->whereNull('user_id')->having('subfleets_count', 0)->pluck('id')->toArray();
-            // Merge results
             $allowed_flights = array_merge($user_flights, $open_flights);
+            // Build aircraft icao codes by considering allowed subfleets
+            $icao_codes = Aircraft::whereIn('subfleet_id', $user_subfleets)->groupBy('icao')->orderBy('icao')->pluck('icao')->toArray();
+            // Build type ratings collection by considering user's capabilities
+            $type_ratings = $user->typeratings;
         } else {
             $allowed_flights = [];
+            // Build aircraft icao codes array from complete fleet
+            $icao_codes = Aircraft::groupBy('icao')->orderBy('icao')->pluck('icao')->toArray();
+            // Build type ratings collection from all active ratings
+            $type_ratings = Typerating::where('active', 1)->select('id', 'type')->orderBy('type')->get();
         }
 
         // Get only used Flight Types for the search form
@@ -181,6 +190,8 @@ class FlightController extends Controller
             'simbrief'      => !empty(setting('simbrief.api_key')),
             'simbrief_bids' => setting('simbrief.only_bids'),
             'acars_plugin'  => $this->moduleSvc->isModuleActive('VMSAcars'),
+            'icao_codes'    => $icao_codes,
+            'type_ratings'  => $type_ratings,
         ]);
     }
 

--- a/app/Repositories/Criteria/WhereCriteria.php
+++ b/app/Repositories/Criteria/WhereCriteria.php
@@ -56,7 +56,17 @@ class WhereCriteria implements CriteriaInterface
                 $model = $model
                     ->with($relation)
                     ->whereHas($relation, function (Builder $query) use ($criterea) {
-                        $query->where($criterea);
+                        // By Taylor Broad
+                        if (!isset($criterea['method'])) {
+                            $query->where($criterea);
+                        } else {
+                            if ($criterea['method'] == 'where') {
+                                $query->where($criterea['query']);
+                            }
+                            if ($criterea['method'] == 'whereIn') {
+                                $query->whereIn($criterea['query']['key'], $criterea['query']['values']);
+                            }
+                        }
                     });
             }
         }

--- a/resources/views/layouts/default/flights/search.blade.php
+++ b/resources/views/layouts/default/flights/search.blade.php
@@ -55,19 +55,19 @@
         </select>
       </div>
 
-      @if(!empty($type_ratings))
+      @if(filled($type_ratings))
         <div class="mt-3">
           <div>Type Rating</div>
           <select name="type_rating_id" id="type_rating_id" class="form-control select2">
             <option value=""></option>
             @foreach($type_ratings as $tr)
-              <option value="{{ $tr->id }}" @if(request()->get('type_rating_id') == $tr->id) selected @endif>{{ $tr->type }}</option>
+              <option value="{{ $tr->id }}" @if(request()->get('type_rating_id') == $tr->id) selected @endif>{{ $tr->type.' | '.$tr->name }}</option>
             @endforeach
           </select>
         </div>
       @endif
 
-      @if(!empty($icao_codes))
+      @if(filled($icao_codes))
         <div class="mt-3">
           <div>ICAO Type</div>
           <select name="icao_type" id="icao_type" class="form-control select2">

--- a/resources/views/layouts/default/flights/search.blade.php
+++ b/resources/views/layouts/default/flights/search.blade.php
@@ -55,6 +55,30 @@
         </select>
       </div>
 
+      @if(!empty($type_ratings))
+        <div class="mt-3">
+          <div>Type Rating</div>
+          <select name="type_rating_id" id="type_rating_id" class="form-control select2">
+            <option value=""></option>
+            @foreach($type_ratings as $tr)
+              <option value="{{ $tr->id }}" @if(request()->get('type_rating_id') == $tr->id) selected @endif>{{ $tr->type }}</option>
+            @endforeach
+          </select>
+        </div>
+      @endif
+
+      @if(!empty($icao_codes))
+        <div class="mt-3">
+          <div>ICAO Type</div>
+          <select name="icao_type" id="icao_type" class="form-control select2">
+            <option value=""></option>
+            @foreach($icao_codes as $icao)
+              <option value="{{ $icao }}" @if(request()->get('icao_type') == $icao) selected @endif>{{ $icao }}</option>
+            @endforeach
+          </select>
+        </div>
+      @endif
+
       <div class="clear mt-3" style="margin-top: 10px;">
         <button type="submit" class="btn btn-outline-primary">@lang('common.find')</button>
         <a href="{{ route('frontend.flights.index') }}">@lang('common.reset')</a>


### PR DESCRIPTION
Based on @BossOfGames 's idea and implementation for the usage of `whereIn()` as a new search criteria [_WhereCriteria_], I slightly changed his Type Rating based query to improve performance and added Aircraft ICAO Type Code based search capabilities. [_FlightRepository_]

According to VA settings, both **$type_ratings** and **$icao_codes** are built upon user capabilities (restricted settings) or all (relaxed settings). [_FlightController_]

Added both fields with conditional checks to default theme. [_search.blade_]

![image](https://github.com/user-attachments/assets/62e75bf3-bd69-4ce8-b882-e11e11f101fc)

Enhances #1879 and provides other changes for this feature to be used with any theme.

Closes #1851 
