### PR TITLE
[8.x] fix(routing): register module routes last to allow core overrides

### DIFF
--- a/app/Contracts/Modules/ServiceProvider.php
+++ b/app/Contracts/Modules/ServiceProvider.php
@@ -163,29 +163,32 @@ abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     private function registerRoutes(): void
     {
-        $root = $this->addonBasePath();
+        // Register routes at the end of the boot process so that they can override core's routes.
+        $this->app->booted(function (): void {
+            $root = $this->addonBasePath();
 
-        $webRoutes = $root.'/routes/web.php';
+            $webRoutes = $root.'/routes/web.php';
 
-        if (file_exists($webRoutes)) {
-            $this->loadRoutesFrom($webRoutes);
-        }
-
-        $apiRoutes = $root.'/routes/api.php';
-
-        if (file_exists($apiRoutes)) {
-            $this->loadRoutesFrom($apiRoutes);
-        }
-
-        // Only load console routes in the console context — a bare require on
-        // every HTTP worker boot would execute side-effecting closure code.
-        if ($this->app->runningInConsole()) {
-            $consoleRoutes = $root.'/routes/console.php';
-
-            if (file_exists($consoleRoutes)) {
-                require $consoleRoutes;
+            if (file_exists($webRoutes)) {
+                $this->loadRoutesFrom($webRoutes);
             }
-        }
+
+            $apiRoutes = $root.'/routes/api.php';
+
+            if (file_exists($apiRoutes)) {
+                $this->loadRoutesFrom($apiRoutes);
+            }
+
+            // Only load console routes in the console context — a bare require on
+            // every HTTP worker boot would execute side-effecting closure code.
+            if ($this->app->runningInConsole()) {
+                $consoleRoutes = $root.'/routes/console.php';
+
+                if (file_exists($consoleRoutes)) {
+                    require $consoleRoutes;
+                }
+            }
+        });
     }
 
     /**

--- a/app/Contracts/Modules/ServiceProvider.php
+++ b/app/Contracts/Modules/ServiceProvider.php
@@ -160,10 +160,15 @@ abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     /**
      * Load web, api, and console route files when present.
+     *
+     * Routes are loaded from a deferred `booted()` callback so they register
+     * after core's routes, allowing addons to override core endpoints. Because
+     * this runs after the framework's own name/action lookup refresh, we rebuild
+     * those lookups here so addon routes stay resolvable via `route()` and
+     * `Route::has()` (mirrors Laravel's RouteServiceProvider).
      */
     private function registerRoutes(): void
     {
-        // Register routes at the end of the boot process so that they can override core's routes.
         $this->app->booted(function (): void {
             $root = $this->addonBasePath();
 
@@ -188,6 +193,10 @@ abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
                     require $consoleRoutes;
                 }
             }
+
+            $routes = $this->app['router']->getRoutes();
+            $routes->refreshNameLookups();
+            $routes->refreshActionLookups();
         });
     }
 

--- a/tests/Feature/Addons/BaseAddonServiceProviderTest.php
+++ b/tests/Feature/Addons/BaseAddonServiceProviderTest.php
@@ -57,17 +57,14 @@ function registerFixturePsr4(): void
  * each time. Laravel deduplicates by class, so calling this is idempotent
  * within a single app instance.
  *
- * Calls refreshNameLookups() after registration because routes added via
- * loadRoutesFrom() after the framework boot phase are not automatically
- * indexed into the route name lookup table.
+ * The provider loads its routes from a deferred booted() callback and refreshes
+ * the name/action lookups itself, so addon routes are resolvable here without
+ * the test having to rebuild the lookup tables.
  */
 function registerFixtureAddon(): void
 {
     registerFixturePsr4();
     app()->register(AcmeServiceProvider::class);
-
-    // Routes added post-boot are not auto-indexed; refresh the name lookup.
-    Route::getRoutes()->refreshNameLookups();
 
     // Commands registered via $this->commands() use Artisan::starting() callbacks,
     // which only fire when the Artisan Console Application is first created. During


### PR DESCRIPTION
Defers module route registration to the end of the routing stack. This fixes the issue where core routes were matching first and blocking module-level overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deferred loading of addon route files until the application completes booting, improving startup performance and ensuring routes are registered at the right lifecycle stage.
  * Refreshed route name and action lookups after addon route registration to keep route resolution consistent.
* **Tests**
  * Updated addon service provider test setup to rely on the new deferred boot behavior, removing now-unnecessary manual route lookup refresh calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->