### PR TITLE
Modify Flight Importer Deletion Options

### DIFF
--- a/app/Http/Controllers/Admin/FlightController.php
+++ b/app/Http/Controllers/Admin/FlightController.php
@@ -118,6 +118,7 @@ class FlightController extends Controller
             ->with(['dpt_airport', 'arr_airport', 'alt_airport', 'airline', 'subfleets'])
             ->withCount(['subfleets', 'fares'])
             ->searchCriteria($request, false)
+            ->whereNull('owner_type')
             ->sortable('flight_number')->orderBy('route_code')->orderBy('route_leg')
             ->paginate();
 

--- a/app/Http/Controllers/Admin/Traits/Importable.php
+++ b/app/Http/Controllers/Admin/Traits/Importable.php
@@ -39,6 +39,10 @@ trait Importable
 
         $delete_previous = get_truth_state($request->get('delete'));
 
+        if ($importType === ImportExportType::FLIGHTS) {
+            $delete_previous = $request->get('delete');
+        }
+
         switch ($importType) {
             case ImportExportType::AIRCRAFT:
                 return $importSvc->importAircraft($path, $delete_previous);

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -209,11 +209,19 @@ class ImportService extends Service
      *
      * @return mixed
      */
-    public function importFlights($csv_file, bool $delete_previous = true)
+    public function importFlights($csv_file, string $delete_previous)
     {
-        if ($delete_previous) {
-            Flight::truncate();
-            FlightFieldValue::truncate();
+        
+        if (!empty($delete_previous)) {
+            // If delete_previous contains all, then delete everything
+            if (in_array('all', $delete_previous)) {
+                Flight::truncate();
+                FlightFieldValue::truncate();
+            } else if (in_array('core', $delete_previous)) {
+                // Delete all flights where the onwer_type is null
+                Flight::whereNull('owner_type')->delete();
+            }
+
         }
 
         $importer = new FlightImporter();

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -211,17 +211,15 @@ class ImportService extends Service
      */
     public function importFlights($csv_file, string $delete_previous)
     {
-        
         if (!empty($delete_previous)) {
             // If delete_previous contains all, then delete everything
             if (in_array('all', $delete_previous)) {
                 Flight::truncate();
                 FlightFieldValue::truncate();
-            } else if (in_array('core', $delete_previous)) {
+            } elseif (in_array('core', $delete_previous)) {
                 // Delete all flights where the onwer_type is null
                 Flight::whereNull('owner_type')->delete();
             }
-
         }
 
         $importer = new FlightImporter();

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -209,7 +209,7 @@ class ImportService extends Service
      *
      * @return mixed
      */
-    public function importFlights($csv_file, string $delete_previous)
+    public function importFlights($csv_file, string $delete_previous = null)
     {
         if (!empty($delete_previous)) {
             // If delete_previous contains all, then delete everything

--- a/resources/views/admin/flights/import.blade.php
+++ b/resources/views/admin/flights/import.blade.php
@@ -1,5 +1,60 @@
 @extends('admin.app')
 @section('title', 'Import Flights')
 @section('content')
-  @include('admin.common.import', ['route' => 'admin.flights.import'])
+<div class="card border-blue-bottom">
+  <div class="content">
+    <div class="row">
+    <form method="post" action="{{ route('admin.flights.import') }}" enctype="multipart/form-data">
+      @csrf
+      <div class="form-group col-12">
+        <label for="csv_file">Choose a CSV file to import</label>
+        <input type="file" name="csv_file" accept=".csv">
+        <p class="text-danger">{{ $errors->first('csv_file') }}</p>
+        <div class="checkbox">
+          <label class="checkbox-inline">
+            <input type="checkbox" name="delete" value="all" id="deleteAll"> Delete <b>ALL</b> Flights
+          </label>
+        </div>
+        <div class="checkbox">
+          <label class="checkbox-inline">
+            <input type="checkbox" name="delete" value="core" id="deleteCore"> Delete Only Core (Non-Module Owned/Controlled) Flights
+          </label>
+        </div>
+      </div>
+      <div class="form-group col-md-12">
+        <div class="text-right">
+          <script>
+            
+            document.querySelector('form').addEventListener('submit', function(event) {
+              if (document.querySelector('input[name="delete"][value="all"]').checked) {
+                if (!confirm('Are you sure you want to delete all flights? This action is irreversible and can cause problems.')) {
+                  event.preventDefault();
+                }
+              }
+            });
+          </script>
+          <button type="submit" class="btn btn-success">Start Import</button>
+        </div>
+      </div>
+    </form>
+
+      <div class="form-group col-md-12">
+        @if($logs['success'])
+          <h4>Logs</h4>
+          @foreach($logs['success'] as $line)
+            <p>{{ $line }}</p>
+          @endforeach
+        @endif
+
+        @if($logs['errors'])
+          <h4>Errors</h4>
+          @foreach($logs['errors'] as $line)
+            <p>{{ $line }}</p>
+          @endforeach
+        @endif
+      </div>
+    </div>
+  </div>
+</div>
+
 @endsection


### PR DESCRIPTION
This PR addresses an issue encountered when 3rd party modules write to the flights table, and these flights get deleted if the import checkbox is entered.

This PR:

- Adds a additional checkbox to only delete core flights
- Adds a confirmation dialogue for the delete all option
- Hides module generated flights from the admin flights table.