### PR TITLE
Add stats in User resource API

### DIFF
--- a/app/Http/Resources/Stats.php
+++ b/app/Http/Resources/Stats.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Support\Facades\DB;
+use App\Contracts\Resource;
+use App\Models\Enums\PirepSource;
+use App\Models\Enums\PirepState;
+
+/**
+ * @mixin \App\Models\Stats
+ */
+class Stats extends Resource
+{
+    public function toArray($request)
+    {
+        $avgLanding = DB::table('pireps')
+            ->selectRaw('avg(landing_rate) as uresult')
+            ->where('user_id', $this->id)
+            ->where('source', PirepSource::ACARS)->where('landing_rate', '<',0)
+            ->where('state', PirepState::ACCEPTED)
+            ->value('uresult');
+
+        $avgFuel = DB::table('pireps')
+        ->selectRaw('avg(fuel_used) as uresult')
+        ->where('user_id', $this->id)
+        ->where('state', PirepState::ACCEPTED)
+        ->value('uresult');
+
+        $avgScore = DB::table('pireps')
+        ->selectRaw('avg(score) as uresult')
+        ->where('user_id', $this->id)
+        ->where('state', PirepState::ACCEPTED)
+        ->value('uresult');
+
+        return [
+            'balance'       => $this->balance ?? 0,
+            'avgScore'      => number_format($avgScore) ?? 0,
+            'avgLanding'    => number_format($avgLanding) ?? 0,
+            'avgFuel'       => number_format($avgFuel / 2.20462262185) . ' kg' ?? '',
+        ];
+    }
+}

--- a/app/Http/Resources/Stats.php
+++ b/app/Http/Resources/Stats.php
@@ -17,24 +17,24 @@ class Stats extends Resource
         $avgLanding = DB::table('pireps')
             ->selectRaw('avg(landing_rate) as uresult')
             ->where('user_id', $this->id)
-            ->where('source', PirepSource::ACARS)->where('landing_rate', '<',0)
+            ->where('source', PirepSource::ACARS)->where('landing_rate', '<', 0)
             ->where('state', PirepState::ACCEPTED)
             ->value('uresult');
 
         $avgFuel = DB::table('pireps')
-        ->selectRaw('avg(fuel_used) as uresult')
-        ->where('user_id', $this->id)
-        ->where('state', PirepState::ACCEPTED)
-        ->value('uresult');
+            ->selectRaw('avg(fuel_used) as uresult')
+            ->where('user_id', $this->id)
+            ->where('state', PirepState::ACCEPTED)
+            ->value('uresult');
 
         $avgScore = DB::table('pireps')
-        ->selectRaw('avg(score) as uresult')
-        ->where('user_id', $this->id)
-        ->where('state', PirepState::ACCEPTED)
-        ->value('uresult');
+            ->selectRaw('avg(score) as uresult')
+            ->where('user_id', $this->id)
+            ->where('state', PirepState::ACCEPTED)
+            ->value('uresult');
 
         return [
-            'balance'       => $this->balance ?? 0,
+            'balance'       => $this->journal->balance->money->getValue() ?? 0,
             'avgScore'      => number_format($avgScore) ?? 0,
             'avgLanding'    => number_format($avgLanding) ?? 0,
             'avgFuel'       => number_format($avgFuel / 2.20462262185) . ' kg' ?? '',

--- a/app/Http/Resources/User.php
+++ b/app/Http/Resources/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use Illuminate\Support\Facades\Auth;
 use App\Contracts\Resource;
 
 /**
@@ -31,8 +32,10 @@ class User extends Resource
             'total_time'    => $this->flight_time,
             'timezone'      => $this->timezone,
             'state'         => $this->state,
+
         ];
 
+        $res['stats'] = new Stats(Auth::user());
         $res['airline'] = Airline::make($this->whenLoaded('airline'));
         $res['bids'] = UserBid::collection($this->whenLoaded('bids'));
         $res['rank'] = Rank::make($this->whenLoaded('rank'));


### PR DESCRIPTION
Hello Nabel!

I'm here again, I think create a project that maybe can help for all community and I expect more later tell you about this.
But firts I need make some modifications in the API's

## Preview

### Endpoint: /api/user
```php
{
       ...
        "flights": 125,
        "flight_time": 12463,
        "transfer_time": 0,
        "total_time": 12463,
        "timezone": "GMT",
        "state": 1,
        "stats": {
            "balance": 9999.99,
            "avgScore": "100",
            "avgLanding": "-100",
            "avgFuel": "4,648 kg"
        },
        ...
}
```
> Remember that only you can user Average Score and Average Landing if your pirep was submitted with Acars

I hope in the future add more stats how Average burn fuel and other field


