### PR TITLE
Fix Aircraft and Subfleet Import (Delete existing data)

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -122,7 +122,7 @@ class ImportService extends Service
         if ($delete_previous) {
             Aircraft::truncate();
 
-            Log::warning('Aircraft table truncated by User: '.Auth::id().' , '.Auth::user()->name_private);
+            // Log::warning('Aircraft table truncated by User: '.Auth::id().' , '.Auth::user()->name_private);
         }
 
         $importer = new AircraftImporter();
@@ -228,7 +228,7 @@ class ImportService extends Service
             DB::table('flight_subfleet')->truncate();
             DB::table('typerating_subfleet')->truncate();
 
-            Log::warning('Subfleet and tied relationship tables truncated by User: '.Auth::id().' , '.Auth::user()->name_private);
+            // Log::warning('Subfleet and tied relationship tables truncated by User: '.Auth::id().' , '.Auth::user()->name_private);
         }
 
         $importer = new SubfleetImporter();


### PR DESCRIPTION
- Truncate aircraft and subfleet tables
- Truncate relationship table entries for subfleets (flight, rank, subfleet)
- Log actions with `warning` level (these actions should be important than debug, can be changed to notice or info too)

Closes #2127 