### PR TITLE
Update FinanceService to include post_date parameter

### DIFF
--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -500,7 +500,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Ground Handling (Departure)',
             'Ground Handling',
-            'ground_handling'
+            'ground_handling',
+            $pirep->submitted_at
         );
 
         $ground_handling_cost = $this->getGroundHandlingCost($pirep, $pirep->arr_airport);
@@ -512,7 +513,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Ground Handling (Arrival)',
             'Ground Handling',
-            'ground_handling'
+            'ground_handling',
+            $pirep->submitted_at
         );
     }
 
@@ -547,7 +549,8 @@ class PirepFinanceService extends Service
             $pirep,
             $memo,
             'Pilot Pay',
-            'pilot_pay'
+            'pilot_pay',
+            $pirep->submitted_at
         );
 
         $this->financeSvc->creditToJournal(
@@ -556,7 +559,8 @@ class PirepFinanceService extends Service
             $pirep,
             $memo,
             'Pilot Pay',
-            'pilot_pay'
+            'pilot_pay',
+            $pirep->submitted_at
         );
     }
 

--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -122,7 +122,7 @@ class PirepFinanceService extends Service
                 $debit,
                 $pirep,
                 $memo,
-                null,
+                $pirep->submitted_at,
                 'Fares',
                 'fare'
             );
@@ -168,7 +168,7 @@ class PirepFinanceService extends Service
                     $debit,
                     $pirep,
                     $fare->name,
-                    null,
+                    $pirep->submitted_at,
                     $fare->notes,
                     'additional-sales'
                 );
@@ -243,7 +243,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Fuel Cost ('.$fuel_cost.'/'.config('phpvms.internal_units.fuel').')',
             'Fuel',
-            'fuel'
+            'fuel',
+            $pirep->submitted_at
         );
     }
 
@@ -285,7 +286,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Subfleet '.$sf->type.': Block Time Cost',
             'Subfleet '.$sf->type,
-            'subfleet'
+            'subfleet',
+            $pirep->submitted_at
         );
     }
 
@@ -381,7 +383,8 @@ class PirepFinanceService extends Service
                 $pirep,
                 $memo,
                 $transaction_group,
-                strtolower($klass)
+                strtolower($klass),
+                $pirep->submitted_at
             );
         });
     }
@@ -417,7 +420,8 @@ class PirepFinanceService extends Service
                 $pirep,
                 $memo,
                 $transaction_group,
-                'airport'
+                'airport',
+                $pirep->submitted_at
             );
         });
     }
@@ -470,7 +474,8 @@ class PirepFinanceService extends Service
                     $pirep,
                     'Expense: '.$expense->name,
                     $expense->transaction_group ?? 'Expenses',
-                    'expense'
+                    'expense',
+                    $pirep->submitted_at
                 );
             }
         }

--- a/app/Services/FinanceService.php
+++ b/app/Services/FinanceService.php
@@ -168,7 +168,7 @@ class FinanceService extends Service
                          SUM(debit) as sum_debits'
             )
             ->where(['journal_id' => $airline->journal->id])
-            ->whereBetween('created_at', [$start_date, $end_date], 'AND')
+            ->whereBetween('post_date', [$start_date, $end_date], 'AND')
             ->orderBy('sum_credits', 'desc')
             ->orderBy('sum_debits', 'desc')
             ->orderBy('transaction_group', 'asc')

--- a/app/Services/FinanceService.php
+++ b/app/Services/FinanceService.php
@@ -83,7 +83,7 @@ class FinanceService extends Service
             null,
             $reference,
             $memo,
-            null,
+            $post_date,
             $transaction_group,
             $tag
         );


### PR DESCRIPTION
Let both Finance and Journal functions use `$pirep->submitted_at` as the `post_date`, which will work for automated live calculations and fixes the problem of re-calculations.

Closes #2176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credit journal entries now honor provided posting dates for more accurate financial records.
  * Transactions from PIREPs (fares, fuel, pilot pay, and other expenses) are posted using the report submission date for consistent timing.
  * Airline transaction lookups now filter by post date (not creation date) to return correct date-range results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->