### PR TITLE
[8.x] fix(FinanceService): update date filtering and add submitted_at to finance entries

### DIFF
--- a/app/Services/Finance/PirepFinanceService.php
+++ b/app/Services/Finance/PirepFinanceService.php
@@ -127,7 +127,7 @@ class PirepFinanceService extends Service
                 $debit,
                 $pirep,
                 $memo,
-                null,
+                $pirep->submitted_at,
                 'Fares',
                 'fare'
             );
@@ -173,7 +173,7 @@ class PirepFinanceService extends Service
                     $debit,
                     $pirep,
                     $fare->name,
-                    null,
+                    $pirep->submitted_at,
                     $fare->notes,
                     'additional-sales'
                 );
@@ -244,7 +244,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Fuel Cost ('.$fuel_cost.'/'.config('phpvms.internal_units.fuel').')',
             'Fuel',
-            'fuel'
+            'fuel',
+            $pirep->submitted_at
         );
     }
 
@@ -281,7 +282,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Subfleet '.$sf->type.': Block Time Cost',
             'Subfleet '.$sf->type,
-            'subfleet'
+            'subfleet',
+            $pirep->submitted_at
         );
     }
 
@@ -373,7 +375,8 @@ class PirepFinanceService extends Service
                 $pirep,
                 $memo,
                 $transaction_group,
-                strtolower($klass)
+                strtolower($klass),
+                $pirep->submitted_at
             );
         });
     }
@@ -409,7 +412,8 @@ class PirepFinanceService extends Service
                 $pirep,
                 $memo,
                 $transaction_group,
-                'airport'
+                'airport',
+                $pirep->submitted_at
             );
         });
     }
@@ -462,7 +466,8 @@ class PirepFinanceService extends Service
                     $pirep,
                     'Expense: '.$expense->name,
                     $expense->transaction_group ?? 'Expenses',
-                    'expense'
+                    'expense',
+                    $pirep->submitted_at
                 );
             }
         }
@@ -487,7 +492,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Ground Handling (Departure)',
             'Ground Handling',
-            'ground_handling'
+            'ground_handling',
+            $pirep->submitted_at
         );
 
         $ground_handling_cost = $this->getGroundHandlingCost($pirep, $pirep->arr_airport);
@@ -499,7 +505,8 @@ class PirepFinanceService extends Service
             $pirep,
             'Ground Handling (Arrival)',
             'Ground Handling',
-            'ground_handling'
+            'ground_handling',
+            $pirep->submitted_at
         );
     }
 
@@ -534,7 +541,8 @@ class PirepFinanceService extends Service
             $pirep,
             $memo,
             'Pilot Pay',
-            'pilot_pay'
+            'pilot_pay',
+            $pirep->submitted_at
         );
 
         $this->financeSvc->creditToJournal(
@@ -543,7 +551,8 @@ class PirepFinanceService extends Service
             $pirep,
             $memo,
             'Pilot Pay',
-            'pilot_pay'
+            'pilot_pay',
+            $pirep->submitted_at
         );
     }
 

--- a/app/Services/FinanceService.php
+++ b/app/Services/FinanceService.php
@@ -157,7 +157,7 @@ class FinanceService extends Service
                          SUM(debit) as sum_debits'
             )
             ->where(['journal_id' => $airline->journal->id])
-            ->whereBetween('created_at', [$start_date, $end_date], 'AND')
+            ->whereBetween('post_date', [$start_date, $end_date], 'AND')
             ->orderBy('sum_credits', 'desc')
             ->orderBy('sum_debits', 'desc')
             ->orderBy('transaction_group', 'asc')


### PR DESCRIPTION
Basically the same as #2177 but for v8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved PIREP financial transaction recording by ensuring submission timestamps are properly captured for all transaction types including fares, fuel, expenses, ground handling, and pilot pay.
* Enhanced airline transaction filtering to accurately retrieve transactions based on posting date for more reliable financial reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->