### PR TITLE
A380 Support and Fix For Aircraft Weights (API Resource)

### DIFF
--- a/app/Database/migrations/2024_11_22_182419_update_aircraft_table.php
+++ b/app/Database/migrations/2024_11_22_182419_update_aircraft_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('aircraft', function (Blueprint $table) {
+            $table->unsignedDecimal('dow', 10, 2)->nullable()->change();
+            $table->unsignedDecimal('zfw', 10, 2)->nullable()->change();
+            $table->unsignedDecimal('mlw', 10, 2)->nullable()->change();
+            $table->unsignedDecimal('mtow', 10, 2)->nullable()->change();
+        });
+    }
+};

--- a/app/Http/Resources/Aircraft.php
+++ b/app/Http/Resources/Aircraft.php
@@ -3,6 +3,8 @@
 namespace App\Http\Resources;
 
 use App\Contracts\Resource;
+use App\Support\Units\Fuel;
+use App\Support\Units\Mass;
 
 /**
  * @mixin \App\Models\Aircraft
@@ -14,12 +16,40 @@ class Aircraft extends Resource
         $res = parent::toArray($request);
         $res['ident'] = $this->ident;
 
-        // Set these to the response units
-        $res['dow'] = $this->dow->getResponseUnits();
-        $res['zfw'] = $this->zfw->getResponseUnits();
-        $res['mtow'] = $this->mtow->getResponseUnits();
-        $res['mlw'] = $this->mlw->getResponseUnits();
-        $res['fuel_onboard'] = $this->fuel_onboard->getResponseUnits();
+        // Dry Operating Weight
+        if (!array_key_exists('dow', $res)) {
+            $res['dow'] = 0;
+        }
+        $dow = Mass::make($res['dow'], config('phpvms.internal_units.mass'));
+        $res['dow'] = $dow->getResponseUnits();
+
+        // Maximum Zero Fuel Weight
+        if (!array_key_exists('zfw', $res)) {
+            $res['zfw'] = 0;
+        }
+        $zfw = Mass::make($res['zfw'], config('phpvms.internal_units.mass'));
+        $res['zfw'] = $zfw->getResponseUnits();
+
+        // Maximum TakeOff Weight
+        if (!array_key_exists('mtow', $res)) {
+            $res['mtow'] = 0;
+        }
+        $mtow = Mass::make($res['mtow'], config('phpvms.internal_units.mass'));
+        $res['mtow'] = $mtow->getResponseUnits();
+
+        // Maximum Landing Weight
+        if (!array_key_exists('mlw', $res)) {
+            $res['mlw'] = 0;
+        }
+        $mlw = Mass::make($res['mlw'], config('phpvms.internal_units.mass'));
+        $res['mlw'] = $mlw->getResponseUnits();
+
+        // Fuel On Board
+        if (!array_key_exists('fuel_onboard', $res)) {
+            $res['fuel_onboard'] = 0;
+        }
+        $fuel_onboard = Fuel::make($res['fuel_onboard'], config('phpvms.internal_units.fuel'));
+        $res['fuel_onboard'] = $fuel_onboard->getResponseUnits();
 
         return $res;
     }

--- a/app/Http/Resources/Pirep.php
+++ b/app/Http/Resources/Pirep.php
@@ -68,6 +68,7 @@ class Pirep extends Resource
             $res['block_off_time'] = $this->block_off_time->toIso8601ZuluString();
         }
 
+        $res['aircraft'] = new Aircraft($this->aircraft);
         $res['airline'] = new Airline($this->airline);
         $res['dpt_airport'] = new Airport($this->dpt_airport);
         $res['arr_airport'] = new Airport($this->arr_airport);


### PR DESCRIPTION
Provide support for extra ordinary weights.

_Even though it is not needed for weights except MTOW of A380, provide enough room for possible imaginary/experimental aircraft by updating all fields to support weights above 1 million pounds._