### PR TITLE
[7.x] fix(modules): null pointer in DatabaseActivator::setActive when enabling fresh module

### DIFF
--- a/app/Support/Modules/DatabaseActivator.php
+++ b/app/Support/Modules/DatabaseActivator.php
@@ -147,10 +147,11 @@ class DatabaseActivator implements ActivatorInterface
      */
     public function setActive(Module $module, bool $active): void
     {
-        $module = $this->getModuleByName($module->getName());
+        $name = $module->getName();
+        $module = $this->getModuleByName($name);
         if (!$module) {
             $module = \App\Models\Module::create([
-                'name' => $module->name,
+                'name' => $name,
             ]);
         }
 

--- a/tests/DatabaseActivatorTest.php
+++ b/tests/DatabaseActivatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests;
+
+use App\Models\Module as ModuleModel;
+use App\Support\Modules\DatabaseActivator;
+use Nwidart\Modules\Module as NwidartModule;
+
+class DatabaseActivatorTest extends TestCase
+{
+    public function test_enable_creates_modules_row_when_none_exists(): void
+    {
+        $name = 'PhpvmsRegressionFixtureModule';
+
+        $this->assertFalse(
+            ModuleModel::where('name', $name)->exists(),
+            'Test setup invariant violated: row already exists.'
+        );
+
+        $nwidartModule = $this->getMockBuilder(NwidartModule::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['registerAliases', 'registerProviders', 'getCachedServicesPath', 'getName'])
+            ->getMock();
+        $nwidartModule->method('getName')->willReturn($name);
+
+        $activator = app(DatabaseActivator::class);
+
+        $activator->enable($nwidartModule);
+
+        $this->assertTrue(
+            ModuleModel::where('name', $name)->where('enabled', true)->exists(),
+            'Expected DatabaseActivator::enable() to create + enable a modules row.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`DatabaseActivator::setActive()` reassigns the local `$module` variable from the Nwidart `Module` parameter to the result of `getModuleByName()`. When no row exists yet in the `modules` table — i.e. the first time a freshly installed module is enabled — the lookup returns null, and the subsequent `Module::create(['name' => $module->name])` call dereferences null, throwing:

> Attempt to read property "name" on null

This blocks `php artisan module:enable <Name>` for any module that hasn't been registered in the DB yet, which is exactly the path the admin UI's *Add New Module → Enable* flow takes for a fresh install.

## Fix

Capture the name from the parameter before the reassignment, so the create call references the original Nwidart module's name:

```diff
 public function setActive(Module $module, bool $active): void
 {
-    $module = $this->getModuleByName($module->getName());
+    $name = $module->getName();
+    $module = $this->getModuleByName($name);
     if (!$module) {
         $module = \App\Models\Module::create([
-            'name' => $module->name,
+            'name' => $name,
         ]);
     }

     $module->enabled = $active;
     $module->save();
 }
```

The same shadowing pattern exists in `hasStatus()` and `setActiveByName()`, but neither references the original parameter after the reassignment, so only `setActive()` actually breaks.

## Test plan

- [x] Added `tests/DatabaseActivatorTest.php` — a regression test that builds a partial mock of `Nwidart\Modules\Module`, calls `enable()` on a name not in the `modules` table, and asserts the row is created with `enabled = true`. Fails on `releases/7.0` HEAD with the null-deref above; passes with the fix.
- [x] `./vendor/bin/phpunit --filter test_enable_creates_modules_row_when_none_exists` — green.
- [x] `./vendor/bin/pint app/Support/Modules/DatabaseActivator.php tests/DatabaseActivatorTest.php` — clean against the project's `pint.json`.
- [x] Reproduced the failure end-to-end against a real install (`php artisan module:enable <NewModule>` on a clean modules table) before and after the fix.
