### PR TITLE
Remove Eager Loading in some areas to increase performance with large datasets

### DIFF
--- a/app/Http/Controllers/Admin/PirepController.php
+++ b/app/Http/Controllers/Admin/PirepController.php
@@ -73,6 +73,8 @@ class PirepController extends Controller
             $subfleets = $this->userSvc->getAllowableSubfleets($user);
         }
 
+        $subfleets->load('aircraft');
+
         foreach ($subfleets as $subfleet) {
             $tmp = [];
             foreach ($subfleet->aircraft as $ac) {

--- a/app/Http/Controllers/Admin/PirepController.php
+++ b/app/Http/Controllers/Admin/PirepController.php
@@ -73,7 +73,7 @@ class PirepController extends Controller
             $subfleets = $this->userSvc->getAllowableSubfleets($user);
         }
 
-        $subfleets->load('aircraft');
+        $subfleets->loadMissing('aircraft');
 
         foreach ($subfleets as $subfleet) {
             $tmp = [];


### PR DESCRIPTION
This PR addresses an issue where if you have a huge amount of subfleets, you get a significant perf drop because it's trying to eager load the relationships in the foreach loop.

![image](https://github.com/user-attachments/assets/42bbd016-7420-406e-94cb-dc4711b7beed)

Doing this one line change significantly increases perf.

![image](https://github.com/user-attachments/assets/b4675b5e-5d45-4d1f-8c5b-d601e3980a7c)
