### PR TITLE
Nested Eager Loading

### DIFF
--- a/app/Http/Controllers/Api/FleetController.php
+++ b/app/Http/Controllers/Api/FleetController.php
@@ -58,7 +58,7 @@ class FleetController extends Controller
         }
 
         $aircraft = $this->aircraftRepo
-            ->with(['subfleet', 'subfleet.fares'])
+            ->with('subfleet.fares')
             ->findWhere($where)
             ->first();
 

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -65,13 +65,10 @@ class FlightController extends Controller
         $flight = $this->flightRepo->with([
             'airline',
             'fares',
-            'subfleets',
-            'subfleets.aircraft',
-            'subfleets.aircraft.bid',
-            'subfleets.fares',
+            'subfleets' => [ 'aircraft.bid', 'fares'],
             'field_values',
             'simbrief' => function ($query) use ($user) {
-                return $query->where('user_id', $user->id);
+                return $query->with('aircraft')->where('user_id', $user->id);
             },
         ])->find($id);
 
@@ -121,7 +118,7 @@ class FlightController extends Controller
                 'fares',
                 'field_values',
                 'simbrief' => function ($query) use ($user) {
-                    return $query->where('user_id', $user->id);
+                    return $query->with('aircraft')->where('user_id', $user->id);
                 },
             ];
 
@@ -145,9 +142,7 @@ class FlightController extends Controller
                 });
             }
 
-            $flights = $this->flightRepo
-                ->with($with)
-                ->paginate();
+            $flights = $this->flightRepo->with($with)->paginate();
         } catch (RepositoryException $e) {
             return response($e, 503);
         }

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -65,7 +65,7 @@ class FlightController extends Controller
         $flight = $this->flightRepo->with([
             'airline',
             'fares',
-            'subfleets' => [ 'aircraft.bid', 'fares'],
+            'subfleets' => ['aircraft.bid', 'fares'],
             'field_values',
             'simbrief' => function ($query) use ($user) {
                 return $query->with('aircraft')->where('user_id', $user->id);


### PR DESCRIPTION
No need to add the main relationship if a sub relationship is being loaded by dot notation.

Also SimBrief relationships should be loaded with the aircraft

[Reference > Laravel 10x Docs](https://laravel.com/docs/10.x/eloquent-relationships#nested-eager-loading)