### PR TITLE
fix: change the plugin directory name 

### DIFF
--- a/app/Addons/AddonRegistry.php
+++ b/app/Addons/AddonRegistry.php
@@ -18,7 +18,6 @@ use App\Services\Installer\MigrationService;
 use App\Services\Installer\SeederService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 
 /**
  * Lifecycle façade for addons. Owns reads (find/all/enabled), enable/disable,
@@ -288,7 +287,8 @@ class AddonRegistry
             }
         }
 
-        $safe = Str::studly((string) preg_replace('/[^A-Za-z]+/', ' ', $manifest->name));
+        $safe = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $manifest->name));
+        $safe = trim($safe, '-');
 
         if ($safe === '') {
             throw new AddonInstallException(sprintf('Invalid addon name: %s', $manifest->name));

--- a/app/Addons/AddonRegistry.php
+++ b/app/Addons/AddonRegistry.php
@@ -185,7 +185,7 @@ class AddonRegistry
 
         try {
             $manifest = $this->validator->validate($extracted);
-            $dest = config('addons.paths.base').'/'.$this->safeName($manifest->name);
+            $dest = config('addons.paths.base').'/'.$this->safeName($manifest);
 
             if (File::exists($dest)) {
                 throw new AddonInstallException(sprintf('Addon already installed: %s', $manifest->name));
@@ -229,7 +229,7 @@ class AddonRegistry
 
         try {
             $manifest = $this->validator->validate($extracted);
-            $dest = config('addons.paths.base').'/'.$this->safeName($manifest->name);
+            $dest = config('addons.paths.base').'/'.$this->safeName($manifest);
 
             File::deleteDirectory($dest);
 
@@ -266,20 +266,32 @@ class AddonRegistry
     }
 
     /**
-     * Derive a filesystem-safe directory name from an addon's manifest name.
+     * Derive a filesystem-safe directory name from an addon manifest.
      *
-     * Strips everything that is not an ASCII letter and forces StudlyCase, so a
-     * crafted manifest name (e.g. "../../app") can never escape the addons base
-     * directory when used as a path segment.
+     * When a registry_id is present (managed addons), converts it to a
+     * lowercase slug: slashes become hyphens, non-alphanumeric/hyphen chars
+     * are stripped. A registry_id of "phpvms/vmsacars" produces "phpvms-vmsacars".
      *
-     * @throws AddonInstallException when no letters remain after sanitisation
+     * Falls back to StudlyCase from the manifest name for unmanaged addons, so
+     * a crafted name (e.g. "../../app") can never escape the addons base directory.
+     *
+     * @throws AddonInstallException when no safe characters remain after sanitisation
      */
-    private function safeName(string $name): string
+    private function safeName(AddonManifest $manifest): string
     {
-        $safe = Str::studly((string) preg_replace('/[^A-Za-z]+/', ' ', $name));
+        if ($manifest->registryId !== null) {
+            $safe = strtolower((string) preg_replace('/[^A-Za-z0-9\-]+/', '-', str_replace('/', '-', $manifest->registryId)));
+            $safe = trim($safe, '-');
+
+            if ($safe !== '') {
+                return $safe;
+            }
+        }
+
+        $safe = Str::studly((string) preg_replace('/[^A-Za-z]+/', ' ', $manifest->name));
 
         if ($safe === '') {
-            throw new AddonInstallException(sprintf('Invalid addon name: %s', $name));
+            throw new AddonInstallException(sprintf('Invalid addon name: %s', $manifest->name));
         }
 
         return $safe;

--- a/app/Addons/AddonRegistry.php
+++ b/app/Addons/AddonRegistry.php
@@ -268,27 +268,25 @@ class AddonRegistry
      * Derive a filesystem-safe directory name from an addon manifest.
      *
      * When a registry_id is present (managed addons), converts it to a
-     * lowercase slug: slashes become hyphens, non-alphanumeric/hyphen chars
-     * are stripped. A registry_id of "phpvms/vmsacars" produces "phpvms-vmsacars".
+     * lowercase slug via keyed_str(): slashes become hyphens, non-alphanumeric
+     * chars are stripped. A registry_id of "phpvms/vmsacars" produces "phpvms-vmsacars".
      *
-     * Falls back to StudlyCase from the manifest name for unmanaged addons, so
-     * a crafted name (e.g. "../../app") can never escape the addons base directory.
+     * Falls back to keyed_str() on the manifest name for unmanaged addons,
+     * ensuring the same sanitisation guarantee in both paths.
      *
      * @throws AddonInstallException when no safe characters remain after sanitisation
      */
     private function safeName(AddonManifest $manifest): string
     {
         if ($manifest->registryId !== null) {
-            $safe = strtolower((string) preg_replace('/[^A-Za-z0-9\-]+/', '-', $manifest->slug()));
-            $safe = trim($safe, '-');
+            $safe = keyed_str(strtolower($manifest->registryId));
 
             if ($safe !== '') {
                 return $safe;
             }
         }
 
-        $safe = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $manifest->name));
-        $safe = trim($safe, '-');
+        $safe = keyed_str(strtolower($manifest->name));
 
         if ($safe === '') {
             throw new AddonInstallException(sprintf('Invalid addon name: %s', $manifest->name));

--- a/app/Addons/AddonRegistry.php
+++ b/app/Addons/AddonRegistry.php
@@ -279,7 +279,7 @@ class AddonRegistry
     private function safeName(AddonManifest $manifest): string
     {
         if ($manifest->registryId !== null) {
-            $safe = strtolower((string) preg_replace('/[^A-Za-z0-9\-]+/', '-', str_replace('/', '-', $manifest->registryId)));
+            $safe = strtolower((string) preg_replace('/[^A-Za-z0-9\-]+/', '-', $manifest->slug()));
             $safe = trim($safe, '-');
 
             if ($safe !== '') {

--- a/app/Addons/Models/AddonManifest.php
+++ b/app/Addons/Models/AddonManifest.php
@@ -70,9 +70,17 @@ final readonly class AddonManifest
         public array $files = [],
     ) {}
 
+    /**
+     * Permission- and filesystem-safe key for the addon.
+     *
+     * Managed addons key off the slugified registry_id (`acme/my-addon` =>
+     * `acme-my-addon`); registry-less addons fall back to `local-{name}`.
+     */
     public function slug(): string
     {
-        return trim(strtolower(str_replace('/', '-', $this->registryId)));
+        return $this->registryId !== null
+            ? keyed_str(strtolower($this->registryId))
+            : 'local-'.strtolower($this->name);
     }
 
     public function dirName(): string

--- a/app/Addons/Models/AddonManifest.php
+++ b/app/Addons/Models/AddonManifest.php
@@ -69,4 +69,14 @@ final readonly class AddonManifest
         public array $tables = [],
         public array $files = [],
     ) {}
+
+    public function slug(): string
+    {
+        return trim(strtolower(str_replace('/', '-', $this->registryId)));
+    }
+
+    public function dirName(): string
+    {
+        return $this->slug();
+    }
 }

--- a/app/Addons/Models/AddonManifest.php
+++ b/app/Addons/Models/AddonManifest.php
@@ -70,21 +70,4 @@ final readonly class AddonManifest
         public array $files = [],
     ) {}
 
-    /**
-     * Permission- and filesystem-safe key for the addon.
-     *
-     * Managed addons key off the slugified registry_id (`acme/my-addon` =>
-     * `acme-my-addon`); registry-less addons fall back to `local-{name}`.
-     */
-    public function slug(): string
-    {
-        return $this->registryId !== null
-            ? keyed_str(strtolower($this->registryId))
-            : 'local-'.strtolower($this->name);
-    }
-
-    public function dirName(): string
-    {
-        return $this->slug();
-    }
 }

--- a/app/Models/Addon.php
+++ b/app/Models/Addon.php
@@ -127,6 +127,15 @@ class Addon extends Model
         return $this->name ?? basename($this->path);
     }
 
+    public function getSlug(): string
+    {
+        if (!blank($this->registry_id)) {
+            return str_replace('/', '-', $this->registry_id);
+        }
+
+        return strtolower((string) $this->name);
+    }
+
     /**
      * Return the absolute filesystem path to the addon root
      */

--- a/app/Models/Addon.php
+++ b/app/Models/Addon.php
@@ -127,15 +127,6 @@ class Addon extends Model
         return $this->name ?? basename($this->path);
     }
 
-    public function getSlug(): string
-    {
-        if (!blank($this->registry_id)) {
-            return str_replace('/', '-', $this->registry_id);
-        }
-
-        return strtolower((string) $this->name);
-    }
-
     /**
      * Return the absolute filesystem path to the addon root
      */

--- a/app/Services/PermissionRegistry.php
+++ b/app/Services/PermissionRegistry.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Addons\Models\AddonBootCache;
+use App\Addons\Support\BootCache;
 use App\Contracts\Filament\ProvidesPermissions;
 use App\Enums\Ability;
 use Filament\Facades\Filament;
@@ -34,6 +36,8 @@ class PermissionRegistry
      * @var array<string, array{group: string, label: string}>
      */
     protected array $custom = [];
+
+    public function __construct(private readonly BootCache $bootCache) {}
 
     /**
      * Register a custom permission (e.g. from a module service provider).
@@ -234,10 +238,22 @@ class PermissionRegistry
     }
 
     /**
-     * The permission-safe key for a module (e.g. `VMSAcars` => `vmsacars`).
+     * The permission-safe key for a module.
+     *
+     * Managed modules (those with a registry_id in the boot cache) key off the
+     * slugified registry_id, e.g. `acme/my-addon` => `acme-my-addon`. Every other
+     * module falls back to its lower-cased display name, e.g. `VMSAcars` => `vmsacars`.
      */
     public function moduleKey(string $module): string
     {
+        $entry = $this->bootCache->all()->first(
+            fn (AddonBootCache $entry): bool => $entry->name === $module
+        );
+
+        if ($entry !== null && $entry->registryId !== null) {
+            return keyed_str(strtolower($entry->registryId));
+        }
+
         return Str::lower($module);
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -386,6 +386,24 @@ if (!function_exists('_fmt')) {
     }
 }
 
+if (!function_exists('keyed_str')) {
+    /**
+     * Normalise a string into a key-safe token.
+     *
+     * Replaces any run of non-alphanumeric characters (spaces, `\ / : ,` etc.)
+     * with the delimiter and trims leading/trailing delimiters. Case is
+     * preserved; lower-case at the call site if required.
+     *
+     * e.g. `keyed_str('phpvms/vms-acars')` => `phpvms-vms-acars`
+     */
+    function keyed_str(string $source, string $delimiter = '-'): string
+    {
+        $replaced = preg_replace('/[^\p{L}\p{N}]+/u', $delimiter, $source);
+
+        return trim((string) $replaced, $delimiter);
+    }
+}
+
 if (!function_exists('docs_link')) {
     /**
      * Return a link to the docs

--- a/tests/Feature/Addons/AddonRegistryInstallTest.php
+++ b/tests/Feature/Addons/AddonRegistryInstallTest.php
@@ -32,7 +32,7 @@ it('install() places the addon and registers a DB row', function (): void {
 
     expect($addon)->toBeInstanceOf(Addon::class)
         ->and($addon->getName())->toBe('Demo')
-        ->and(File::isDirectory($this->modules.'/Demo'))->toBeTrue()
+        ->and(File::isDirectory($this->modules.'/demo'))->toBeTrue()
         ->and(Addon::query()->where('name', 'Demo')->exists())->toBeTrue();
 });
 

--- a/tests/Feature/Permissions/PermissionRegistryTest.php
+++ b/tests/Feature/Permissions/PermissionRegistryTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Addons\Models\AddonBootCache;
+use App\Addons\Support\BootCache;
 use App\Models\User;
 use App\Services\PermissionRegistry;
 use Modules\VMSAcars\Models\Rule;

--- a/tests/Feature/Permissions/PermissionRegistryTest.php
+++ b/tests/Feature/Permissions/PermissionRegistryTest.php
@@ -73,6 +73,32 @@ it('attributes app classes to the core scope and module classes to their module'
     expect($registry->moduleKey('VMSAcars'))->toBe('vmsacars');
 });
 
+it('uses registry_id slug as module key when the boot cache has a registry_id', function (): void {
+    $fakeEntry = new AddonBootCache(
+        name: 'Acme',
+        alias: 'acme',
+        type: 'module',
+        registryId: 'acme/my-addon',
+        version: null,
+        namespace: 'Modules\\Acme',
+        providers: [],
+        path: '/modules/Acme',
+        autoloadPath: '/modules/Acme/app',
+        layout: 'app',
+        description: null,
+        enabled: true,
+    );
+
+    $fakeCache = mock(BootCache::class);
+    $fakeCache->allows('all')->andReturns(collect([$fakeEntry]));
+    app()->instance(BootCache::class, $fakeCache);
+
+    // Re-resolve so the new BootCache instance is injected.
+    app()->forgetInstance(PermissionRegistry::class);
+
+    expect(app(PermissionRegistry::class)->moduleKey('Acme'))->toBe('acme-my-addon');
+});
+
 it('scopes core permission groups to the core scope', function (): void {
     $grouped = collect(app(PermissionRegistry::class)->grouped());
 


### PR DESCRIPTION
Change to to `<author>-<name>` (from registry_id)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Addon installation now consistently generates filesystem-safe destination folder names in lowercase, hyphen-delimited format (e.g., `demo` instead of `Demo`).

* **New Features**
  * Permission keys for managed addons are now derived from the addon’s registry identifier, producing more consistent module permission naming.

* **Tests**
  * Updated addon install and permission registry feature tests to reflect the new naming/permission-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->