### PR TITLE
Revert "[8.x] feat(admin): support relative URLs"

### DIFF
--- a/app/Filament/RelationManagers/FilesRelationManager.php
+++ b/app/Filament/RelationManagers/FilesRelationManager.php
@@ -39,7 +39,7 @@ class FilesRelationManager extends RelationManager
 
                 TextInput::make('url')
                     ->label('URL')
-                    ->string()
+                    ->url()
                     ->requiredWithout('file'),
 
                 FileUpload::make('file')

--- a/app/Filament/Resources/Awards/Schemas/AwardForm.php
+++ b/app/Filament/Resources/Awards/Schemas/AwardForm.php
@@ -36,7 +36,7 @@ class AwardForm
 
                         TextInput::make('image_url')
                             ->label(__('common.image_url'))
-                            ->string(),
+                            ->url(),
 
                         RichEditor::make('description')
                             ->label(__('common.description'))

--- a/app/Filament/Resources/Pages/Schemas/PageForm.php
+++ b/app/Filament/Resources/Pages/Schemas/PageForm.php
@@ -74,7 +74,7 @@ class PageForm
 
                         TextInput::make('link')
                             ->label(__('common.link'))
-                            ->string()
+                            ->url()
                             ->requiredIf('type', PageType::LINK)
                             ->visibleJs(<<<'JS'
                                     $get('type') == '1'


### PR DESCRIPTION
Reverts phpvms/phpvms#2094

People should provide a valid URL here, since we’ll be sending these URLs to Discord later (for notifications) or potentially using them elsewhere in the app. It’s much more logical and safer to enforce valid URLs upfront rather than checking each time whether it’s relative or absolute.