### PR TITLE
Add user language preference detection as default fallback

### DIFF
--- a/app/Http/Middleware/SetActiveLanguage.php
+++ b/app/Http/Middleware/SetActiveLanguage.php
@@ -18,7 +18,15 @@ class SetActiveLanguage
      */
     public function handle(Request $request, Closure $next)
     {
-        App::setLocale($request->cookie('lang', config('app.locale', 'en')));
+        $preferredLanguage = 'en';
+        if ($request->hasCookie('lang')) {
+            $preferredLanguage = $request->cookie('lang', config('app.locale', 'en'));
+        } else {
+            $preferredLanguage = $request->getPreferredLanguage(array_keys(config('languages')));
+        }
+
+        App::setLocale($preferredLanguage);
+
         return $next($request);
     }
 }

--- a/config/languages.php
+++ b/config/languages.php
@@ -1,13 +1,14 @@
 <?php
 
 return [
-    'de' => [
-        'display'   => 'German',
-        'flag-icon' => 'de',
-    ],
+    // First in the list is the default
     'en' => [
         'display'   => 'English',
         'flag-icon' => 'us',
+    ],
+    'de' => [
+        'display'   => 'German',
+        'flag-icon' => 'de',
     ],
     'es-es' => [
         'display'   => 'Spanish (Spain)',


### PR DESCRIPTION
This PR introduces a system to detect the user's language preference based on their browser or system settings (through the `Accept-Language` HTTP header). If no language has been explicitly chosen by the user, this detected preference will be set as the default language.