### PR TITLE
Update Module Stub to Fix Theme Overrides for Module Views

### DIFF
--- a/resources/stubs/modules/provider.stub
+++ b/resources/stubs/modules/provider.stub
@@ -68,18 +68,13 @@ class AppServiceProvider extends ServiceProvider
     public function registerViews()
     {
         $viewPath = resource_path('views/modules/$LOWER_NAME$');
-        $sourcePath = __DIR__.'/../Resources/views';
+        $sourcePath = __DIR__ . '/../Resources/views';
 
-        $this->publishes([$sourcePath => $viewPath],'views');
+        $this->publishes([$sourcePath => $viewPath,], 'views');
 
-        $this->loadViewsFrom(array_merge(array_filter(array_map(function ($path) {
-            $path = str_replace('default', setting('general.theme'), $path);
-            // Check if the directory exists before adding it
-            if (file_exists($path.'/modules/$LOWER_NAME$') && is_dir($path.'/modules/$LOWER_NAME$'))
-              return $path.'/modules/$LOWER_NAME$';
-
-            return null;
-        }, \Config::get('view.paths'))), [$sourcePath]), '$LOWER_NAME$');
+        $this->loadViewsFrom(array_merge(array_map(function ($path) {
+            return str_replace('default', setting('general.theme'), $path) . '/modules/$LOWER_NAME$';
+        }, \Config::get('view.paths')), [$sourcePath]), '$LOWER_NAME$');
     }
 
     /**


### PR DESCRIPTION
closes #1901

This will fix the above. Modules will need to be updated, but at least new modules will be generated with the correct code.

One point of discussion. For the folder inside the theme, should we enforce the Pascal naming convention as seen by other modules (i.e. `DisposableBasic`, `DisposableSpecial`)? If so, I can switch all lower case to Pascal in another commit.