### PR TITLE
Credits Page (For phpvms v7 and installed modules)

### DIFF
--- a/app/Http/Controllers/Frontend/CreditsController.php
+++ b/app/Http/Controllers/Frontend/CreditsController.php
@@ -35,7 +35,7 @@ class CreditsController extends Controller
     // Return laravel collection
     public function ReadModuleJson($module_name = null)
     {
-        $file = isset($module_name) ? base_path() . '/modules/' . $module_name . '/module.json' : null;
+        $file = isset($module_name) ? base_path().'/modules/'.$module_name.'/module.json' : null;
 
         if (!is_file($file)) {
             return null;

--- a/app/Http/Controllers/Frontend/CreditsController.php
+++ b/app/Http/Controllers/Frontend/CreditsController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Contracts\Controller;
+use Illuminate\View\View;
+use Nwidart\Modules\Facades\Module;
+
+class CreditsController extends Controller
+{
+    public function index(): View
+    {
+        $all_modules = Module::all();
+        $v7_defaults = ['Awards', 'Vacentral', 'Sample'];
+        $modules = collect();
+
+        foreach ($all_modules as $key => $module) {
+            if (in_array($key, $v7_defaults)) {
+                continue;
+            }
+
+            $module_details = $this->ReadModuleJson($key);
+
+            if ($module_details) {
+                $modules->push($module_details);
+            }
+        }
+
+        return view('credits', [
+            'modules' => $modules,
+        ]);
+    }
+
+    // Read module.json file
+    // Return laravel collection
+    public function ReadModuleJson($module_name = null)
+    {
+        $file = isset($module_name) ? base_path() . '/modules/' . $module_name . '/module.json' : null;
+
+        if (!is_file($file)) {
+            return null;
+        }
+
+        $contents = json_decode(file_get_contents($file));
+
+        $details = collect();
+        $details->name = isset($contents->name) ? $contents->name : $module_name;
+        $details->description = isset($contents->description) ? $contents->description : null;
+        $details->version = isset($contents->version) ? $contents->version : null;
+        $details->readme_url = isset($contents->readme_url) ? $contents->readme_url : null;
+        $details->license_url = isset($contents->license_url) ? $contents->license_url : null;
+        $details->attribution = isset($contents->attribution) ? $contents->attribution : null;
+        $details->active = Module::isEnabled($contents->name);
+
+        return $details;
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -170,6 +170,8 @@ class RouteServiceProvider extends ServiceProvider
                 Route::get('livemap', 'LiveMapController@index')->name('livemap.index');
 
                 Route::get('lang/{lang}', 'LanguageController@switchLang')->name('lang.switch');
+
+                Route::get('credits', 'CreditsController@index')->name('credits');
             });
 
             Route::group([

--- a/resources/views/layouts/default/credits.blade.php
+++ b/resources/views/layouts/default/credits.blade.php
@@ -1,0 +1,45 @@
+@extends('app')
+@section('title', 'phpVMS v7 Credits')
+
+@section('content')
+  <div class="row row-cols-2">
+    <div class="col-sm-5">
+      <div class="card p-1 mb-2 border-blue-bottom">
+        <h4 class="header mt-1">PHPVMS v7</h4>
+        <img src="{{ public_asset('/assets/img/logo_blue_bg.svg') }}" width="100%" alt=""/>
+        <p class="description">Open-Source Virtual Airline Management</p>
+        <div class="footer text-left p-1">
+          <a href="https://docs.phpvms.net" target="_blank" class="btn btn-info btn-sm">Documents & Guides</a>
+          <a href="https://docs.phpvms.net/#license" target="_blank" class="btn btn-info btn-sm">License</a>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-7">
+      @foreach($modules as $module)
+        <div class="card p-1 mb-2 border-blue-bottom">
+          <h4 class="header mt-1">{{ $module->name }}</h4>
+          <p class="description">{{ $module->description }}</p>
+          @if($module->version)
+            <p class="description">Version: {{ $module->version }}</p>
+          @endif
+          <div class="footer text-right p-1">
+            @if($module->active)
+              <span class="btn btn-success btn-sm disabled" title="Active">&checkmark;</span>
+            @else
+              <span class="btn btn-warning btn-sm disabled" title="Not Active">&cross;</span>
+            @endif
+            @if($module->attribution)
+              <a href="{{ $module->attribution->url }}" target="_blank" class="btn btn-outline-danger btn-sm">{{ $module->attribution->text }}</a>
+            @endif
+            @if($module->readme_url)
+              <a href="{{ $module->readme_url }}" target="_blank" class="btn btn-outline-info btn-sm">Readme</a>
+            @endif
+            @if($module->license_url)
+              <a href="{{ $module->license_url }}" target="_blank" class="btn btn-outline-info btn-sm">License</a>
+            @endif
+          </div>
+        </div>
+      @endforeach
+    </div>
+  </div>
+@endsection


### PR DESCRIPTION
Provides a public credits page, which holds logo and links for phpvms v7 itself and lists any installed modules. It skips the default modules (Awards, VaCentral and Sample.)

Basically we need more lines in module.json file, so this should be documented on developers section otherwise only the name and status of the module (active/deactive) will be displayed.

```json
    "version": null,
    "readme_url": null,
    "license_url": null,
    "attribution": {
        "text": null,
        "url": null,
        "img": null
    },
```

If the design and logic is ok, can be merged.

Closes #1867 