### PR TITLE
[7.x] fix(modules): bust nwidart manifest cache on install + activator mutation

### DIFF
--- a/app/Services/ModuleService.php
+++ b/app/Services/ModuleService.php
@@ -7,6 +7,7 @@ use App\Exceptions\ModuleExistsException;
 use App\Exceptions\ModuleInstallationError;
 use App\Exceptions\ModuleInvalidFileType;
 use App\Models\Module;
+use App\Support\Modules\DatabaseActivator;
 use Exception;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
@@ -142,6 +143,8 @@ class ModuleService extends Service
                 'name'    => $module_name,
                 'enabled' => 1,
             ]);
+
+            DatabaseActivator::flushCaches($module_name);
 
             try {
                 Artisan::call('module:migrate', ['module' => $module_name, '--force' => true]);

--- a/app/Support/Modules/DatabaseActivator.php
+++ b/app/Support/Modules/DatabaseActivator.php
@@ -157,6 +157,8 @@ class DatabaseActivator implements ActivatorInterface
 
         $module->enabled = $active;
         $module->save();
+
+        self::flushCaches($name);
     }
 
     /**
@@ -171,6 +173,8 @@ class DatabaseActivator implements ActivatorInterface
 
         $module->enabled = $status;
         $module->save();
+
+        self::flushCaches($name);
     }
 
     /**
@@ -188,6 +192,24 @@ class DatabaseActivator implements ActivatorInterface
             Log::error('Module '.$module.' Delete failed! Exception : '.$e->getMessage());
 
             return;
+        }
+
+        self::flushCaches($name);
+    }
+
+    public static function flushCaches(string $name): void
+    {
+        if (app()->environment('production')) {
+            $cache = config('cache.keys.MODULES');
+            if ($cache) {
+                Cache::forget($cache['key']);
+                Cache::forget($cache['key'].'.'.$name);
+            }
+        }
+
+        $nwidartKey = config('modules.cache.key');
+        if ($nwidartKey) {
+            Cache::store(config('modules.cache.driver'))->forget($nwidartKey);
         }
     }
 }

--- a/tests/ModuleServiceCacheTest.php
+++ b/tests/ModuleServiceCacheTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests;
+
+use App\Services\ModuleService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Nwidart\Modules\Facades\Module as NwidartModuleFacade;
+
+class ModuleServiceCacheTest extends TestCase
+{
+    public function test_add_module_makes_freshly_deposited_module_findable(): void
+    {
+        $name = 'PhpvmsCacheBustingFixtureModule';
+        $moduleDir = base_path('modules/'.$name);
+        $cacheKey = config('modules.cache.key');
+        $cacheStore = Cache::store(config('modules.cache.driver'));
+
+        if (File::exists($moduleDir)) {
+            File::deleteDirectory($moduleDir);
+        }
+
+        try {
+            $cacheStore->put($cacheKey, [
+                'Sample' => ['path' => base_path('modules/Sample')],
+            ], 3600);
+
+            File::makeDirectory($moduleDir, 0777, true);
+            file_put_contents($moduleDir.'/module.json', json_encode([
+                'name'        => $name,
+                'alias'       => strtolower($name),
+                'description' => '',
+                'keywords'    => [],
+                'active'      => 1,
+                'order'       => 0,
+                'providers'   => [],
+                'aliases'     => (object) [],
+                'files'       => [],
+                'requires'    => [],
+            ]));
+
+            $this->assertNull(
+                NwidartModuleFacade::find($name),
+                'Test premise broken: stale cache should hide the new module from Nwidart::find.'
+            );
+
+            app(ModuleService::class)->addModule($name);
+
+            $this->assertNotNull(
+                NwidartModuleFacade::find($name),
+                'addModule must invalidate the phpvms-modules cache so the just-deposited module is findable by the very next module:migrate.'
+            );
+        } finally {
+            if (File::exists($moduleDir)) {
+                File::deleteDirectory($moduleDir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Uploading a module zip via `admin/modules` throws `ModuleNotFoundException: Module [X] does not exist!` even though the directory is sitting in `modules/` immediately after the upload — and running `optimize:clear` between attempts doesn't fix it.

### Root cause

`ModuleService::installModule` runs through this sequence in a single request:

1. **Request boot**: `LaravelModulesServiceProvider` -> `FileRepository::register` -> `getOrdered` -> `allEnabled` -> `all` -> `getCached` populates the `phpvms-modules` cache (6h TTL, `config/modules.php`) with whatever was on disk at boot time.
2. **`File::moveDirectory`** drops the new module into `modules/`.
3. **`addModule`** inserts the DB row, then `Artisan::call('module:migrate', ['module' => $name, ...])`.
4. **`MigrateCommand::handle`** -> `findOrFail($name)` -> `find` -> `all` -> reads the step-1 snapshot, doesn't see the just-moved module, throws.

`optimize:clear` clears the file cache between requests, but it doesn't help: the very next upload request re-snapshots the (still pre-move) on-disk set during boot before `installModule` runs.

### Fix

- New `DatabaseActivator::flushCaches(string $name)` public static helper that forgets both the `phpvms-modules` (nwidart) and the production-only `MODULES` (phpVMS) cache keys.
- Called from `ModuleService::addModule` between the DB insert and `Artisan::call('module:migrate', ...)` so `findOrFail` re-scans disk.
- Also called from the activator's own `setActive` / `setActiveByName` / `delete`, since those mutate the modules table but were leaving the same caches stale on enable / disable / delete paths.

Covers both upload (`ModulesController::store` -> `installModule` -> `addModule`) and enable-existing-on-disk (`ModulesController::enable` -> `addModule`), which funnel through the same method.

### Reproducer

`tests/ModuleServiceCacheTest.php` pins a stale `phpvms-modules` snapshot, drops a real `module.json` on disk, calls `addModule`, asserts `Nwidart::find` now returns the module. Without the flush call, the assertion fails with `null` — the same lookup failure the production stack trace shows.

## Test plan

- [x] `vendor/bin/phpunit tests/ModuleServiceCacheTest.php` — new test passes
- [x] `vendor/bin/phpunit tests/ModuleServiceCacheTest.php` with `flushCaches` call removed — fails on the post-`addModule` assertion (proves the test exercises the bug)
- [x] `vendor/bin/phpunit tests/DatabaseActivatorTest.php` — existing activator test still passes
- [x] Manual: upload a module zip via `admin/modules` end-to-end on a clean install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Module cache is now properly invalidated when modules are installed, enabled, disabled, or deleted, ensuring changes take effect immediately.

* **Tests**
  * Added test to verify module cache invalidation during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phpvms/phpvms/pull/2213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->