### PR TITLE
[8.x] fix(UserController): update error handling for SimBrief username validation

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -209,7 +209,7 @@ class UserController extends Controller
             'json'     => 'v2',
         ]);
 
-        if ($response->failed() || $response->json('fetch.status') === 'Error: Unknown UserID') {
+        if ($response->serverError() || $response->json('fetch.status') === 'Error: Unknown UserID') {
             return response()->json([
                 'success' => false,
                 'message' => 'Invalid SimBrief username provided.',


### PR DESCRIPTION
If no SimBrief OFP is available, SimBrief may return a 400 error even if the user is still valid. Therefore, we only check for server errors (5xx), but inspect the response body when a 4xx is returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SimBrief username validation to properly handle server errors, ensuring users receive accurate validation feedback when the service experiences technical issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->