### PR TITLE
Add Aircraft Count For Each Flight

### DIFF
--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -111,6 +111,7 @@ class FlightController extends Controller
             // Build type ratings collection by considering user's capabilities
             $type_ratings = $user->typeratings;
         } else {
+            $user_subfleets = null;
             $allowed_flights = [];
             // Build aircraft icao codes array from complete fleet
             $icao_codes = Aircraft::groupBy('icao')->orderBy('icao')->pluck('icao')->toArray();
@@ -150,7 +151,7 @@ class FlightController extends Controller
             ->paginate();
 
         // Count available aircraft for each flight in the result set
-        $ac_counts = $this->CountAvailableAircraftForFlights($flights);
+        $ac_counts = $this->CountAvailableAircraftForFlights($flights, $user_subfleets);
 
         // Get the user's saved flights (bids)
         $saved_flights = [];
@@ -276,7 +277,7 @@ class FlightController extends Controller
         ]);
     }
 
-    private function CountAvailableAircraftForFlights($flights): array
+    private function CountAvailableAircraftForFlights($flights, $user_subfleets = null): array
     {
         $counts = [];
         $batchSize = 50;
@@ -286,8 +287,13 @@ class FlightController extends Controller
             $airportIds = $batch->pluck('dpt_airport_id')->unique()->toArray();
             $subfleetIds = collect($batch)->flatMap(fn($f) => $f->subfleets->pluck('id'))->unique()->toArray();
 
+            if ($user_subfleets !== null) {
+                // If we have user subfleet restrictions, intersect with flight subfleets
+                $subfleetIds = array_intersect($subfleetIds, $user_subfleets);
+            }
+
             // Get airline IDs for this batch
-            $airlineIds = collect($batch)->pluck('airline_id')->unique()->toArray();
+            // $airlineIds = collect($batch)->pluck('airline_id')->unique()->toArray();
 
             // Query aircraft for this batch
             $aircraftQuery = Aircraft::query()

--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -285,15 +285,33 @@ class FlightController extends Controller
         foreach ($flights->chunk($batchSize) as $batch) {
             // Collect unique airports and subfleets
             $airportIds = $batch->pluck('dpt_airport_id')->unique()->toArray();
-            $subfleetIds = collect($batch)->flatMap(fn($f) => $f->subfleets->pluck('id'))->unique()->toArray();
+            // Get airline IDs for this batch
+            $airlineIds = collect($batch)->pluck('airline_id')->unique()->toArray();
+
+            // Subfleets explicitly assigned to flights in this batch
+            $explicitSubfleetIds = collect($batch)
+                ->flatMap(fn($f) => $f->subfleets->pluck('id'))
+                ->unique()
+                ->toArray();
+
+            // Subfleets eligible for open flights (those with no assigned subfleets)
+            $hasOpenFlights = collect($batch)->contains(fn($f) => $f->subfleets->isEmpty());
+            $fallbackSubfleetIds = [];
+            if ($hasOpenFlights) {
+                $fallbackSubfleetIds = DB::table('subfleets')
+                    ->when(setting('flights.only_company_aircraft', false), function ($query) use ($airlineIds) {
+                        return $query->whereIn('airline_id', $airlineIds);
+                    })
+                    ->pluck('id')
+                    ->toArray();
+            }
+
+            $subfleetIds = array_unique(array_merge($explicitSubfleetIds, $fallbackSubfleetIds));
 
             if ($user_subfleets !== null) {
                 // If we have user subfleet restrictions, intersect with flight subfleets
                 $subfleetIds = array_intersect($subfleetIds, $user_subfleets);
             }
-
-            // Get airline IDs for this batch
-            // $airlineIds = collect($batch)->pluck('airline_id')->unique()->toArray();
 
             // Query aircraft for this batch
             $aircraftQuery = Aircraft::query()
@@ -326,19 +344,29 @@ class FlightController extends Controller
                 )
                 ->toArray();
 
+            // Build the subfleetIDs cache for this batch to avoid repeated queries
+            $onlyCompanyAircraft = setting('flights.only_company_aircraft', false);
+            $airlineSubfleetIdsCache = [];
+
+            $uniqueAirlineIds = $batch->pluck('airline_id')->unique()->toArray();
+            $subfleetRows = DB::table('subfleets')
+                ->when($onlyCompanyAircraft, fn($q) => $q->whereIn('airline_id', $uniqueAirlineIds))
+                ->select('id', 'airline_id')
+                ->get();
+
+            foreach ($uniqueAirlineIds as $airlineId) {
+                $airlineSubfleetIdsCache[$airlineId] = $onlyCompanyAircraft
+                    ? $subfleetRows->where('airline_id', $airlineId)->pluck('id')->toArray()
+                    : $subfleetRows->pluck('id')->toArray();
+            }
+
             // For each flight
             foreach ($batch as $flight) {
                 if ($flight->subfleets->isEmpty()) {
                     // NO subfleets assigned, count ALL aircraft for this airline at departure airport
                     // or check all aircraft according to settings
                     // Get all subfleets for this airline
-                    $airlineSubfleetIds = DB::table("subfleets")
-                        ->when(setting('flights.only_company_aircraft', false), function ($query) use ($flight) {
-                            return $query->where('airline_id', $flight->airline_id);
-                        })
-                        ->select('id')
-                        ->pluck('id')
-                        ->toArray();
+                    $airlineSubfleetIds = $airlineSubfleetIdsCache[$flight->airline_id] ?? [];
 
                     // Sum all aircraft counts for these subfleets at this airport
                     $count = 0;

--- a/app/Http/Controllers/Frontend/FlightController.php
+++ b/app/Http/Controllers/Frontend/FlightController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Frontend;
 use App\Contracts\Controller;
 use App\Models\Aircraft;
 use App\Models\Bid;
+use App\Models\Enums\AircraftStatus;
+use App\Models\Enums\AircraftState;
 use App\Models\Enums\FlightType;
 use App\Models\Flight;
 use App\Models\Typerating;
@@ -147,6 +149,10 @@ class FlightController extends Controller
             ->sortable('flight_number')->orderBy('route_code')->orderBy('route_leg')
             ->paginate();
 
+        // Count available aircraft for each flight in the result set
+        $ac_counts = $this->CountAvailableAircraftForFlights($flights);
+
+        // Get the user's saved flights (bids)
         $saved_flights = [];
         $bids = Bid::where('user_id', Auth::id())->get();
         foreach ($bids as $bid) {
@@ -161,6 +167,7 @@ class FlightController extends Controller
 
         return view('flights.index', [
             'user'          => $user,
+            'ac_counts'     => $ac_counts,
             'airlines'      => $this->airlineRepo->selectBoxList(true),
             'airports'      => [],
             'flights'       => $flights,
@@ -267,5 +274,85 @@ class FlightController extends Controller
             'bid'          => $bid,
             'acars_plugin' => $this->moduleSvc->isModuleActive('VMSAcars'),
         ]);
+    }
+
+    private function CountAvailableAircraftForFlights($flights): array
+    {
+        $counts = [];
+        $batchSize = 50;
+
+        foreach ($flights->chunk($batchSize) as $batch) {
+            // Collect unique airports and subfleets
+            $airportIds = $batch->pluck('dpt_airport_id')->unique()->toArray();
+            $subfleetIds = collect($batch)->flatMap(fn($f) => $f->subfleets->pluck('id'))->unique()->toArray();
+
+            // Get airline IDs for this batch
+            $airlineIds = collect($batch)->pluck('airline_id')->unique()->toArray();
+
+            // Query aircraft for this batch
+            $aircraftQuery = Aircraft::query()
+                ->where('status', AircraftStatus::ACTIVE)
+                ->where('state', AircraftState::PARKED)
+                ->whereIn('airport_id', $airportIds);
+
+            // Only add subfleet filter if we have subfleets
+            if (!empty($subfleetIds)) {
+                $aircraftQuery->whereIn('subfleet_id', $subfleetIds);
+            }
+
+            $aircraftData = $aircraftQuery
+                ->select(
+                    'airport_id',
+                    'subfleet_id',
+                    DB::raw('COUNT(*) as count'),
+                )
+                ->groupBy('airport_id', 'subfleet_id')
+                ->get()
+                ->groupBy('airport_id')
+                ->map(
+                    fn($airportAircrafts) => $airportAircrafts
+                        ->groupBy('subfleet_id')
+                        ->map(
+                            fn($subfleetGroup) => collect($subfleetGroup)->sum(
+                                'count',
+                            ),
+                        ),
+                )
+                ->toArray();
+
+            // For each flight
+            foreach ($batch as $flight) {
+                if ($flight->subfleets->isEmpty()) {
+                    // NO subfleets assigned, count ALL aircraft for this airline at departure airport
+                    // or check all aircraft according to settings
+                    // Get all subfleets for this airline
+                    $airlineSubfleetIds = DB::table("subfleets")
+                        ->when(setting('flights.only_company_aircraft', false), function ($query) use ($flight) {
+                            return $query->where('airline_id', $flight->airline_id);
+                        })
+                        ->select('id')
+                        ->pluck('id')
+                        ->toArray();
+
+                    // Sum all aircraft counts for these subfleets at this airport
+                    $count = 0;
+                    foreach ($airlineSubfleetIds as $sfId) {
+                        $count += $aircraftData[$flight->dpt_airport_id][$sfId] ?? 0;
+                    }
+                } else {
+                    // HAS subfleets, count only the members of the assigned subfleets for this flight at departure airport
+                    $count = 0;
+                    foreach ($flight->subfleets as $subfleet) {
+                        $subfleetCount =
+                            $aircraftData[$flight->dpt_airport_id][$subfleet->id] ?? 0;
+                        $count += $subfleetCount;
+                    }
+                }
+
+                $counts[$flight->id] = $count;
+            }
+        }
+
+        return $counts;
     }
 }


### PR DESCRIPTION
Process the paginated result, count available aircraft for each flight and return an array.

It can be used both for displaying the availabilities and/or to control Bid/SimBrief/Load in Acars buttons.

The view will have `$ac_counts` as an array, so in any theme blade it can be used easily like
`{{ $ac_counts[$flight->id] ?? 0 }}` 
or in some conditional checks like
`@if(isset($ac_counts[$flight->id]) && $ac_counts[$flight->id] > 0) ... @endif`

Closes #2038 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flight search results now display the number of available aircraft for each flight, based on active, parked aircraft at the departure airport.
  * Availability counts respect aircraft-type assignments and any user/company fleet filters, ensuring displayed counts match applicable fleet restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->