### PR TITLE
[7.x] fix(simbrief): write OFP aircraft back to the user's bid

### DIFF
--- a/app/Services/SimBriefService.php
+++ b/app/Services/SimBriefService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Contracts\Service;
 use App\Models\Acars;
+use App\Models\Bid;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\AirframeSource;
 use App\Models\Pirep;
@@ -100,10 +101,40 @@ class SimBriefService extends Service
         }
 
         // Save this into the Simbrief table, if it doesn't already exist
-        return SimBrief::updateOrCreate(
+        $simbrief = SimBrief::updateOrCreate(
             ['id' => $ofp_id],
             $attrs
         );
+
+        // Sync the aircraft the OFP was generated with back to the user's bid
+        $this->syncBidAircraft($user_id, $flight_id, $ac_id);
+
+        return $simbrief;
+    }
+
+    /**
+     * Update the user's bid for a flight (if one exists) with the aircraft
+     * the OFP was generated with, so the bid always reflects the briefing
+     */
+    private function syncBidAircraft(string $user_id, string $flight_id, string $ac_id): void
+    {
+        $bid = Bid::where(['user_id' => $user_id, 'flight_id' => $flight_id])->first();
+        if (!$bid || $bid->aircraft_id === (int) $ac_id) {
+            return;
+        }
+
+        // Respect aircraft blocking, don't take an aircraft another bid already holds
+        if (setting('bids.block_aircraft')) {
+            $blocked = Bid::where('aircraft_id', $ac_id)->where('id', '!=', $bid->id)->exists();
+            if ($blocked) {
+                Log::info('SimBrief | Bid aircraft sync skipped, aircraft='.$ac_id.' is held by another bid');
+
+                return;
+            }
+        }
+
+        $bid->aircraft_id = $ac_id;
+        $bid->save();
     }
 
     /**

--- a/tests/SimBriefTest.php
+++ b/tests/SimBriefTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use App\Models\Acars;
 use App\Models\Aircraft;
+use App\Models\Bid;
 use App\Models\Enums\AcarsType;
 use App\Models\Enums\FareType;
 use App\Models\Enums\UserState;
@@ -267,6 +268,114 @@ final class SimBriefTest extends TestCase
         $subfleet = $body['flight']['simbrief']['subfleet'];
         $this->assertEquals($fares[0]['id'], $subfleet['fares'][0]['id']);
         $this->assertEquals($fares[0]['count'], $subfleet['fares'][0]['count']);
+    }
+
+    /**
+     * The aircraft used to generate the OFP is written back to the user's bid
+     *
+     * @throws \Exception
+     */
+    public function test_ofp_download_writes_aircraft_to_bid(): void
+    {
+        $userinfo = $this->createUserData();
+        $this->user = $userinfo['user'];
+        $aircraft = $userinfo['aircraft']->first();
+
+        /** @var Flight $flight */
+        $flight = Flight::factory()->create();
+
+        $bid = Bid::create([
+            'user_id'   => $this->user->id,
+            'flight_id' => $flight->id,
+        ]);
+
+        $this->downloadOfp($this->user, $flight, $aircraft, []);
+
+        $bid->refresh();
+        $this->assertEquals($aircraft->id, $bid->aircraft_id);
+    }
+
+    /**
+     * A bid holding a different aircraft is synced to the aircraft the OFP
+     * was generated with
+     *
+     * @throws \Exception
+     */
+    public function test_ofp_download_overwrites_stale_bid_aircraft(): void
+    {
+        $userinfo = $this->createUserData();
+        $this->user = $userinfo['user'];
+        $old_aircraft = $userinfo['aircraft'][0];
+        $new_aircraft = $userinfo['aircraft'][1];
+
+        /** @var Flight $flight */
+        $flight = Flight::factory()->create();
+
+        $bid = Bid::create([
+            'user_id'     => $this->user->id,
+            'flight_id'   => $flight->id,
+            'aircraft_id' => $old_aircraft->id,
+        ]);
+
+        $this->downloadOfp($this->user, $flight, $new_aircraft, []);
+
+        $bid->refresh();
+        $this->assertEquals($new_aircraft->id, $bid->aircraft_id);
+    }
+
+    /**
+     * With bids.block_aircraft enabled, the bid is left untouched when another
+     * bid already holds the OFP aircraft
+     *
+     * @throws \Exception
+     */
+    public function test_ofp_download_skips_bid_sync_when_aircraft_blocked(): void
+    {
+        $this->updateSetting('bids.block_aircraft', true);
+
+        $userinfo = $this->createUserData();
+        $this->user = $userinfo['user'];
+        $aircraft = $userinfo['aircraft']->first();
+
+        // Another user's bid already holds this aircraft
+        $other_user = User::factory()->create();
+        $other_flight = Flight::factory()->create();
+        Bid::create([
+            'user_id'     => $other_user->id,
+            'flight_id'   => $other_flight->id,
+            'aircraft_id' => $aircraft->id,
+        ]);
+
+        /** @var Flight $flight */
+        $flight = Flight::factory()->create();
+
+        $bid = Bid::create([
+            'user_id'   => $this->user->id,
+            'flight_id' => $flight->id,
+        ]);
+
+        $this->downloadOfp($this->user, $flight, $aircraft, []);
+
+        $bid->refresh();
+        $this->assertNull($bid->aircraft_id);
+    }
+
+    /**
+     * Downloading an OFP without a bid on the flight never creates a bid
+     *
+     * @throws \Exception
+     */
+    public function test_ofp_download_without_bid_creates_no_bid(): void
+    {
+        $userinfo = $this->createUserData();
+        $this->user = $userinfo['user'];
+
+        /** @var Flight $flight */
+        $flight = Flight::factory()->create();
+
+        $this->downloadOfp($this->user, $flight, $userinfo['aircraft']->first(), []);
+
+        $this->assertEquals(0, Bid::count());
     }
 
     /**


### PR DESCRIPTION
## Summary

When a pilot generates a SimBrief OFP, the selected aircraft is saved only to the `simbrief` table — the user's bid for the same flight keeps a `null` (or stale) `aircraft_id`. The bid is read to *seed* the aircraft selection in `SimBriefController::generate()`, but the choice never flows back.

This adds a sync in `SimBriefService::downloadOfp()` (single choke point covering both initial generation via `check_ofp()` and OFP updates via `update_ofp()`):

- If the user has a bid on the flight, its `aircraft_id` is synced to the aircraft the OFP was generated with (fills null, overwrites stale).
- With `bids.block_aircraft` enabled, the sync is skipped (and logged) if another bid already holds the aircraft — mirroring `BidService::addBid()`, but non-fatal since the OFP already exists.
- No bid is ever created by the sync; the briefing flow is never interrupted.

## Test Plan

- [x] `test_ofp_download_writes_aircraft_to_bid` — bid with null aircraft gets populated
- [x] `test_ofp_download_overwrites_stale_bid_aircraft` — bid holding a different aircraft is synced to the OFP aircraft
- [x] `test_ofp_download_skips_bid_sync_when_aircraft_blocked` — with `bids.block_aircraft`, a bid is left untouched when another bid holds the aircraft
- [x] `test_ofp_download_without_bid_creates_no_bid` — no bid is created when none exists
- [x] Full `SimBriefTest` + `BidTest` suites pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flight planning operations now automatically synchronize aircraft assignments back to associated user bids, with built-in conflict prevention when aircraft are reserved by other bookings.

* **Tests**
  * Added four new test cases validating aircraft synchronization behavior during flight planning, including successful syncs, aircraft updates, conflict prevention, and scenarios without associated bids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->