### PR TITLE
[8.x] Fix settings

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -156,7 +156,7 @@ class Settings extends Page
                         if ($setting->id === 'general_theme') {
                             return Select::make($setting->key)->label($setting->name)->helperText($setting->description)->options(list_to_assoc($this->getThemes()));
                         } elseif ($setting->id === 'units_currency') {
-                            return Select::make($setting->key)->label($setting->name)->helperText($setting->description)->options(list_to_assoc($this->getCurrencyList()));
+                            return Select::make($setting->key)->label($setting->name)->helperText($setting->description)->options($this->getCurrencyList())->searchable()->native(false);
                         }
 
                         return Select::make($setting->key)->label($setting->name)->helperText($setting->description)->options(list_to_assoc(explode(',', $setting->options)));

--- a/app/Repositories/SettingRepository.php
+++ b/app/Repositories/SettingRepository.php
@@ -101,7 +101,7 @@ class SettingRepository extends Repository implements CacheableInterface
                 $value = $value === true ? 1 : 0;
             }
 
-            if ($value) {
+            if ($value !== null) {
                 $this->update(['value' => $value], $setting->id);
             }
         } catch (ValidatorException $e) {

--- a/app/Repositories/SettingRepository.php
+++ b/app/Repositories/SettingRepository.php
@@ -101,7 +101,9 @@ class SettingRepository extends Repository implements CacheableInterface
                 $value = $value === true ? 1 : 0;
             }
 
-            $this->update(['value' => $value], $setting->id);
+            if ($value) {
+                $this->update(['value' => $value], $setting->id);
+            }
         } catch (ValidatorException $e) {
             Log::error($e->getMessage(), $e->getTrace());
         }


### PR DESCRIPTION
This PR addresses two issues on the settings page:

1. The currencies list was not loading correctly, which meant the settings weren’t being updated properly, and the default currency wasn’t selected.
2. If a non-optional setting was left blank and an attempt was made to update it, the MariaDB driver would throw an error stating that `null` cannot be set to a non-nullable field. I added a check to ensure the value is not `null` before updating. 

Note: The second error could occur elsewhere in the app, and we should be on the lookout for them. It's important to fix these, as trying to set a `null` value into a non-nullable field is not correct behavior.

Further details in [this discord conversation](https://discord.com/channels/332920618729340929/1329603966337552514/1330139466953654272).

Huge thanks to @FatihKoz for identifying these two issues.