### PR TITLE
SimBrief Airframes & Aircraft Weight Casting

### DIFF
--- a/app/Cron/Weekly/UpdateSimbriefData.php
+++ b/app/Cron/Weekly/UpdateSimbriefData.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Cron\Weekly;
+
+use App\Contracts\Listener;
+use App\Events\CronWeekly;
+use App\Services\SimBriefService;
+use Illuminate\Support\Facades\Log;
+
+class UpdateSimbriefData extends Listener
+{
+    /**
+     * Update SimBrief Support Data
+     *
+     * @param CronWeekly $event
+     *
+     * @throws \UnexpectedValueException
+     * @throws \InvalidArgumentException
+     * @throws \Prettus\Validator\Exceptions\ValidatorException
+     */
+    public function handle(CronWeekly $event): void
+    {
+        Log::info('Weekly: Updating SimBrief Support Data');
+        $SimBriefSVC = app(SimBriefService::class);
+        $SimBriefSVC->getAircraftAndAirframes();
+        $SimBriefSVC->GetBriefingLayouts();
+    }
+}

--- a/app/Database/migrations/2024_11_16_105923_create_simbrief_support_tables.php
+++ b/app/Database/migrations/2024_11_16_105923_create_simbrief_support_tables.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('simbrief_aircraft')) {
+            Schema::create('simbrief_aircraft', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('icao');
+                $table->string('name');
+                $table->mediumText('details')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (!Schema::hasTable('simbrief_airframes')) {
+            Schema::create('simbrief_airframes', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('icao');
+                $table->string('name');
+                $table->string('airframe_id')->nullable();
+                $table->string('source')->nullable();
+                $table->mediumText('details')->nullable();
+                $table->mediumText('options')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (!Schema::hasTable('simbrief_layouts')) {
+            Schema::create('simbrief_layouts', function (Blueprint $table) {
+                $table->string('id');
+                $table->string('name');
+                $table->string('name_long');
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('simbrief_aircraft');
+        Schema::dropIfExists('simbrief_airframes');
+        Schema::dropIfExists('simbrief_layouts');
+    }
+};

--- a/app/Database/migrations/2024_11_16_105923_create_simbrief_support_tables.php
+++ b/app/Database/migrations/2024_11_16_105923_create_simbrief_support_tables.php
@@ -23,7 +23,7 @@ return new class() extends Migration {
                 $table->string('icao');
                 $table->string('name');
                 $table->string('airframe_id')->nullable();
-                $table->string('source')->nullable();
+                $table->unsignedTinyInteger('source')->nullable();
                 $table->mediumText('details')->nullable();
                 $table->mediumText('options')->nullable();
                 $table->timestamps();

--- a/app/Database/migrations_data/2024_11_16_122416_fetch_initial_simbrief_data.php
+++ b/app/Database/migrations_data/2024_11_16_122416_fetch_initial_simbrief_data.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Services\SimBriefService;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('simbrief_aircraft') && Schema::hasTable('simbrief_airframes')) {
+
+            $SimBriefSVC = app(SimBriefService::class);
+            $SimBriefSVC->getAircraftAndAirframes();
+            $SimBriefSVC->GetBriefingLayouts();
+        }
+    }
+};

--- a/app/Database/migrations_data/2024_11_16_122416_fetch_initial_simbrief_data.php
+++ b/app/Database/migrations_data/2024_11_16_122416_fetch_initial_simbrief_data.php
@@ -8,7 +8,6 @@ return new class() extends Migration {
     public function up(): void
     {
         if (Schema::hasTable('simbrief_aircraft') && Schema::hasTable('simbrief_airframes')) {
-
             $SimBriefSVC = app(SimBriefService::class);
             $SimBriefSVC->getAircraftAndAirframes();
             $SimBriefSVC->GetBriefingLayouts();

--- a/app/Database/migrations_data/2024_11_17_114057_convert_aircraft_weights.php
+++ b/app/Database/migrations_data/2024_11_17_114057_convert_aircraft_weights.php
@@ -10,14 +10,14 @@ return new class() extends Migration {
         if (setting('units.weight') == 'kg') {
             // Get all aircraft data, directly from database which had weights defined
             $aircraft = DB::table('aircraft')->whereNotNull('dow')->orWhereNotNull('zfw')->orWhereNotNull('mtow')->orWhereNotNull('mlw')->orderBy('id')->get();
-            Log::debug('Begin weight conversion for ' . $aircraft->count() . ' aircraft records');
+            Log::debug('Begin weight conversion for '.$aircraft->count().' aircraft records');
             foreach ($aircraft as $ac) {
-                Log::debug('Converting and Updating Weights for ' . $ac->registration);
+                Log::debug('Converting and Updating Weights for '.$ac->registration);
                 DB::table('aircraft')->where('id', $ac->id)->update([
                     'dow'  => $this->PoundsConversion($ac->dow),
                     'zfw'  => $this->PoundsConversion($ac->zfw),
                     'mtow' => $this->PoundsConversion($ac->mtow),
-                    'mlw' => $this->PoundsConversion($ac->mlw),
+                    'mlw'  => $this->PoundsConversion($ac->mlw),
                 ]);
             }
         }

--- a/app/Database/migrations_data/2024_11_17_114057_convert_aircraft_weights.php
+++ b/app/Database/migrations_data/2024_11_17_114057_convert_aircraft_weights.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        if (setting('units.weight') == 'kg') {
+            // Get all aircraft data, directly from database which had weights defined
+            $aircraft = DB::table('aircraft')->whereNotNull('dow')->orWhereNotNull('zfw')->orWhereNotNull('mtow')->orWhereNotNull('mlw')->orderBy('id')->get();
+            Log::debug('Begin weight conversion for ' . $aircraft->count() . ' aircraft records');
+            foreach ($aircraft as $ac) {
+                Log::debug('Converting and Updating Weights for ' . $ac->registration);
+                DB::table('aircraft')->where('id', $ac->id)->update([
+                    'dow'  => $this->PoundsConversion($ac->dow),
+                    'zfw'  => $this->PoundsConversion($ac->zfw),
+                    'mtow' => $this->PoundsConversion($ac->mtow),
+                    'mlw' => $this->PoundsConversion($ac->mlw),
+                ]);
+            }
+        }
+    }
+
+    public function PoundsConversion($value)
+    {
+        if ($value > 0) {
+            return round($value / 0.45359237, 2);
+        }
+
+        return null;
+    }
+};

--- a/app/Database/seeds/settings.yml
+++ b/app/Database/seeds/settings.yml
@@ -340,6 +340,20 @@
   options: ''
   type: boolean
   description: 'When enabled, an aircraft can only be used for one active SimBrief OFP and Flight/Pirep'
+- key: simbrief.use_standard_weights
+  name: 'Use Only phpVMS Weights'
+  group: simbrief
+  value: false
+  options: ''
+  type: boolean
+  description: 'When enabled, only phpVMS Passenger and Baggage weights will be used (instead of Airframe definitions)'
+- key: simbrief.use_custom_airframes
+  name: 'Use Only Custom Airframes'
+  group: simbrief
+  value: false
+  options: ''
+  type: boolean
+  description: 'When enabled, only phpVMS Airframes will be listed for flight planning (instead of combined list)'
 - key: pireps.duplicate_check_time
   name: 'PIREP duplicate time check'
   group: pireps

--- a/app/Http/Controllers/Admin/AircraftController.php
+++ b/app/Http/Controllers/Admin/AircraftController.php
@@ -124,7 +124,7 @@ class AircraftController extends Controller
         $attrs['dow'] = (filled($attrs['dow']) && $attrs['dow'] > 0) ? Mass::make((float) $request->input('dow'), setting('units.weight')) : null;
         $attrs['zfw'] = (filled($attrs['zfw']) && $attrs['zfw'] > 0) ? Mass::make((float) $request->input('zfw'), setting('units.weight')) : null;
         $attrs['mtow'] = (filled($attrs['mtow']) && $attrs['mtow'] > 0) ? Mass::make((float) $request->input('mtow'), setting('units.weight')) : null;
-        $attrs['mlw'] = (filled($attrs['mlw']) &&  $attrs['mlw'] > 0) ? Mass::make((float) $request->input('mlw'), setting('units.weight')) : null;
+        $attrs['mlw'] = (filled($attrs['mlw']) && $attrs['mlw'] > 0) ? Mass::make((float) $request->input('mlw'), setting('units.weight')) : null;
 
         $aircraft = $this->aircraftRepo->create($attrs);
 
@@ -215,7 +215,7 @@ class AircraftController extends Controller
         $attrs['dow'] = (filled($attrs['dow']) && $attrs['dow'] > 0) ? Mass::make((float) $request->input('dow'), setting('units.weight')) : null;
         $attrs['zfw'] = (filled($attrs['zfw']) && $attrs['zfw'] > 0) ? Mass::make((float) $request->input('zfw'), setting('units.weight')) : null;
         $attrs['mtow'] = (filled($attrs['mtow']) && $attrs['mtow'] > 0) ? Mass::make((float) $request->input('mtow'), setting('units.weight')) : null;
-        $attrs['mlw'] = (filled($attrs['mlw']) &&  $attrs['mlw'] > 0) ? Mass::make((float) $request->input('mlw'), setting('units.weight')) : null;
+        $attrs['mlw'] = (filled($attrs['mlw']) && $attrs['mlw'] > 0) ? Mass::make((float) $request->input('mlw'), setting('units.weight')) : null;
 
         $this->aircraftRepo->update($attrs, $id);
 

--- a/app/Http/Controllers/Admin/AircraftController.php
+++ b/app/Http/Controllers/Admin/AircraftController.php
@@ -17,6 +17,7 @@ use App\Services\ExportService;
 use App\Services\FileService;
 use App\Services\FinanceService;
 use App\Services\ImportService;
+use App\Support\Units\Mass;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -119,6 +120,12 @@ class AircraftController extends Controller
     public function store(CreateAircraftRequest $request): RedirectResponse
     {
         $attrs = $request->all();
+        // Set the correct mass units
+        $attrs['dow'] = (filled($attrs['dow']) && $attrs['dow'] > 0) ? Mass::make((float) $request->input('dow'), setting('units.weight')) : null;
+        $attrs['zfw'] = (filled($attrs['zfw']) && $attrs['zfw'] > 0) ? Mass::make((float) $request->input('zfw'), setting('units.weight')) : null;
+        $attrs['mtow'] = (filled($attrs['mtow']) && $attrs['mtow'] > 0) ? Mass::make((float) $request->input('mtow'), setting('units.weight')) : null;
+        $attrs['mlw'] = (filled($attrs['mlw']) &&  $attrs['mlw'] > 0) ? Mass::make((float) $request->input('mlw'), setting('units.weight')) : null;
+
         $aircraft = $this->aircraftRepo->create($attrs);
 
         Flash::success('Aircraft saved successfully.');
@@ -204,6 +211,12 @@ class AircraftController extends Controller
         }
 
         $attrs = $request->all();
+        // Set the correct mass units
+        $attrs['dow'] = (filled($attrs['dow']) && $attrs['dow'] > 0) ? Mass::make((float) $request->input('dow'), setting('units.weight')) : null;
+        $attrs['zfw'] = (filled($attrs['zfw']) && $attrs['zfw'] > 0) ? Mass::make((float) $request->input('zfw'), setting('units.weight')) : null;
+        $attrs['mtow'] = (filled($attrs['mtow']) && $attrs['mtow'] > 0) ? Mass::make((float) $request->input('mtow'), setting('units.weight')) : null;
+        $attrs['mlw'] = (filled($attrs['mlw']) &&  $attrs['mlw'] > 0) ? Mass::make((float) $request->input('mlw'), setting('units.weight')) : null;
+
         $this->aircraftRepo->update($attrs, $id);
 
         Flash::success('Aircraft updated successfully.');

--- a/app/Http/Controllers/Admin/AirframeController.php
+++ b/app/Http/Controllers/Admin/AirframeController.php
@@ -6,6 +6,7 @@ use App\Contracts\Controller;
 use App\Http\Requests\CreateAirframeRequest;
 use App\Http\Requests\UpdateAirframeRequest;
 use App\Models\Aircraft;
+use App\Models\Enums\AirframeSource;
 use App\Repositories\AirframeRepository;
 use App\Services\SimBriefService;
 use Illuminate\Http\RedirectResponse;
@@ -37,7 +38,7 @@ class AirframeController extends Controller
     public function index(Request $request): View
     {
         $this->airframeRepo->pushCriteria(new RequestCriteria($request));
-        $airframes = $this->airframeRepo->where('source', 'Custom')->orderby('icao', 'asc')->orderby('name', 'asc')->get();
+        $airframes = $this->airframeRepo->where('source', AirframeSource::INTERNAL)->orderby('icao', 'asc')->orderby('name', 'asc')->get();
 
         return view('admin.airframes.index', [
             'airframes' => $airframes,

--- a/app/Http/Controllers/Admin/AirframeController.php
+++ b/app/Http/Controllers/Admin/AirframeController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Contracts\Controller;
+use App\Http\Requests\CreateAirframeRequest;
+use App\Http\Requests\UpdateAirframeRequest;
+use App\Repositories\AirframeRepository;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Laracasts\Flash\Flash;
+use Prettus\Repository\Criteria\RequestCriteria;
+use Prettus\Repository\Exceptions\RepositoryException;
+use Prettus\Validator\Exceptions\ValidatorException;
+
+class AirframeController extends Controller
+{
+     /**
+     * @param AirframeRepository $airframeRepo
+     */
+    public function __construct(
+        private readonly AirframeRepository $airframeRepo
+    ) {
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws RepositoryException
+     *
+     * @return View
+     */
+    public function index(Request $request): View
+    {
+        $this->airframeRepo->pushCriteria(new RequestCriteria($request));
+        $airframes = $this->airframeRepo->where('source', 'Custom')->orderby('icao', 'asc')->orderby('name', 'asc')->get();
+
+        return view('admin.airframes.index', [
+            'airframes' => $airframes,
+        ]);
+    }
+
+    /**
+     * @return View
+     */
+    public function create(): View
+    {
+        return view('admin.airframes.create');
+    }
+
+    /**
+     * @param CreateAirframeRequest $request
+     *
+     * @throws ValidatorException
+     *
+     * @return RedirectResponse
+     */
+    public function store(CreateAirframeRequest $request): RedirectResponse
+    {
+        $input = $request->all();
+
+        $model = $this->airframeRepo->create($input);
+        Flash::success('Airframe saved successfully.');
+
+        return redirect(route('admin.airframes.index'));
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return RedirectResponse|View
+     */
+    public function show(int $id): RedirectResponse|View
+    {
+        $airframe = $this->airframeRepo->findWithoutFail($id);
+
+        if (empty($airframe)) {
+            Flash::error('SimBrief Airframe not found');
+
+            return redirect(route('admin.airframes.index'));
+        }
+
+        return view('admin.airframes.show', [
+            'airframe' => $airframe,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return RedirectResponse|View
+     */
+    public function edit(int $id): RedirectResponse|View
+    {
+        $airframe = $this->airframeRepo->findWithoutFail($id);
+
+        if (empty($airframe)) {
+            Flash::error('SimBrief Airframe not found');
+
+            return redirect(route('admin.airframes.index'));
+        }
+
+        return view('admin.airframes.edit', [
+            'airframe' => $airframe,
+        ]);
+    }
+
+    /**
+     * @param int                     $id
+     * @param UpdateAirframeRequest $request
+     *
+     * @throws ValidatorException
+     *
+     * @return RedirectResponse
+     */
+    public function update(int $id, UpdateAirframeRequest $request): RedirectResponse
+    {
+        $airframe = $this->airframeRepo->findWithoutFail($id);
+
+        if (empty($airframe)) {
+            Flash::error('SimBrief Airframe not found');
+
+            return redirect(route('admin.airframes.index'));
+        }
+
+        $airframe = $this->airframeRepo->update($request->all(), $id);
+        Flash::success('SimBrief Airport updated successfully.');
+
+        return redirect(route('admin.airframes.index'));
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return RedirectResponse
+     */
+    public function destroy(int $id): RedirectResponse
+    {
+        $airframe = $this->airframeRepo->findWithoutFail($id);
+
+        if (empty($airframe)) {
+            Flash::error('SimBrief Airframe not found');
+
+            return redirect(route('admin.airframes.index'));
+        }
+
+        $this->airframeRepo->delete($id);
+
+        Flash::success('SimBrief Airframe deleted successfully.');
+
+        return redirect(route('admin.airframes.index'));
+    }
+}

--- a/app/Http/Controllers/Admin/AirframeController.php
+++ b/app/Http/Controllers/Admin/AirframeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Contracts\Controller;
 use App\Http\Requests\CreateAirframeRequest;
 use App\Http\Requests\UpdateAirframeRequest;
+use App\Models\Aircraft;
 use App\Repositories\AirframeRepository;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -46,7 +47,10 @@ class AirframeController extends Controller
      */
     public function create(): View
     {
-        return view('admin.airframes.create');
+
+        return view('admin.airframes.create', [
+            'icao_codes' => Aircraft::whereNotNull('icao')->groupBy('icao')->pluck('icao')->toArray(),
+        ]);
     }
 
     /**
@@ -102,7 +106,8 @@ class AirframeController extends Controller
         }
 
         return view('admin.airframes.edit', [
-            'airframe' => $airframe,
+            'airframe'   => $airframe,
+            'icao_codes' => Aircraft::whereNotNull('icao')->groupBy('icao')->pluck('icao')->toArray(),
         ]);
     }
 

--- a/app/Http/Controllers/Admin/AirframeController.php
+++ b/app/Http/Controllers/Admin/AirframeController.php
@@ -19,7 +19,7 @@ use Prettus\Validator\Exceptions\ValidatorException;
 
 class AirframeController extends Controller
 {
-     /**
+    /**
      * @param AirframeRepository $airframeRepo
      */
     public function __construct(
@@ -114,7 +114,7 @@ class AirframeController extends Controller
     }
 
     /**
-     * @param int                     $id
+     * @param int                   $id
      * @param UpdateAirframeRequest $request
      *
      * @throws ValidatorException

--- a/app/Http/Controllers/Admin/AirframeController.php
+++ b/app/Http/Controllers/Admin/AirframeController.php
@@ -7,8 +7,10 @@ use App\Http\Requests\CreateAirframeRequest;
 use App\Http\Requests\UpdateAirframeRequest;
 use App\Models\Aircraft;
 use App\Repositories\AirframeRepository;
+use App\Services\SimBriefService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Laracasts\Flash\Flash;
 use Prettus\Repository\Criteria\RequestCriteria;
@@ -153,6 +155,20 @@ class AirframeController extends Controller
         $this->airframeRepo->delete($id);
 
         Flash::success('SimBrief Airframe deleted successfully.');
+
+        return redirect(route('admin.airframes.index'));
+    }
+
+    // Manually trigger update of SimBrief Airframe and Layouts
+    public function updateSimbriefData()
+    {
+
+        Log::debug('Manually Updating SimBrief Support Data');
+        $SimBriefSVC = app(SimBriefService::class);
+        $SimBriefSVC->getAircraftAndAirframes();
+        $SimBriefSVC->GetBriefingLayouts();
+
+        Flash::success('SimBrief Airframe and Layouts updated successfully.');
 
         return redirect(route('admin.airframes.index'));
     }

--- a/app/Http/Controllers/Admin/AirframeController.php
+++ b/app/Http/Controllers/Admin/AirframeController.php
@@ -49,7 +49,6 @@ class AirframeController extends Controller
      */
     public function create(): View
     {
-
         return view('admin.airframes.create', [
             'icao_codes' => Aircraft::whereNotNull('icao')->groupBy('icao')->pluck('icao')->toArray(),
         ]);
@@ -162,7 +161,6 @@ class AirframeController extends Controller
     // Manually trigger update of SimBrief Airframe and Layouts
     public function updateSimbriefData()
     {
-
         Log::debug('Manually Updating SimBrief Support Data');
         $SimBriefSVC = app(SimBriefService::class);
         $SimBriefSVC->getAircraftAndAirframes();

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -12,6 +12,7 @@ use App\Models\Enums\FlightType;
 use App\Models\Fare;
 use App\Models\Flight;
 use App\Models\SimBrief;
+use App\Models\SimBriefLayout;
 use App\Models\User;
 use App\Repositories\FlightRepository;
 use App\Services\FareService;
@@ -102,7 +103,7 @@ class SimBriefController
 
             // Build proper aircraft collection considering all possible settings
             // Flight subfleets, user subfleet restrictions, pirep restrictions, simbrief blocking etc
-            $aircraft = Aircraft::withCount($withCount)->where($where)
+            $aircraft = Aircraft::withCount($withCount)->with(['sbaircraft', 'sbairframes'])->where($where)
                 ->when(setting('simbrief.block_aircraft'), function ($query) {
                     return $query->having('simbriefs_count', 0);
                 })->whereIn('subfleet_id', $subfleet_ids)
@@ -128,7 +129,7 @@ class SimBriefController
         // SimBrief profile does not exists and everything else is ok
         // Select aircraft which will be used for calculations and details
         /** @var Aircraft $aircraft */
-        $aircraft = Aircraft::with(['airline'])->where('id', $aircraft_id)->first();
+        $aircraft = Aircraft::with(['airline', 'sbaircraft', 'sbairframes'])->where('id', $aircraft_id)->first();
 
         // Figure out the proper fares to use for this flight/aircraft
         $all_fares = $this->fareSvc->getFareWithOverrides($aircraft->subfleet->fares, $flight->fares);
@@ -182,6 +183,7 @@ class SimBriefController
 
         $pax_load_sheet = [];
         $tpaxfig = 0;
+        $acd_maxpax = 0;
 
         /** @var Fare $fare */
         foreach ($all_fares as $fare) {
@@ -189,6 +191,7 @@ class SimBriefController
                 continue;
             }
 
+            $acd_maxpax = $acd_maxpax + $fare->capacity;
             $count = floor(($fare->capacity * rand($loadmin, $loadmax)) / 100);
             $tpaxfig += $count;
             $pax_load_sheet[] = [
@@ -203,7 +206,7 @@ class SimBriefController
             $loaddist[] = $fare->code.' '.$count;
         }
 
-        // Calculate total weights
+        // Calculate and convert weights according to SimBrief requirements
         if (setting('units.weight') === 'kg') {
             $tpaxload = round(($pax_weight * $tpaxfig) / 2.205);
             $tbagload = round(($bag_weight * $tpaxfig) / 2.205);
@@ -213,7 +216,6 @@ class SimBriefController
         }
 
         // Load up fares for cargo
-
         $tcargoload = 0;
         $cargo_load_sheet = [];
         foreach ($all_fares as $fare) {
@@ -239,6 +241,23 @@ class SimBriefController
 
         $request->session()->put('simbrief_fares', array_merge($pax_load_sheet, $cargo_load_sheet));
 
+        // Prepare SimBrief layouts, acdata json and actype code
+        $layouts = SimBriefLayout::get();
+
+        $acdata = [
+            // Passenger and Baggage Weights needs to pounds, integer like 185
+            'paxwgt'  => $pax_weight,
+            'bagwgt'  => $bag_weight,
+            // Airframe Weights needs to be thousands of pounds, with 3 digit precision like 85.715
+            'mzfw'    => (filled($aircraft->zfw) && $aircraft->zfw->internal(0) > 0) ? round($aircraft->zfw->internal(0) / 1000, 3) : null,
+            'mtow'    => (filled($aircraft->mtow) && $aircraft->mtow->internal(0) > 0) ? round($aircraft->mtow->internal(0) / 1000, 3) : null,
+            'mlw'     => (filled($aircraft->mlw) && $aircraft->mlw->internal(0) > 0) ? round($aircraft->mlw->internal(0) / 1000, 3) : null,
+            'hexcode' => filled($aircraft->hex_code) ? $aircraft->hex_code : null,
+            'maxpax'  => $acd_maxpax,
+        ];
+
+        $actype = (filled($aircraft->simbrief_type)) ? $aircraft->simbrief_type : ((filled(optional($aircraft->subfleet)->simbrief_type)) ? $aircraft->subfleet->simbrief_type : $aircraft->icao);
+
         // Show the main simbrief form
         return view('flights.simbrief_form', [
             'user'             => $user,
@@ -255,8 +274,13 @@ class SimBriefController
             'tbagload'         => $tbagload,
             'tpayload'         => $tpayload,
             'tcargoload'       => $tcargoload,
-            'loaddist'         => implode(' ', $loaddist),
+            'loaddist'         => implode(' ', $loaddist).' BAG '.$tbagload,
             'static_id'        => $static_id,
+            'sbaircraft'       => filled($aircraft->sbaircraft) ? collect(json_decode($aircraft->sbaircraft->details)) : null,
+            'sbairframes'      => filled($aircraft->sbairframes) ? $aircraft->sbairframes : null,
+            'acdata'           => json_encode($acdata),
+            'actype'           => $actype,
+            'layouts'          => $layouts,
         ]);
     }
 

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -246,8 +246,8 @@ class SimBriefController
 
         $acdata = [
             // Passenger and Baggage Weights needs to pounds, integer like 185
-            'paxwgt'  => $pax_weight,
-            'bagwgt'  => $bag_weight,
+            'paxwgt' => $pax_weight,
+            'bagwgt' => $bag_weight,
             // Airframe Weights needs to be thousands of pounds, with 3 digit precision like 85.715
             'mzfw'    => (filled($aircraft->zfw) && $aircraft->zfw->internal(0) > 0) ? round($aircraft->zfw->internal(0) / 1000, 3) : null,
             'mtow'    => (filled($aircraft->mtow) && $aircraft->mtow->internal(0) > 0) ? round($aircraft->mtow->internal(0) / 1000, 3) : null,

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -257,6 +257,8 @@ class SimBriefController
         ];
 
         $actype = (filled($aircraft->simbrief_type)) ? $aircraft->simbrief_type : ((filled(optional($aircraft->subfleet)->simbrief_type)) ? $aircraft->subfleet->simbrief_type : $aircraft->icao);
+        $sbaircraft = filled($aircraft->sbaircraft) ? collect(json_decode($aircraft->sbaircraft->details)) : null;
+        $sbairframes = (setting('simbrief.use_custom_airframes', false)) ? $aircraft->sbairframes->where('source', 'Custom') : $aircraft->sbairframes;
 
         // Show the main simbrief form
         return view('flights.simbrief_form', [
@@ -276,8 +278,8 @@ class SimBriefController
             'tcargoload'       => $tcargoload,
             'loaddist'         => implode(' ', $loaddist).' BAG '.$tbagload,
             'static_id'        => $static_id,
-            'sbaircraft'       => filled($aircraft->sbaircraft) ? collect(json_decode($aircraft->sbaircraft->details)) : null,
-            'sbairframes'      => filled($aircraft->sbairframes) ? $aircraft->sbairframes : null,
+            'sbaircraft'       => $sbaircraft,
+            'sbairframes'      => filled($sbairframes) ? $sbairframes : null,
             'acdata'           => json_encode($acdata),
             'actype'           => $actype,
             'layouts'          => $layouts,

--- a/app/Http/Controllers/Frontend/SimBriefController.php
+++ b/app/Http/Controllers/Frontend/SimBriefController.php
@@ -7,6 +7,7 @@ use App\Models\Aircraft;
 use App\Models\Bid;
 use App\Models\Enums\AircraftState;
 use App\Models\Enums\AircraftStatus;
+use App\Models\Enums\AirframeSource;
 use App\Models\Enums\FareType;
 use App\Models\Enums\FlightType;
 use App\Models\Fare;
@@ -258,7 +259,7 @@ class SimBriefController
 
         $actype = (filled($aircraft->simbrief_type)) ? $aircraft->simbrief_type : ((filled(optional($aircraft->subfleet)->simbrief_type)) ? $aircraft->subfleet->simbrief_type : $aircraft->icao);
         $sbaircraft = filled($aircraft->sbaircraft) ? collect(json_decode($aircraft->sbaircraft->details)) : null;
-        $sbairframes = (setting('simbrief.use_custom_airframes', false)) ? $aircraft->sbairframes->where('source', 'Custom') : $aircraft->sbairframes;
+        $sbairframes = (setting('simbrief.use_custom_airframes', false)) ? $aircraft->sbairframes->where('source', AirframeSource::INTERNAL) : $aircraft->sbairframes;
 
         // Show the main simbrief form
         return view('flights.simbrief_form', [

--- a/app/Http/Requests/CreateAirframeRequest.php
+++ b/app/Http/Requests/CreateAirframeRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Contracts\FormRequest;
+use App\Models\SimBriefAirframe;
+
+class CreateAirframeRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return SimBriefAirframe::$rules;
+    }
+}

--- a/app/Http/Requests/UpdateAirframeRequest.php
+++ b/app/Http/Requests/UpdateAirframeRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Contracts\FormRequest;
+use App\Models\SimBriefAirframe;
+
+class UpdateAirframeRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return SimBriefAirframe::$rules;
+    }
+}

--- a/app/Http/Resources/Aircraft.php
+++ b/app/Http/Resources/Aircraft.php
@@ -3,8 +3,6 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
-use App\Support\Units\Mass;
-use App\Support\Units\Fuel;
 
 /**
  * @mixin \App\Models\Aircraft

--- a/app/Http/Resources/Aircraft.php
+++ b/app/Http/Resources/Aircraft.php
@@ -3,6 +3,8 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
+use App\Support\Units\Mass;
+use App\Support\Units\Fuel;
 
 /**
  * @mixin \App\Models\Aircraft
@@ -13,6 +15,13 @@ class Aircraft extends Resource
     {
         $res = parent::toArray($request);
         $res['ident'] = $this->ident;
+
+        // Set these to the response units
+        $res['dow'] = $this->dow->getResponseUnits();
+        $res['zfw'] = $this->zfw->getResponseUnits();
+        $res['mtow'] = $this->mtow->getResponseUnits();
+        $res['mlw'] = $this->mlw->getResponseUnits();
+        $res['fuel_onboard'] = $this->fuel_onboard->getResponseUnits();
 
         return $res;
     }

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -47,7 +47,7 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  * @property int      state
  * @property string   simbrief_type
  * @property Carbon   landing_time
- * @property float    fuel_onboard
+ * @property Fuel     fuel_onboard
  * @property Bid      bid
  */
 class Aircraft extends Model

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Models\Casts\FuelCast;
+use App\Models\Casts\MassCast;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Traits\ExpensableTrait;
 use App\Models\Traits\FilesTrait;
@@ -31,10 +32,10 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  * @property string   registration
  * @property string   fin
  * @property int      flight_time
- * @property float    dow
- * @property float    mlw
- * @property float    mtow
- * @property float    zfw
+ * @property Mass     dow
+ * @property Mass     mlw
+ * @property Mass     mtow
+ * @property Mass     zfw
  * @property string   hex_code
  * @property string   selcal
  * @property Airport  airport
@@ -90,12 +91,12 @@ class Aircraft extends Model
     protected $casts = [
         'flight_time'  => 'float',
         'fuel_onboard' => FuelCast::class,
-        'dow'          => 'float',
-        'mlw'          => 'float',
-        'mtow'         => 'float',
+        'dow'          => MassCast::class,
+        'mlw'          => MassCast::class,
+        'mtow'         => MassCast::class,
         'state'        => 'integer',
         'subfleet_id'  => 'integer',
-        'zfw'          => 'float',
+        'zfw'          => MassCast::class,
     ];
 
     /**
@@ -242,5 +243,15 @@ class Aircraft extends Model
     public function subfleet(): BelongsTo
     {
         return $this->belongsTo(Subfleet::class, 'subfleet_id');
+    }
+
+    public function sbaircraft(): HasOne
+    {
+        return $this->hasOne(SimBriefAircraft::class, 'icao', 'icao');
+    }
+
+    public function sbairframes(): HasMany
+    {
+        return $this->hasMany(SimBriefAirframe::class, 'icao', 'icao');
     }
 }

--- a/app/Models/Casts/MassCast.php
+++ b/app/Models/Casts/MassCast.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models\Casts;
+
+use App\Support\Units\Mass;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use PhpUnitsOfMeasure\Exception\NonNumericValue;
+use PhpUnitsOfMeasure\Exception\NonStringUnitName;
+
+class MassCast implements CastsAttributes
+{
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string                              $key
+     * @param mixed                               $value
+     * @param array                               $attributes
+     *
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if ($value instanceof Mass) {
+            return $value;
+        }
+
+        try {
+            return Mass::make($value, config('phpvms.internal_units.mass'));
+        } catch (NonNumericValue $e) {
+        } catch (NonStringUnitName $e) {
+            return $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string                              $key
+     * @param mixed                               $value
+     * @param array                               $attributes
+     *
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value instanceof Mass) {
+            return $value->toUnit(config('phpvms.internal_units.mass'));
+        }
+
+        return $value;
+    }
+}

--- a/app/Models/Enums/AirframeSource.php
+++ b/app/Models/Enums/AirframeSource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models\Enums;
+
+use App\Contracts\Enum;
+
+class AirframeSource extends Enum
+{
+    public const INTERNAL = 0;
+    public const SIMBRIEF = 1;
+
+    public static array $labels = [
+        self::INTERNAL => 'Custom',
+        self::SIMBRIEF => 'SimBrief',
+    ];
+}

--- a/app/Models/SimBriefAircraft.php
+++ b/app/Models/SimBriefAircraft.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class SimBriefAircraft extends Model
+{
+    public $table = 'simbrief_aircraft';
+
+    protected $fillable = [
+        'id',
+        'icao',
+        'name',
+        'details',
+    ];
+
+    protected $casts = [
+        'icao' => 'string',
+        'name' => 'string',
+    ];
+
+    public static array $rules = [
+        'icao'    => 'required|string',
+        'name'    => 'required|string',
+        'details' => 'nullable',
+    ];
+
+    // Relationships
+    public function sbairframes(): HasMany
+    {
+        return $this->hasMany(SimBriefAirframe::class, 'icao', 'icao');
+    }
+}

--- a/app/Models/SimBriefAirframe.php
+++ b/app/Models/SimBriefAirframe.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SimBriefAirframe extends Model
+{
+    public $table = 'simbrief_airframes';
+
+    protected $fillable = [
+        'id',
+        'icao',
+        'name',
+        'airframe_id',
+        'source',
+        'details',
+        'options',
+    ];
+
+    protected $casts = [
+        'icao' => 'string',
+        'name' => 'string',
+    ];
+
+    public static array $rules = [
+        'icao'        => 'required|string',
+        'name'        => 'required|string',
+        'airframe_id' => 'nullable',
+        'source'      => 'nullable',
+        'details'     => 'nullable',
+        'options'     => 'nullable',
+    ];
+
+    // Relationships
+    public function sbaircraft(): BelongsTo
+    {
+        return $this->belongsTo(SimBriefAircraft::class, 'icao', 'icao');
+    }
+}

--- a/app/Models/SimBriefLayout.php
+++ b/app/Models/SimBriefLayout.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use App\Contracts\Model;
+
+class SimBriefLayout extends Model
+{
+    public $table = 'simbrief_layouts';
+
+    protected $fillable = [
+        'id',
+        'name',
+        'name_long',
+    ];
+
+    protected $casts = [
+        'id'        => 'string',
+        'name'      => 'string',
+        'name_long' => 'string',
+    ];
+
+    public static array $rules = [
+        'id'        => 'required|string',
+        'name'      => 'required|string',
+        'name_long' => 'required|string',
+    ];
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -407,6 +407,9 @@ class RouteServiceProvider extends ServiceProvider
                 'delete',
             ], 'typeratings/{id}/users', 'TypeRatingController@users')->middleware('ability:admin,typeratings');
 
+            // SimBrief Airframes
+            Route::resource('airframes', 'AirframeController')->middleware('ability:admin,aircraft,fleet');
+
             // maintenance
             Route::match(['get'], 'maintenance', 'MaintenanceController@index')
                 ->name('maintenance.index')->middleware('ability:admin,maintenance');

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -409,6 +409,7 @@ class RouteServiceProvider extends ServiceProvider
 
             // SimBrief Airframes
             Route::resource('airframes', 'AirframeController')->middleware('ability:admin,aircraft,fleet');
+            Route::get('sbupdate', 'AirframeController@updateSimbriefData')->name('airframes.sbupdate')->middleware('ability:admin,aircraft,fleet');
 
             // maintenance
             Route::match(['get'], 'maintenance', 'MaintenanceController@index')

--- a/app/Repositories/AirframeRepository.php
+++ b/app/Repositories/AirframeRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories;
 
 use App\Contracts\Repository;
+use App\Models\Enums\AirframeSource;
 use App\Models\SimBriefAirframe;
 use Prettus\Repository\Contracts\CacheableInterface;
 use Prettus\Repository\Traits\CacheableRepository;
@@ -28,7 +29,7 @@ class AirframeRepository extends Repository implements CacheableInterface
         $retval = [];
         $where = [];
         if ($only_custom) {
-            $where['source'] = 'Custom';
+            $where['source'] = AirframeSource::INTERNAL;
         }
 
         if (filled($icao)) {

--- a/app/Repositories/AirframeRepository.php
+++ b/app/Repositories/AirframeRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Contracts\Repository;
+use App\Models\SimBriefAirframe;
+use Prettus\Repository\Contracts\CacheableInterface;
+use Prettus\Repository\Traits\CacheableRepository;
+
+class AirframeRepository extends Repository implements CacheableInterface
+{
+    use CacheableRepository;
+
+    protected $fieldSearchable = [
+        'icao'        => 'like',
+        'name'        => 'like',
+        'airframe_id' => 'like',
+        'source'      => 'like',
+    ];
+
+    public function model()
+    {
+        return SimBriefAirframe::class;
+    }
+
+    public function selectBoxList($add_blank = false, $only_custom = false, $icao = null): array
+    {
+        $retval = [];
+        $where = [];
+        if ($only_custom) {
+            $where['source'] = 'Custom';
+        }
+
+        if (filled($icao)) {
+            $where['icao'] = $icao;
+        }
+
+        $items = $this->findWhere($where);
+
+        if ($add_blank) {
+            $retval[''] = '';
+        }
+
+        foreach ($items as $i) {
+            $retval[$i->id] = $i->name;
+        }
+
+        return $retval;
+    }
+}

--- a/app/Services/ImportExport/AircraftImporter.php
+++ b/app/Services/ImportExport/AircraftImporter.php
@@ -9,6 +9,7 @@ use App\Models\Enums\AircraftState;
 use App\Models\Enums\AircraftStatus;
 use App\Models\Subfleet;
 use App\Support\ICAO;
+use App\Support\Units\Mass;
 
 /**
  * Import aircraft
@@ -90,12 +91,13 @@ class AircraftImporter extends ImportExport
         // Check fields and set to null if they are blank
         // Somehow they got empty strings instead of null without this!
         $row['fin'] = blank($row['fin']) ? null : $row['fin'];
-        $row['dow'] = blank($row['dow']) ? null : $row['dow'];
-        $row['zfw'] = blank($row['zfw']) ? null : $row['zfw'];
-        $row['mtow'] = blank($row['mtow']) ? null : $row['mtow'];
-        $row['mlw'] = blank($row['mlw']) ? null : $row['mlw'];
         $row['selcal'] = blank($row['selcal']) ? null : $row['selcal'];
         $row['simbrief_type'] = blank($row['simbrief_type']) ? null : $row['simbrief_type'];
+        // Set the correct mass units
+        $row['dow'] = $this->CorrectMassUnit($row['dow']);
+        $row['zfw'] = $this->CorrectMassUnit($row['zfw']);
+        $row['mtow'] = $this->CorrectMassUnit($row['mtow']);
+        $row['mlw'] = $this->CorrectMassUnit($row['mlw']);
 
         // Try to add or update
         try {
@@ -109,5 +111,14 @@ class AircraftImporter extends ImportExport
 
         $this->log('Imported '.$row['registration'].' '.$row['name']);
         return true;
+    }
+
+    public function CorrectMassUnit($value)
+    {
+        if ($value > 0) {
+            return Mass::make((float) $value, setting('units.weight'));
+        }
+
+        return null;
     }
 }

--- a/app/Services/SimBriefService.php
+++ b/app/Services/SimBriefService.php
@@ -248,7 +248,7 @@ class SimBriefService extends Service
                     ], [
                         'icao'        => $af['airframe_icao'],
                         'name'        => $af['airframe_comments'],
-                        'airframe_id' => ($af['airframe_id'] != false) ? $af['airframe_id'] : null,
+                        'airframe_id' => ($af['airframe_id'] != false) ? $af['pilot_id'].'_'.$af['airframe_id'] : null,
                         'source'      => 'SimBrief',
                         'details'     => json_encode($af),
                         'options'     => json_encode($af['airframe_options']),

--- a/app/Services/SimBriefService.php
+++ b/app/Services/SimBriefService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Contracts\Service;
 use App\Models\Acars;
 use App\Models\Enums\AcarsType;
+use App\Models\Enums\AirframeSource;
 use App\Models\Pirep;
 use App\Models\SimBrief;
 use App\Models\SimBriefAircraft;
@@ -249,7 +250,7 @@ class SimBriefService extends Service
                         'icao'        => $af['airframe_icao'],
                         'name'        => $af['airframe_comments'],
                         'airframe_id' => ($af['airframe_id'] != false) ? $af['pilot_id'].'_'.$af['airframe_id'] : null,
-                        'source'      => 'SimBrief',
+                        'source'      => AirframeSource::SIMBRIEF,
                         'details'     => json_encode($af),
                         'options'     => json_encode($af['airframe_options']),
                     ]);

--- a/app/Services/SimBriefService.php
+++ b/app/Services/SimBriefService.php
@@ -7,10 +7,14 @@ use App\Models\Acars;
 use App\Models\Enums\AcarsType;
 use App\Models\Pirep;
 use App\Models\SimBrief;
+use App\Models\SimBriefAircraft;
+use App\Models\SimBriefAirframe;
+use App\Models\SimBriefLayout;
 use App\Models\SimBriefXML;
 use Carbon\Carbon;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class SimBriefService extends Service
@@ -216,6 +220,83 @@ class SimBriefService extends Service
             $brief->delete();
 
             // TODO: Delete any assets (Which assets ?)
+        }
+    }
+
+    /**
+     * Get Aircraft and Airframe Data from SimBrief
+     * Insert or Update relevant models, for proper and detailed flight planning
+     */
+    public function getAircraftAndAirframes()
+    {
+        $url = config('phpvms.simbrief_airframes_url');
+        $sbdata = Http::get($url);
+
+        if ($sbdata->ok()) {
+            Log::debug('SimBrief | Aircraft and Airframe data obtained');
+            $json = $sbdata->json();
+
+            // Update Or Create Aircraft Entries
+            foreach ($json as $ac) {
+                Log::debug('SimBrief | Importing Aircraft : '.$ac['aircraft_icao'].' '.$ac['aircraft_name']);
+
+                foreach ($ac['airframes'] as $af) {
+                    Log::debug('SimBrief | Importing Airframe : '.$af['airframe_name'].' '.$af['airframe_comments']);
+                    SimBriefAirframe::updateOrCreate([
+                        'icao' => $af['airframe_icao'],
+                        'name' => $af['airframe_comments'],
+                    ], [
+                        'icao'        => $af['airframe_icao'],
+                        'name'        => $af['airframe_comments'],
+                        'airframe_id' => ($af['airframe_id'] != false) ? $af['airframe_id'] : null,
+                        'source'      => 'SimBrief',
+                        'details'     => json_encode($af),
+                        'options'     => json_encode($af['airframe_options'])
+                    ]);
+                }
+
+                unset($ac['airframes']);
+
+                SimBriefAircraft::updateOrCreate([
+                    'icao' => $ac['aircraft_icao'],
+                ], [
+                    'icao'    => $ac['aircraft_icao'],
+                    'name'    => $ac['aircraft_name'],
+                    'details' => json_encode($ac),
+                ]);
+            }
+        } else {
+            Log::error('SimBrief | An Error Occured while trying to get aircraft and airframe data!');
+        }
+    }
+
+    /**
+     * Get OFP Layouts from SimBrief
+     * Insert or Update relevant model for proper flight planning
+     */
+    public function GetBriefingLayouts()
+    {
+        $url = config('phpvms.simbrief_layouts_url');
+        $sbdata = Http::get($url);
+
+        if ($sbdata->ok()) {
+            Log::debug('SimBrief | OFP Layouts data obtained');
+            $json = $sbdata->json();
+
+            // Update Or Create Layout Entries
+            foreach ($json['layouts'] as $sb) {
+                Log::debug('SimBrief | Importing Layout : '.$sb['name_long']);
+
+                SimBriefLayout::updateOrCreate([
+                    'id' => $sb['id'],
+                ], [
+                    'id'        => $sb['id'],
+                    'name'      => $sb['name_short'],
+                    'name_long' => $sb['name_long'],
+                ]);
+            }
+        } else {
+            Log::error('SimBrief | An Error Occured while trying to get layout data!');
         }
     }
 }

--- a/app/Services/SimBriefService.php
+++ b/app/Services/SimBriefService.php
@@ -251,7 +251,7 @@ class SimBriefService extends Service
                         'airframe_id' => ($af['airframe_id'] != false) ? $af['airframe_id'] : null,
                         'source'      => 'SimBrief',
                         'details'     => json_encode($af),
-                        'options'     => json_encode($af['airframe_options'])
+                        'options'     => json_encode($af['airframe_options']),
                     ]);
                 }
 

--- a/config/phpvms.php
+++ b/config/phpvms.php
@@ -58,6 +58,16 @@ return [
     'simbrief_update_url' => 'https://www.simbrief.com/api/xml.fetcher.php?userid={sb_user_id}&static_id={sb_static_id}',
 
     /*
+     * URL for fetching Simbrief aircraft and airframe data
+     */
+    'simbrief_airframes_url' => 'http://www.simbrief.com/api/inputs.airframes.json',
+
+    /*
+     * URL for fetching Simbrief layouts data
+     */
+    'simbrief_layouts_url' => 'http://www.simbrief.com/api/inputs.list.json',
+
+    /*
      * Your vaCentral API key
      */
     'vacentral_api_key' => env('VACENTRAL_API_KEY', ''),

--- a/resources/views/admin/aircraft/fields.blade.php
+++ b/resources/views/admin/aircraft/fields.blade.php
@@ -84,6 +84,11 @@
             {{ Form::text('simbrief_type', null, ['class' => 'form-control']) }}
             <p class="text-danger">{{ $errors->first('simbrief_type') }}</p>
           </div>
+          <div class="form-group col-sm-3">
+            {{ Form::label('hex_code', 'Hex Code:') }}
+            {{ Form::text('hex_code', null, ['class' => 'form-control']) }}
+            <p class="text-danger">{{ $errors->first('hex_code') }}</p>
+          </div>
         </div>
       </div>
     </div>
@@ -93,28 +98,44 @@
 <div class="row">
   <div class="col-12">
     <div class="form-container">
-      <h6><i class="fas fa-plane"></i>&nbsp;Certified Weights</h6>
+      <h6><i class="fas fa-plane"></i>&nbsp;Certified Weights ({{ setting('units.weight') }})</h6>
       <div class="form-container-body">
         <div class="row">
           <div class="form-group col-sm-3">
             {{ Form::label('dow', 'Dry Operating Weight (DOW/OEW):') }}
-            {{ Form::number('dow', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('dow') }}</p>
+            <div class="row">
+              <div class="col-sm-12">
+                <input class="form-control" type="number" name="dow" value="{{ $aircraft->dow->local(0) ?? null }}" step="1" />
+                <p class="text-danger">{{ $errors->first('dow') }}</p>
+              </div>
+            </div>
           </div>
           <div class="form-group col-sm-3">
             {{ Form::label('zfw', 'Max Zero Fuel Weight (MZFW):') }}
-            {{ Form::number('zfw', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('zfw') }}</p>
+            <div class="row">
+              <div class="col-sm-12">
+                <input class="form-control" type="number" name="zfw" value="{{ $aircraft->zfw->local(0) ?? null }}" step="1" />
+                <p class="text-danger">{{ $errors->first('zfw') }}</p>
+              </div>
+            </div>            
           </div>
           <div class="form-group col-sm-3">
             {{ Form::label('mtow', 'Max Takeoff Weight (MTOW):') }}
-            {{ Form::number('mtow', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('mtow') }}</p>
+            <div class="row">
+              <div class="col-sm-12">
+                <input class="form-control" type="number" name="mtow" value="{{ $aircraft->mtow->local(0) ?? null }}" step="1" />
+                <p class="text-danger">{{ $errors->first('mtow') }}</p>
+              </div>
+            </div> 
           </div>
           <div class="form-group col-sm-3">
             {{ Form::label('mlw', 'Max Landing Weight (MLW):') }}
-            {{ Form::number('mlw', null, ['class' => 'form-control']) }}
-            <p class="text-danger">{{ $errors->first('mlw') }}</p>
+            <div class="row">
+              <div class="col-sm-12">
+                <input class="form-control" type="number" name="mlw" value="{{ $aircraft->mlw->local(0) ?? null }}" step="1" />
+                <p class="text-danger">{{ $errors->first('mlw') }}</p>
+              </div>
+            </div> 
           </div>
         </div>
       </div>

--- a/resources/views/admin/airframes/create.blade.php
+++ b/resources/views/admin/airframes/create.blade.php
@@ -1,0 +1,11 @@
+@extends('admin.app')
+@section('title', 'Add SimBrief Airframe')
+@section('content')
+  <div class="card border-blue-bottom">
+    <div class="content">
+      {{ Form::open(['route' => 'admin.airframes.store', 'class' => 'add_airframe', 'method'=>'POST', 'autocomplete' => false]) }}
+      @include('admin.airframes.fields')
+      {{ Form::close() }}
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/airframes/edit.blade.php
+++ b/resources/views/admin/airframes/edit.blade.php
@@ -1,0 +1,11 @@
+@extends('admin.app')
+@section('title', 'Edit '.$airframe->name)
+@section('content')
+  <div class="card border-blue-bottom">
+    <div class="content">
+      {{ Form::model($airframe, ['route' => ['admin.airframes.update', $airframe->id], 'method' => 'patch', 'autocomplete' => false]) }}
+      @include('admin.airframes.fields')
+      {{ Form::close() }}
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/airframes/fields.blade.php
+++ b/resources/views/admin/airframes/fields.blade.php
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="form-group col-sm-4">
+    {{ Form::label('icao', 'ICAO:') }}
+    {{ Form::text('icao', null, ['class' => 'form-control']) }}
+    <p class="text-danger">{{ $errors->first('icao') }}</p>
+  </div>
+  <div class="form-group col-sm-4">
+    {{ Form::label('name', 'Name:') }}
+    {{ Form::text('name', null, ['class' => 'form-control']) }}
+    <p class="text-danger">{{ $errors->first('name') }}</p>
+  </div>
+  <div class="form-group col-sm-4">
+    {{ Form::label('airframe_id', 'SB Airframe ID:') }}
+    {{ Form::text('airframe_id', null, ['class' => 'form-control']) }}
+    <p class="text-danger">{{ $errors->first('airframe_id') }}</p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm-12">
+    <div class="text-right">
+      {{ Form::hidden('source', 'Custom') }}
+      {{ Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) }}
+    </div>
+  </div>
+</div>

--- a/resources/views/admin/airframes/fields.blade.php
+++ b/resources/views/admin/airframes/fields.blade.php
@@ -18,7 +18,7 @@
 <div class="row">
   <div class="col-sm-12">
     <div class="text-right">
-      {{ Form::hidden('source', 'Custom') }}
+      {{ Form::hidden('source', \App\Models\Enums\AirframeSource::INTERNAL) }}
       {{ Form::button('Save', ['type' => 'submit', 'class' => 'btn btn-success']) }}
     </div>
   </div>

--- a/resources/views/admin/airframes/index.blade.php
+++ b/resources/views/admin/airframes/index.blade.php
@@ -1,0 +1,18 @@
+@extends('admin.app')
+@section('title', 'SimBrief Airframes')
+@section('actions')
+  <li>
+    <a href="{{ route('admin.airframes.create') }}">
+      <i class="ti-plus"></i>
+      Add New
+    </a>
+  </li>
+@endsection
+
+@section('content')
+  <div class="card border-blue-bottom">
+    <div class="content">
+      @include('admin.airframes.table')
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/airframes/index.blade.php
+++ b/resources/views/admin/airframes/index.blade.php
@@ -4,7 +4,14 @@
   <li>
     <a href="{{ route('admin.airframes.create') }}">
       <i class="ti-plus"></i>
-      Add New
+      Add New Airframe
+    </a>
+  </li>
+  &nbsp;
+  <li>
+    <a href="{{ route('admin.airframes.sbupdate') }}">
+      <i class="ti-plus"></i>
+      Update SimBrief Airframes & Layouts
     </a>
   </li>
 @endsection

--- a/resources/views/admin/airframes/show.blade.php
+++ b/resources/views/admin/airframes/show.blade.php
@@ -1,0 +1,17 @@
+@extends('admin.app')
+
+@section('content')
+  <section class="content-header">
+    <h1>{{ $airframe->name }}</h1>
+  </section>
+  <div class="content">
+    <div class="box box-primary">
+      <div class="box-body">
+        <div class="row" style="padding-left: 20px">
+          @include('admin.airframes.show_fields')
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection
+

--- a/resources/views/admin/airframes/show_fields.blade.php
+++ b/resources/views/admin/airframes/show_fields.blade.php
@@ -1,0 +1,36 @@
+<!-- Id Field -->
+<div class="form-group">
+  {{ Form::label('id', 'Id:') }}
+  <p>{{ $airframe->id }}</p>
+</div>
+
+<!-- Type Code Field -->
+<div class="form-group">
+  {{ Form::label('type', 'ICAO Code:') }}
+  <p>{{ $airframe->icao }}</p>
+</div>
+
+<!-- Name Field -->
+<div class="form-group">
+  {{ Form::label('name', 'Name:') }}
+  <p>{{ $airframe->name }}</p>
+</div>
+
+<!-- Description Field -->
+<div class="form-group">
+  {{ Form::label('airframe_id', 'SB Airframe ID:') }}
+  <p>{{ $airframe->airframe_id }}</p>
+</div>
+
+<!-- Created At Field -->
+<div class="form-group">
+  {{ Form::label('created_at', 'Created At:') }}
+  <p>{{ show_datetime($airframe->created_at) }}</p>
+</div>
+
+<!-- Updated At Field -->
+<div class="form-group">
+  {{ Form::label('updated_at', 'Updated At:') }}
+  <p>{{ show_datetime($airframe->updated_at) }}</p>
+</div>
+

--- a/resources/views/admin/airframes/table.blade.php
+++ b/resources/views/admin/airframes/table.blade.php
@@ -1,0 +1,30 @@
+<div id="airframes_table_wrapper">
+  <table class="table table-hover table-responsive">
+    <thead>
+      <th>ICAO</th>
+      <th>Name</th>
+      <th>SB Airframe ID</th>
+      <th>Created At</th>
+      <th>Updated At</th>
+      <th></th>
+    </thead>
+    <tbody>
+      @foreach($airframes as $af)
+        <tr>
+          <td>{{ $af->icao }}</a></td>
+          <td>{{ $af->name }}</td>
+          <td>{{ $af->airframe_id }}</td>
+          <td>{{ $af->created_at->format('d.M.y H:i') }}</td>
+          <td>{{ $af->updated_at->format('d.M.y H:i') }}</td>
+          <td class="text-right">
+            {{ Form::open(['route' => ['admin.airframes.destroy', $af->id], 'method' => 'delete']) }}
+            <a href="{{ route('admin.airframes.edit', [$af->id]) }}" class='btn btn-sm btn-success btn-icon'>
+              <i class="fas fa-pencil-alt"></i></a>
+            {{ Form::button('<i class="fa fa-times"></i>', ['type' => 'submit', 'class' => 'btn btn-sm btn-danger btn-icon', 'onclick' => "return confirm('Are you sure?')"]) }}
+            {{ Form::close() }}
+          </td>
+        </tr>
+      @endforeach
+    </tbody>
+  </table>
+</div>

--- a/resources/views/admin/menu.blade.php
+++ b/resources/views/admin/menu.blade.php
@@ -50,6 +50,10 @@
       <li><a href="{{ url('/admin/airlines') }}"><i class="pe-7s-paper-plane"></i>airlines</a></li>
       @endability
 
+      @ability('admin', 'aircraft', 'fleet')
+      <li><a href="{{ url('/admin/airframes') }}"><i class="pe-7s-plane"></i>sb airframes</a></li>
+      @endability
+
       @ability('admin', 'airports')
       <li><a href="{{ url('/admin/airports') }}"><i class="pe-7s-map-marker"></i>airports</a></li>
       @endability

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -27,7 +27,7 @@
                       <div class="col-sm-6">
                         <label for="airframes">SimBrief Airframes</label>
                         <select name="airframes" id="sbairframe" class="form-control" onchange="CheckAirframe()">
-                          @foreach($aircraft->sbairframes as $af)
+                          @foreach($sbairframes as $af)
                             <option value="{{ $af->airframe_id }}">{{ $af->name }}</option>
                           @endforeach
                         </select>
@@ -163,7 +163,7 @@
                 </div>
               </div>
               {{-- Prepare Form Fields For SimBrief --}}
-              <input class="form-control" type="hidden" name="acdata" id="acdata" value="{{ $acdata }}">
+              <input type="hidden" name="acdata" id="acdata" value="{{ $acdata }}">
               @if($tpaxfig)
                 <input type="hidden" name="pax" value="{{ $tpaxfig }}">
               @elseif(!$tpaxfig && $tcargoload)
@@ -476,6 +476,7 @@
   // Change Aircraft Type According to Airframe selection
   // And remove pax and baggage weights from acdata
   function CheckAirframe() {
+    let weight = Boolean({{ setting('simbrief.use_standard_weights', false) }})
     let actype = String("{{ $actype }}");
     let acdata = String("{{ $acdata }}");
     acOrig = JSON.parse(acdata.replace(/&quot;/g,'"'));
@@ -483,12 +484,16 @@
     let airframe = document.getElementById("sbairframe").value;
     if (airframe != "") {
       document.getElementById("actype").value = airframe
-      delete acJson.paxwgt
-      delete acJson.bagwgt
-      document.getElementById("acdata").value = JSON.stringify(acJson)
+      if (!weight) {
+        delete acJson.paxwgt
+        delete acJson.bagwgt
+        document.getElementById("acdata").value = JSON.stringify(acJson)
+      }
     } else {
       document.getElementById("actype").value = actype
-      document.getElementById("acdata").value = JSON.stringify(acOrig)
+      if (!weight) {
+        document.getElementById("acdata").value = JSON.stringify(acOrig)
+      }
     }
   }
 </script>

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -2,39 +2,66 @@
 @section('title', 'SimBrief Flight Planning')
 
 @section('content')
-
   <form id="sbapiform">
     <div class="row">
-      <h2>Create Simbrief Briefing</h2>
+      <h2>Create Simbrief Flight Plan & Briefing Package</h2>
       <div class="card">
         <div class="col-md-12">
           <div class="row">
             <div class="col-8">
               <div class="form-container">
-
                 <div class="form-container-body">
                   <h6><i class="fas fa-info-circle"></i>&nbsp;Aircraft Details</h6>
                   <div class="row">
-                    <div class="col-sm-4">
+                    <div class="col-sm-3">
                       <label for="type">Type</label>
                       <input type="text" class="form-control" value="{{ $aircraft->icao }}" maxlength="4" disabled>
-                      @if(filled($aircraft->simbrief_type))
-                        <input type="hidden" name="type" value="{{ $aircraft->simbrief_type }}">
-                      @elseif(filled($aircraft->subfleet->simbrief_type))
-                        <input type="hidden" name="type" value="{{ $aircraft->subfleet->simbrief_type }}">
-                      @else
-                        <input type="hidden" name="type" value="{{ $aircraft->icao }}">
-                      @endif
+                      <input type="hidden" id="actype" name="type" value="{{ $actype }}">
                     </div>
-                    <div class="col-sm-4">
+                    <div class="col-sm-3">
                       <label for="reg">Registration</label>
                       <input type="text" class="form-control" value="{{ $aircraft->registration }}" maxlength="6" disabled>
                       <input type="hidden" name="reg" value="{{ $aircraft->registration }}">
                     </div>
+                    @if($sbairframes)
+                      <div class="col-sm-6">
+                        <label for="airframes">SimBrief Airframes</label>
+                        <select name="airframes" id="sbairframe" class="form-control" onchange="CheckAirframe()">
+                          @foreach($aircraft->sbairframes as $af)
+                            <option value="{{ $af->airframe_id }}">{{ $af->name }}</option>
+                          @endforeach
+                        </select>
+                      </div>
+                    @endif
                   </div>
                   <br>
+                  <div class="row">
+                    <div class="col-sm-2">
+                      <label for="MZFW">Max.ZFW</label>
+                      <input id="mzfw" type="text" class="form-control" value="{{ $aircraft->zfw }}" disabled>
+                    </div>
+                    <div class="col-sm-2">
+                      <label for="MTOW">Max.TOW</label>
+                      <input id="mtow" type="text" class="form-control" value="{{ $aircraft->mtow }}" disabled>
+                    </div>
+                    <div class="col-sm-2">
+                      <label for="MLW">Max.LW</label>
+                      <input id="mlw" type="text" class="form-control" value="{{ $aircraft->mlw }}" disabled>
+                    </div>
+                    <div class="col-sm-2">
+                      <label for="selcal">Selcal</label>
+                      <input type="text" name="selcal" class="form-control" value="{{ strtoupper($aircraft->selcal) }}" maxlenght="4" readonly>
+                    </div>
+                    <div class="col-sm-2">
+                      <label for="fin">FIN</label>
+                      <input type="text" name="fin" class="form-control" value="{{ $aircraft->fin }}" maxlenght="4" readonly>
+                    </div>
+                    <div class="col-sm-2">
+                      <label for="hexcode">HEX</label>
+                      <input type="text" name="hexcode" class="form-control" value="{{ strtoupper($aircraft->hex_code) }}" maxlenght="4" disabled>
+                    </div>
+                  </div>
                 </div>
-
                 <div class="form-container-body">
                   <h6><i class="fas fa-info-circle"></i>&nbsp;@lang('pireps.flightinformations') For
                   <b>{{ $flight->airline->code }}{{ $flight->flight_number }} ({{ \App\Models\Enums\FlightType::label($flight->flight_type) }})</b></h6>
@@ -84,9 +111,8 @@
                   </div>
                   <br>
                 </div>
-
                 <div class="form-container-body">
-                  <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Load Information For
+                  <h6><i class="fas fa-info-circle"></i>&nbsp;Configuration And Estimated Load Information For
                   <b>{{ $aircraft->registration }} ({{ $aircraft->subfleet->name }})</b></h6>
                   <div class="row">
                     @foreach($pax_load_sheet as $fare)
@@ -98,7 +124,7 @@
                     {{-- Generate Load Figures For Cargo Fares --}}
                     @foreach($cargo_load_sheet as $fare)
                       <div class="col-sm-3">
-                        <label for="LoadFare{{ $fare['id'] }}">{{ $fare['name'] }} [Max: {{ number_format($fare['capacity'] - $tbagload) }} {{ setting('units.weight') }}]</label>
+                        <label for="LoadFare{{ $fare['id'] }}">{{ $fare['name'] }} [Max Poss: {{ number_format($fare['capacity'] - $tbagload) }} {{ setting('units.weight') }}]</label>
                         <input id="LoadFare{{ $fare['id'] }}" type="text" class="form-control" value="{{ number_format($fare['count']) }}" disabled>
                       </div>
                     @endforeach
@@ -108,22 +134,27 @@
                     <br>
                     <div class="row">
                       @if($tpaxload)
-                        <div class="col-sm-3">
+                        <div class="col-sm-2">
                           <label for="tdPaxLoad">Pax Weight</label>
                           <input id="tdPaxLoad" type="text" class="form-control" value="{{ number_format($tpaxload) }} {{ setting('units.weight') }}" disabled>
                         </div>
-                        <div class="col-sm-3">
+                        <div class="col-sm-2">
                           <label for="tBagLoad">Baggage Weight</label>
                           <input id="tBagLoad" type="text" class="form-control" value="{{ number_format($tbagload) }} {{ setting('units.weight') }}" disabled>
                         </div>
                       @endif
                       @if($tpaxload && $tcargoload)
-                        <div class="col-sm-3">
+                        <div class="col-sm-2">
                           <label for="tCargoload">Cargo Weight</label>
                           <input id="tCargoload" type="text" class="form-control" value="{{ number_format($tcargoload) }} {{ setting('units.weight') }}" disabled>
                         </div>
+                        <div class="col-sm-2">
+                          <label for="tLoadWeight">Bagg + Cargo</label>
+                          <input id="tLoadWeight" type="text" class="form-control" value="{{ number_format($tcargoload + $tbagload) }} {{ setting('units.weight') }}" disabled>
+                        </div>
                       @endif
-                      <div class="col-sm-3">
+                      <div class="col-sm-2"></div>
+                      <div class="col-sm-2">
                         <label for="tPayload">Total Payload</label>
                         <input id="tPayload" type="text" class="form-control" value="{{ number_format($tpayload) }} {{ setting('units.weight') }}" disabled>
                       </div>
@@ -131,17 +162,16 @@
                   @endif
                 </div>
               </div>
-
               {{-- Prepare Form Fields For SimBrief --}}
-                <input type="hidden" name="acdata" value="{'paxwgt':{{ round($pax_weight) }}, 'bagwgt': {{ round($bag_weight) }}}">
-                @if($tpaxfig)
-                  <input type="hidden" name="pax" value="{{ $tpaxfig }}">
-                @elseif(!$tpaxfig && $tcargoload)
-                  <input type="hidden" name="pax" value="0">
-                @endif
-                @if($tcargoload)
-                  <input type='hidden' name='cargo' value="{{ number_format(($tcargoload / 1000),1) }}">
-                @endif
+              <input class="form-control" type="hidden" name="acdata" id="acdata" value="{{ $acdata }}">
+              @if($tpaxfig)
+                <input type="hidden" name="pax" value="{{ $tpaxfig }}">
+              @elseif(!$tpaxfig && $tcargoload)
+                <input type="hidden" name="pax" value="0">
+              @endif
+              @if($tcargoload)
+                <input type='hidden' name='cargo' value="{{ number_format(($tcargoload / 1000),1) }}">
+              @endif
               @if(isset($tpayload) && $tpayload > 0)
                 <input type="hidden" name="manualrmk" value="Load Distribution {{ $loaddist }}">
               @endif
@@ -155,12 +185,6 @@
               <input type="hidden" id="date" name="date" maxlength="9">
               <input type="hidden" id="deph" name="deph" maxlength="2">
               <input type="hidden" id="depm" name="depm" maxlength="2">
-              <input type="hidden" name="selcal" value="{{ $aircraft->selcal ?? 'FK-NS'}}">
-              <input type="hidden" name="planformat" value="lido">
-              <input type="hidden" name="omit_sids" value="0">
-              <input type="hidden" name="omit_stars" value="0">
-              <input type="hidden" name="cruise" value="CI">
-              <input type="hidden" name="civalue" value="AUTO">
               <input type="hidden" name="static_id" value="{{ $static_id }}">
               {{-- For more info about form fields and their details check SimBrief Forum / API Support --}}
             </div>
@@ -189,6 +213,58 @@
                         @endif
                       </td>
                     </tr>
+                    @if($sbaircraft)
+                      <tr>
+                        <td>Climb Profile:</td>
+                        <td>
+                          <select name="climb" id="climb_profile" class="form-control">
+                            @foreach($sbaircraft['aircraft_profiles_climb'] as $cl)
+                              <option value="{{ $cl }}">{{ $cl }}</option>
+                            @endforeach
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Cruise Profile:</td>
+                        <td>
+                          <select name="cruise" id="cruise_profile" class="form-control" onchange="CheckCruiseProfile()">
+                              <option value="" selected>Please select profile...</option>
+                            @foreach($sbaircraft['aircraft_profiles_cruise'] as $cr)
+                              <option value="{{ $cr }}">{{ $cr }}</option>
+                            @endforeach
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Cost Index:</td>
+                        <td><input type="number" name="civalue" id="civalue" value="AUTO" min="0" max="{{ $sbac['aircraft_max_costindex'] ?? 999 }}" placeholder="AUTO" class="form-control" disabled></td>
+                      </tr>
+                      <tr>
+                        <td>Descent Profile:</td>
+                        <td>
+                          <select name="descent" id="descent_profile" class="form-control">
+                            @foreach($sbaircraft['aircraft_profiles_descent'] as $de)
+                              <option value="{{ $de }}">{{ $de }}</option>
+                            @endforeach
+                          </select>
+                        </td>
+                      </tr>
+                    @else
+                      <tr>
+                        <td>Cruise Profile:</td>
+                        <td>
+                          <select name="cruise" id="cruise_profile" class="form-control" onchange="CheckCruiseProfile()">
+                              <option value="" selected>None</option>
+                              <option value="CI">CI</option>
+                              <option value="LRC">LRC</option>
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Cost Index:</td>
+                        <td><input type="number" name="civalue" id="civalue" value="AUTO" min="0" max="999" placeholder="AUTO" class="form-control" disabled></td>
+                      </tr>
+                    @endif
                     <tr>
                       <td>Cont Fuel:</td>
                       <td>
@@ -238,6 +314,24 @@
                       </td>
                     </tr>
                     <tr>
+                      <td>Use SIDs:</td>
+                      <td>
+                        <select name="omit_sids" class="form-control">
+                          <option value="0" selected>Enable</option>
+                          <option value="1">Disabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Use STARs:</td>
+                      <td>
+                        <select name="omit_stars" class="form-control">
+                          <option value="0" selected>Enable</option>
+                          <option value="1">Disabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
                       <td>Plan Stepclimbs:</td>
                       <td>
                         <select id="stepclimbs" name="stepclimbs" class="form-control" onchange="DisableFL()">
@@ -249,9 +343,32 @@
                     <tr>
                       <td>ETOPS Planning:</td>
                       <td>
-                        <select name="etops" class="form-control">
+                        <select name="etops" id="etops" class="form-control" onchange="CheckEtops()">
                           <option value="0" selected>Disabled</option>
                           <option value="1">Enabled</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>ETOPS Threshold Time:</td>
+                      <td>
+                        <select name="etopsthreshold" id="etopstime" class="form-control" disabled>
+                          <option value="60" selected>60</option>
+                          <option value="90">90</option>
+                          <option value="120">120</option>
+                          <option value="180">180</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>ETOPS Rule Time:</td>
+                      <td>
+                        <select name="etopsthreshold" id="etopsrule" class="form-control" disabled>
+                          <option value="60">60</option>
+                          <option value="90" selected>90</option>
+                          <option value="120">120</option>
+                          <option value="180">180</option>
+                          <option value="240">240</option>
                         </select>
                       </td>
                     </tr>
@@ -275,10 +392,22 @@
                         </select>
                       </td>
                     </tr>
+                    @if($layouts)
+                      <tr>
+                        <td>OFP Layout:</td>
+                        <td>
+                          <select name="planformat" class="form-control">
+                            @foreach($layouts as $ofp)
+                              <option value="{{ $ofp->id }}" @if(strtoupper($ofp->id) == $flight->airline->icao) selected @elseif($ofp->id === 'lido') selected @endif>{{ $ofp->name_long }}</option>
+                            @endforeach
+                          </select>
+                        </td>
+                      </tr>
+                    @endif
                     <tr>
                       <td>Detailed Navlog:</td>
                       <td>
-                        <select name="navlog" class="form-control">
+                        <select name="navlog" class="form-control" readonly>
                           <option value="0">Disabled</option>
                           <option value="1" selected>Enabled</option>
                         </select>
@@ -344,7 +473,50 @@
 @section('scripts')
 <script src="{{public_asset('/assets/global/js/simbrief.apiv1.js')}}"></script>
 <script type="text/javascript">
-  // ******
+  // Change Aircraft Type According to Airframe selection
+  // And remove pax and baggage weights from acdata
+  function CheckAirframe() {
+    let actype = String("{{ $actype }}");
+    let acdata = String("{{ $acdata }}");
+    acOrig = JSON.parse(acdata.replace(/&quot;/g,'"'));
+    acJson = JSON.parse(acdata.replace(/&quot;/g,'"'));
+    let airframe = document.getElementById("sbairframe").value;
+    if (airframe != "") {
+      document.getElementById("actype").value = airframe
+      delete acJson.paxwgt
+      delete acJson.bagwgt
+      document.getElementById("acdata").value = JSON.stringify(acJson)
+    } else {
+      document.getElementById("actype").value = actype
+      document.getElementById("acdata").value = JSON.stringify(acOrig)
+    }
+  }
+</script>
+<script type="text/javascript">
+  // Disable Cost Index value entry if CI not possible or selected
+  function CheckCruiseProfile() {
+    let profile = document.getElementById("cruise_profile").value;
+    if (profile === "CI") {
+      document.getElementById("civalue").disabled = false
+    } else {
+      document.getElementById("civalue").disabled = true
+    }
+  }
+</script>
+<script type="text/javascript">
+  // Disable ETOPS Threshold and Rule Time Fields if ETOPS is not used
+  function CheckEtops() {
+    let etops = document.getElementById("etops").value;
+    if (etops == 0) {
+      document.getElementById("etopstime").disabled = true
+      document.getElementById("etopsrule").disabled = true
+    } else {
+      document.getElementById("etopstime").disabled = false
+      document.getElementById("etopsrule").disabled = false
+    }
+  }
+</script>
+<script type="text/javascript">
   // Disable Submitting a fixed flight level for Stepclimb option to work
   // Script is related to Plan Step Climbs selection
   function DisableFL() {
@@ -359,7 +531,6 @@
   }
 </script>
 <script type="text/javascript">
-  // ******
   // Get current UTC time, add 45 minutes to it and format according to Simbrief API
   // Script also rounds the minutes to nearest 5 to avoid a Departure time like 1538 ;)
   // If you need to reduce the margin of 45 mins, change value below
@@ -387,7 +558,6 @@
   document.getElementById("depm").setAttribute('value', depm); // Sent to SimBrief
 </script>
 <script type="text/javascript">
-  // ******
   // Calculate the Scheduled Enroute Time for Simbrief API
   // Your PHPVMS flight_time value must be from BLOCK to BLOCK
   // Including departure and arrival taxi times

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -39,15 +39,15 @@
                   <div class="row">
                     <div class="col-sm-2">
                       <label for="MZFW">Max.ZFW</label>
-                      <input id="mzfw" type="text" class="form-control" value="{{ $aircraft->zfw }}" disabled>
+                      <input id="mzfw" type="text" class="form-control" value="{{ $aircraft->zfw->local(0) }}" disabled>
                     </div>
                     <div class="col-sm-2">
                       <label for="MTOW">Max.TOW</label>
-                      <input id="mtow" type="text" class="form-control" value="{{ $aircraft->mtow }}" disabled>
+                      <input id="mtow" type="text" class="form-control" value="{{ $aircraft->mtow->local(0) }}" disabled>
                     </div>
                     <div class="col-sm-2">
                       <label for="MLW">Max.LW</label>
-                      <input id="mlw" type="text" class="form-control" value="{{ $aircraft->mlw }}" disabled>
+                      <input id="mlw" type="text" class="form-control" value="{{ $aircraft->mlw->local(0) }}" disabled>
                     </div>
                     <div class="col-sm-2">
                       <label for="selcal">Selcal</label>

--- a/resources/views/layouts/default/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/default/flights/simbrief_form.blade.php
@@ -27,6 +27,7 @@
                       <div class="col-sm-6">
                         <label for="airframes">SimBrief Airframes</label>
                         <select name="airframes" id="sbairframe" class="form-control" onchange="CheckAirframe()">
+                            <option value="">Select an airframe if required...</option>
                           @foreach($sbairframes as $af)
                             <option value="{{ $af->airframe_id }}">{{ $af->name }}</option>
                           @endforeach

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -309,7 +309,7 @@ final class ApiTest extends TestCase
         $aircraft = Aircraft::factory()->create([
             'subfleet_id' => $subfleet->id,
             'mtow'        => 93000,
-            'mzfw'        => 71500,
+            'zfw'         => 71500,
         ]);
 
         /**

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -308,8 +308,8 @@ final class ApiTest extends TestCase
         /** @var Aircraft $aircraft */
         $aircraft = Aircraft::factory()->create([
             'subfleet_id' => $subfleet->id,
-            'mtow'        => 93000,
-            'zfw'         => 71500,
+            'mtow'        => 93000.0,
+            'zfw'         => 71500.0,
         ]);
 
         /**
@@ -321,16 +321,16 @@ final class ApiTest extends TestCase
         $this->assertEquals($body['id'], $aircraft->id);
         $this->assertEquals($body['name'], $aircraft->name);
         $this->assertNotEmpty($body['ident']);
-        $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
-        $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
+        // $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
+        // $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
 
         $resp = $this->get('/api/fleet/aircraft/'.$aircraft->id.'?registration='.$aircraft->registration);
         $body = $resp->json()['data'];
 
         $this->assertEquals($body['id'], $aircraft->id);
         $this->assertEquals($body['name'], $aircraft->name);
-        $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
-        $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
+        // $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
+        // $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
 
         $this->assertNotEmpty($body['ident']);
         $this->assertEquals($body['ident'], $aircraft->ident);
@@ -340,8 +340,8 @@ final class ApiTest extends TestCase
 
         $this->assertEquals($body['id'], $aircraft->id);
         $this->assertEquals($body['name'], $aircraft->name);
-        $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
-        $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
+        // $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
+        // $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
     }
 
     /*

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -308,6 +308,8 @@ final class ApiTest extends TestCase
         /** @var Aircraft $aircraft */
         $aircraft = Aircraft::factory()->create([
             'subfleet_id' => $subfleet->id,
+            'mtow'        => 93000,
+            'mzfw'        => 71500,
         ]);
 
         /**
@@ -319,16 +321,16 @@ final class ApiTest extends TestCase
         $this->assertEquals($body['id'], $aircraft->id);
         $this->assertEquals($body['name'], $aircraft->name);
         $this->assertNotEmpty($body['ident']);
-        $this->assertEquals($body['mtow'], $aircraft->mtow);
-        $this->assertEquals($body['zfw'], $aircraft->zfw);
+        $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
+        $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
 
         $resp = $this->get('/api/fleet/aircraft/'.$aircraft->id.'?registration='.$aircraft->registration);
         $body = $resp->json()['data'];
 
         $this->assertEquals($body['id'], $aircraft->id);
         $this->assertEquals($body['name'], $aircraft->name);
-        $this->assertEquals($body['mtow'], $aircraft->mtow);
-        $this->assertEquals($body['zfw'], $aircraft->zfw);
+        $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
+        $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
 
         $this->assertNotEmpty($body['ident']);
         $this->assertEquals($body['ident'], $aircraft->ident);
@@ -338,8 +340,8 @@ final class ApiTest extends TestCase
 
         $this->assertEquals($body['id'], $aircraft->id);
         $this->assertEquals($body['name'], $aircraft->name);
-        $this->assertEquals($body['mtow'], $aircraft->mtow);
-        $this->assertEquals($body['zfw'], $aircraft->zfw);
+        $this->assertEquals($body['mtow'], $aircraft->mtow->local(0));
+        $this->assertEquals($body['zfw'], $aircraft->zfw->local(0));
     }
 
     /*

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -645,7 +645,7 @@ final class ImporterTest extends TestCase
         $this->assertEquals('A320-211', $aircraft->name);
         $this->assertEquals('N309US', $aircraft->registration);
         $this->assertEquals('780DH', $aircraft->fin);
-        $this->assertEquals(null, $aircraft->zfw);
+        $this->assertEquals(71500.0, $aircraft->zfw->local(0));
         $this->assertEquals(AircraftStatus::ACTIVE, $aircraft->status);
 
         // Now try importing the updated file, the status for the aircraft should change

--- a/tests/data/aircraft-update.csv
+++ b/tests/data/aircraft-update.csv
@@ -1,3 +1,3 @@
 subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,selcal,dow,zfw,mtow,mlw,status,simbrief_type
-A32X,A320,320,,,A320-211,N309US,780DH,,,,,,,S,
-74X,747 400,, ,,,,,,,,,,,,
+A32X,A320,320,,,A320-211,N309US,780DH,,,,71500,93000,,S,
+74X,747 400,, ,,,,,,,,0,0,,,

--- a/tests/data/aircraft.csv
+++ b/tests/data/aircraft.csv
@@ -1,3 +1,3 @@
 subfleet,iata,icao,hub_id,airport_id,name,registration,fin,hex_code,selcal,dow,zfw,mtow,mlw,status,simbrief_type
-A32X,A320,320,,,A320-211,N309US,780DH,,,,,,,A,
-74X,747 400,,, ,,,,,,,,,,,
+A32X,A320,320,,,A320-211,N309US,780DH,,,,71500,93000,,A,
+74X,747 400,,, ,,,,,,,0,0,,,


### PR DESCRIPTION
PR allows fetching/storing SimBrief airframes and layout data, which can be used during flight planning via API. Also allows the admins to add their custom SimBrief airframes to phpvms easily. 

Automated relationship works by `ICAO Type Code` of the aircraft, also it is still possible to define aircraft and subfleet level simbrief airframes (via `simbrief_type` field)

By default initial data fetching is done during install, also scheduled to be run with weekly cron, additionally manually triggering the process is possible. (via admin > sb airframes)

Also Aircraft weights are now casted as `Mass Units`, before they were just plain values not being used by the system.

SimBrief flight planning is enhanced to benefit from both the airframe selections and aircraft weights/data. Controller, blade and jscript changes are present. Two additional settings are introduced to control new features.

⚠️ **WARNING: It is best to export aircraft before applying this update** ⚠️ 

PR provides a simple kg (local) to lbs (internal) conversion for already saved aircraft weights if the VA is using `kg` as weight unit and assuming that the weights was saved in `kg` . If this is not the case, exported csv will fix the mess.

Closes #1304 

![image](https://github.com/user-attachments/assets/819fd691-a1bf-454e-baf6-6185e41b85b4)

![image](https://github.com/user-attachments/assets/ccf73846-a6f7-4458-acc6-c3aaae17433e)

![image](https://github.com/user-attachments/assets/3b2d27e0-0500-418f-b050-15d1d2dc0632)

![image](https://github.com/user-attachments/assets/123a76ab-e39e-4027-985b-00c9cdc2ad2c)

![image](https://github.com/user-attachments/assets/8a07b58d-9f28-4920-9c57-2905f5b665fc)

![image](https://github.com/user-attachments/assets/02d41319-b0fc-4f6e-8c9c-bdb6764aff07)
