### PR TITLE
Fix Pirep Update (Fuel Units)

### DIFF
--- a/app/Http/Controllers/Frontend/PirepController.php
+++ b/app/Http/Controllers/Frontend/PirepController.php
@@ -532,10 +532,11 @@ class PirepController extends Controller
         $attrs['submit'] = strtolower($attrs['submit']);
 
         // Fix the time
-        $attrs['flight_time'] = Time::init(
-            $attrs['minutes'],
-            $attrs['hours']
-        )->getMinutes();
+        $attrs['flight_time'] = Time::init($attrs['minutes'], $attrs['hours'])->getMinutes();
+
+        // Fix the fuel
+        $attrs['block_fuel'] = Fuel::make((float) $attrs['block_fuel'], setting('units.fuel'));
+        $attrs['fuel_used'] = Fuel::make((float) $attrs['fuel_used'], setting('units.fuel'));
 
         $pirep = $this->pirepRepo->update($attrs, $id);
 


### PR DESCRIPTION
Change should be applied to both v7 and v8, fixes fuel unit not being considered during pirep edit problem.

Closes #2052 
Closes #493 

Both issues related with fuel units being not considered during update call. Attributes was being passed directly to the model without local to internal conversion (when necessary).