### PR TITLE
Add SimBrief Rate Limiting

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -140,7 +140,7 @@ class RouteServiceProvider extends ServiceProvider
                 // SimBrief stuff
                 Route::get('simbrief/generate', 'SimBriefController@generate')->name('simbrief.generate');
                 Route::post('simbrief/apicode', 'SimBriefController@api_code')->name('simbrief.api_code');
-                Route::get('simbrief/check_ofp', 'SimBriefController@check_ofp')->name('simbrief.check_ofp');
+                Route::get('simbrief/check_ofp', 'SimBriefController@check_ofp')->name('simbrief.check_ofp')->middleware('throttle:10,1');
                 Route::get('simbrief/update_ofp', 'SimBriefController@update_ofp')->name('simbrief.update_ofp');
                 Route::get('simbrief/{id}', 'SimBriefController@briefing')->name('simbrief.briefing');
                 Route::get('simbrief/{id}/prefile', 'SimBriefController@prefile')->name('simbrief.prefile');

--- a/public/assets/global/js/simbrief.apiv1.js
+++ b/public/assets/global/js/simbrief.apiv1.js
@@ -173,7 +173,7 @@ function checkSBworker() {
 }
 
 
-async function Redirect_caller(nbAttemps = 0) {
+async function Redirect_caller(nbAttemps = 1) {
 
   /*
   * First check that the file actually exists.

--- a/public/assets/global/js/simbrief.apiv1.js
+++ b/public/assets/global/js/simbrief.apiv1.js
@@ -173,7 +173,7 @@ function checkSBworker() {
 }
 
 
-async function Redirect_caller() {
+async function Redirect_caller(nbAttemps = 0) {
 
   /*
   * First check that the file actually exists.
@@ -197,9 +197,13 @@ async function Redirect_caller() {
     });
   } catch (e) {
     console.log('request error', e);
-    setTimeout(function () {
-      Redirect_caller();
-    }, 500);
+    if (nbAttemps < 5) {
+      setTimeout(function () {
+        Redirect_caller(nbAttemps + 1);
+      }, 1500);
+    } else {
+      alert(`There was an error while generating an OFP. Please try reloading the page or contact your administrator. Error : ${e}`)
+    }
 
     return;
   }


### PR DESCRIPTION
This code limits the number of requests to the route to 10 per minute. Once this limit is exceeded, requests are blocked, but the block only lasts for one or two minutes, so users are not locked out for several hours.

Additionally, the SimBrief code (frontend) has been updated to avoid sending more than 5 requests, with a delay of 1500ms between each request. This allows us to smooth out the requests we send afterward.

Example below:
You can see that I triggered the rate limiter, received 429 errors, then got the popup notifying me of a problem. If I regenerate about a minute later, I get a 200 status, and the generation works.

![image](https://github.com/user-attachments/assets/c95c4ef5-7fea-4afc-baec-56d8aa099d61)

![image](https://github.com/user-attachments/assets/62afc125-6fd1-4228-b914-8f6ca773f76b)
