### PR TITLE
refactor: migrate to Laravel 13 attribute syntax

### DIFF
--- a/app/Console/Commands/CreateDatabase.php
+++ b/app/Console/Commands/CreateDatabase.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\DB;
@@ -12,16 +13,12 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use function Laravel\Prompts\confirm;
 
 #[AsCommand(name: 'db:create', description: 'Create a new database based on your configuration')]
-class CreateDatabase extends Command
-{
-    /**
-     * The console command signature.
-     */
-    protected $signature = 'db:create 
+#[Signature('db:create 
                             {--reset : Drop the database before creating it} 
                             {--force : Force the operation to run without prompts} 
-                            {--connection= : The database connection to use}';
-
+                            {--connection= : The database connection to use}')]
+class CreateDatabase extends Command
+{
     public function __construct(private readonly Filesystem $file)
     {
         parent::__construct();

--- a/app/Console/Commands/DevInstall.php
+++ b/app/Console/Commands/DevInstall.php
@@ -4,21 +4,18 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\confirm;
 
 #[AsCommand(name: 'phpvms:dev-install', description: 'Create a fresh development install and run the sample migration')]
+#[Signature('phpvms:dev-install 
+                            {--reset-db : Completely drop and recreate the database}
+                            {--force : Force the operation to run without prompts}')]
 class DevInstall extends Command
 {
-    /**
-     * The console command signature.
-     */
-    protected $signature = 'phpvms:dev-install 
-                            {--reset-db : Completely drop and recreate the database}
-                            {--force : Force the operation to run without prompts}';
-
     /**
      * Execute the console command.
      */

--- a/app/Console/Commands/EmailTest.php
+++ b/app/Console/Commands/EmailTest.php
@@ -5,17 +5,14 @@ namespace App\Console\Commands;
 use App\Events\NewsAdded;
 use App\Listeners\NotificationsSubscriber;
 use App\Models\News;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'phpvms:email-test', description: 'Send a test notification to admins')]
+#[Signature('phpvms:email-test')]
 class EmailTest extends Command
 {
-    /**
-     * The console command signature.
-     */
-    protected $signature = 'phpvms:email-test';
-
     /**
      * Execute the console command.
      */

--- a/app/Console/Commands/ImportFromClassicCommand.php
+++ b/app/Console/Commands/ImportFromClassicCommand.php
@@ -4,23 +4,20 @@ namespace App\Console\Commands;
 
 use App\Services\LegacyImporterService;
 use Exception;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'phpvms:importer', description: 'Import data from an older version of phpVMS')]
-class ImportFromClassicCommand extends Command
-{
-    /**
-     * The console command signature.
-     */
-    protected $signature = 'phpvms:importer 
+#[Signature('phpvms:importer 
                             {db_host : The legacy database host} 
                             {db_name : The legacy database name} 
                             {db_user : The legacy database user} 
                             {db_pass? : The legacy database password} 
-                            {table_prefix=phpvms_ : The legacy database table prefix}';
-
+                            {table_prefix=phpvms_ : The legacy database table prefix}')]
+class ImportFromClassicCommand extends Command
+{
     /**
      * Execute the console command.
      */

--- a/app/Console/Commands/ModuleSetupFilament.php
+++ b/app/Console/Commands/ModuleSetupFilament.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Console\Concerns\PromptsForMissingInput;
 use Illuminate\Contracts\Console\PromptsForMissingInput as PromptsForMissingInputContract;
@@ -11,14 +12,10 @@ use Nwidart\Modules\Module;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'module:setup-filament', description: 'Add Filament Support to a Module')]
+#[Signature('module:setup-filament {module : The name of the module}')]
 class ModuleSetupFilament extends Command implements PromptsForMissingInputContract
 {
     use PromptsForMissingInput;
-
-    /**
-     * The console command signature.
-     */
-    protected $signature = 'module:setup-filament {module : The name of the module}';
 
     protected string $basePath = 'Providers/Filament';
 

--- a/app/Console/Commands/PreserveHiddenVisibility.php
+++ b/app/Console/Commands/PreserveHiddenVisibility.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Models\Flight;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 
+#[Description('One-shot: disable flights that were previously hidden (visible=false), preserving admin intent post-visibility-rename')]
+#[Signature('phpvms:preserve-hidden-visibility')]
 class PreserveHiddenVisibility extends Command
 {
-    protected $signature = 'phpvms:preserve-hidden-visibility';
-
-    protected $description = 'One-shot: disable flights that were previously hidden (visible=false), preserving admin intent post-visibility-rename';
-
     public function handle(): int
     {
         $affected = Flight::query()

--- a/app/Console/Commands/Version.php
+++ b/app/Console/Commands/Version.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Services\VersionService;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -12,17 +13,13 @@ use Version\Extension\PreRelease;
 use Version\Version as SemanticVersion;
 
 #[AsCommand(name: 'phpvms:version', description: 'Get or update the current application version')]
-class Version extends Command
-{
-    /**
-     * The console command signature.
-     */
-    protected $signature = 'phpvms:version 
+#[Signature('phpvms:version 
                             {version? : The semantic version string to apply}
                             {--write : Write the updated version/build number to the version.yml file} 
                             {--base-only : Only output the base version without build metadata} 
-                            {--write-full-version : Update the major, minor, and patch values in the file}';
-
+                            {--write-full-version : Update the major, minor, and patch values in the file}')]
+class Version extends Command
+{
     /**
      * Execute the console command.
      */

--- a/app/Models/Acars.php
+++ b/app/Models/Acars.php
@@ -9,6 +9,7 @@ use App\Enums\AcarsType;
 use App\Enums\NavaidType;
 use App\Traits\HashIdTrait;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -82,6 +83,7 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
+#[WithoutIncrementing]
 class Acars extends Model
 {
     use HasFactory;
@@ -118,8 +120,6 @@ class Acars extends Model
         'created_at',
         'updated_at',
     ];
-
-    public $incrementing = false;
 
     protected $appends = ['altitude'];
 

--- a/app/Models/Airport.php
+++ b/app/Models/Airport.php
@@ -8,6 +8,8 @@ use App\Traits\ExpensableTrait;
 use App\Traits\FilesTrait;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
@@ -94,6 +96,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @mixin \Eloquent
  */
 #[ObservedBy(AirportObserver::class)]
+#[WithoutIncrementing]
+#[WithoutTimestamps]
 class Airport extends Model
 {
     use ExpensableTrait;
@@ -106,10 +110,6 @@ class Airport extends Model
     public $table = 'airports';
 
     protected $keyType = 'string';
-
-    public $incrementing = false;
-
-    public $timestamps = false;
 
     protected $fillable = [
         'id',

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Traits\HashIdTrait;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Carbon;
@@ -45,6 +46,7 @@ use Illuminate\Support\Str;
  *
  * @mixin \Eloquent
  */
+#[WithoutIncrementing]
 class File extends Model
 {
     use HasFactory;
@@ -53,8 +55,6 @@ class File extends Model
     public $table = 'files';
 
     protected $keyType = 'string';
-
-    public $incrementing = false;
 
     protected $fillable = [
         'id',

--- a/app/Models/FlightField.php
+++ b/app/Models/FlightField.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Traits\HasSlug;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Str;
@@ -25,14 +26,13 @@ use Illuminate\Support\Str;
  *
  * @mixin \Eloquent
  */
+#[WithoutTimestamps]
 class FlightField extends Model
 {
     use HasFactory;
     use HasSlug;
 
     public $table = 'flight_fields';
-
-    public $timestamps = false;
 
     protected $fillable = [
         'name',

--- a/app/Models/JournalTransaction.php
+++ b/app/Models/JournalTransaction.php
@@ -10,6 +10,7 @@ namespace App\Models;
 use App\Contracts\Model;
 use App\Observers\JournalTransactionObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -50,13 +51,12 @@ use Illuminate\Support\Carbon;
  * @mixin \Eloquent
  */
 #[ObservedBy(JournalTransactionObserver::class)]
+#[WithoutIncrementing]
 class JournalTransaction extends Model
 {
     use HasFactory;
 
     protected $table = 'journal_transactions';
-
-    public $incrementing = false;
 
     protected $fillable = [
         'transaction_group',

--- a/app/Models/Kvp.php
+++ b/app/Models/Kvp.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 
 /**
  * @property string $key
@@ -18,13 +20,11 @@ use App\Contracts\Model;
  *
  * @mixin \Eloquent
  */
+#[WithoutIncrementing]
+#[WithoutTimestamps]
 class Kvp extends Model
 {
     public $table = 'kvp';
-
-    public $timestamps = false;
-
-    public $incrementing = false;
 
     protected $keyType = 'string';
 

--- a/app/Models/Navdata.php
+++ b/app/Models/Navdata.php
@@ -6,6 +6,8 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Enums\NavaidType;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -30,6 +32,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  *
  * @mixin \Eloquent
  */
+#[WithoutIncrementing]
+#[WithoutTimestamps]
 class Navdata extends Model
 {
     use HasFactory;
@@ -37,10 +41,6 @@ class Navdata extends Model
     public $table = 'navdata';
 
     protected $keyType = 'string';
-
-    public $timestamps = false;
-
-    public $incrementing = false;
 
     protected $fillable = [
         'id',

--- a/app/Models/Pirep.php
+++ b/app/Models/Pirep.php
@@ -15,6 +15,7 @@ use App\Enums\PirepStatus;
 use App\Events\PirepStateChange;
 use App\Events\PirepStatusChange;
 use App\Traits\HashIdTrait;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
@@ -150,6 +151,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *
  * @mixin \Eloquent
  */
+#[WithoutIncrementing]
 class Pirep extends Model
 {
     use AttributeEvents;
@@ -163,8 +165,6 @@ class Pirep extends Model
     public $table = 'pireps';
 
     protected $keyType = 'string';
-
-    public $incrementing = false;
 
     /** The form wants this */
     public $hours;

--- a/app/Models/PirepFare.php
+++ b/app/Models/PirepFare.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Enums\FareType;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -38,11 +39,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @mixin \Eloquent
  */
+#[WithoutTimestamps]
 class PirepFare extends Model
 {
     public $table = 'pirep_fares';
-
-    public $timestamps = false;
 
     protected $fillable = [
         'pirep_id',

--- a/app/Models/PirepField.php
+++ b/app/Models/PirepField.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Contracts\Model;
 use App\Enums\PirepFieldSource;
 use App\Traits\HasSlug;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
@@ -34,14 +35,13 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *
  * @mixin \Eloquent
  */
+#[WithoutTimestamps]
 class PirepField extends Model
 {
     use HasSlug;
     use LogsActivity;
 
     public $table = 'pirep_fields';
-
-    public $timestamps = false;
 
     protected $fillable = [
         'name',

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -6,6 +6,7 @@ use App\Contracts\Model;
 use App\Observers\SettingObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
@@ -52,6 +53,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @mixin \Eloquent
  */
 #[ObservedBy(SettingObserver::class)]
+#[WithoutIncrementing]
 class Setting extends Model
 {
     use LogsActivity;
@@ -59,8 +61,6 @@ class Setting extends Model
     public $table = 'settings';
 
     protected $keyType = 'string';
-
-    public $incrementing = false;
 
     protected $fillable = [
         'name',

--- a/app/Models/SimBrief.php
+++ b/app/Models/SimBrief.php
@@ -6,6 +6,7 @@ use App\Contracts\Model;
 use App\Observers\SimBriefObserver;
 use App\Support\Dto\SimBriefOfp\SimBriefOfp;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -48,13 +49,12 @@ use Illuminate\Support\Facades\Storage;
  * @mixin \Eloquent
  */
 #[ObservedBy(SimBriefObserver::class)]
+#[WithoutIncrementing]
 class SimBrief extends Model
 {
     use HasFactory;
 
     public $table = 'simbrief';
-
-    public $incrementing = false;
 
     protected $fillable = [
         'id',


### PR DESCRIPTION
Apply rector's Laravel13 set:

- 12 models: $incrementing/$timestamps properties -> #[WithoutIncrementing] / #[WithoutTimestamps] attributes
- 7 console commands: $signature property -> #[Signature(...)] attribute

Mechanical changes via 'vendor/bin/rector process'. No behavior changes. All gates green: pint, phpstan, rector dry-run clean post-fix.

Out-of-scope to the route-forge change; landed separately so the RouteForge PR diff stays focused on the new feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated console command declarations to modern PHP attribute-based signatures for improved code organization.
  * Updated application models to use modern PHP attributes for configuration instead of traditional properties while preserving all existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phpvms/phpvms/pull/2220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->