### PR TITLE
[8.x] Fix pint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,13 @@
 name: Fix Code Style
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+      - "feature/**"
+      - "release/**"
+      - "hotfix/**"
 
 jobs:
   lint:


### PR DESCRIPTION
Since we are not allowed to auto-commit on contributors' forks, we run pint on push. This ensures that when a PR is merged, pint is automatically run