### PR TITLE
[8.x] fix: use belongsTo instead of hasOne for relationship

### DIFF
--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -245,9 +245,9 @@ class Aircraft extends Model
         return $this->belongsTo(Bid::class, 'id', 'aircraft_id');
     }
 
-    public function home(): HasOne
+    public function home(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'hub_id');
+        return $this->belongsTo(Airport::class, 'hub_id');
     }
 
     /**
@@ -255,9 +255,9 @@ class Aircraft extends Model
      *
      * @deprecated
      */
-    public function hub(): HasOne
+    public function hub(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'hub_id');
+        return $this->home();
     }
 
     public function pireps(): HasMany

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Kyslik\ColumnSortable\Sortable;
@@ -321,19 +320,19 @@ class Flight extends Model
         return $this->belongsTo(Airline::class, 'airline_id');
     }
 
-    public function dpt_airport(): HasOne
+    public function dpt_airport(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'dpt_airport_id');
+        return $this->belongsTo(Airport::class);
     }
 
-    public function arr_airport(): HasOne
+    public function arr_airport(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'arr_airport_id');
+        return $this->belongsTo(Airport::class);
     }
 
-    public function alt_airport(): HasOne
+    public function alt_airport(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'alt_airport_id');
+        return $this->belongsTo(Airport::class);
     }
 
     public function fares(): BelongsToMany

--- a/app/Models/Subfleet.php
+++ b/app/Models/Subfleet.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Kyslik\ColumnSortable\Sortable;
 use Spatie\Activitylog\LogOptions;
@@ -165,17 +164,17 @@ class Subfleet extends Model
         return $this->belongsTo(Airline::class, 'airline_id');
     }
 
-    public function home(): HasOne
+    public function home(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'hub_id');
+        return $this->belongsTo(Airport::class, 'hub_id');
     }
 
     /**
      * @deprecated use home()
      */
-    public function hub(): HasOne
+    public function hub(): BelongsTo
     {
-        return $this->hasOne(Airport::class, 'id', 'hub_id');
+        return $this->home();
     }
 
     public function fares(): BelongsToMany


### PR DESCRIPTION
There was a critical bug in Filament where some record IDs were being deleted. I opened a bug report with a reproduction repository, and the Filament team confirmed that we were using the wrong type of relationship.

After further research, I found they were right: we should be using `belongsTo` instead of `hasOne`. The `hasOne` relationship is only meant for cases where the foreign key is stored on the related model, not the current one. In our case, the foreign keys are stored on the current model, so belongsTo is the correct relationship type.

For further reference, see the article below:

https://medium.com/@techaiinsights2022/hasone-vs-belongsto-a-simple-guide-to-laravel-relationships-32ee031f3dc9