### PR TITLE
[8.x] fix(modules): register module database/migrations so artisan migrate runs them

### DIFF
--- a/app/Contracts/Modules/ServiceProvider.php
+++ b/app/Contracts/Modules/ServiceProvider.php
@@ -27,6 +27,7 @@ use ReflectionNamedType;
  *  - routes/console.php → require (closure routes; console context only)
  *  - resources/views  → loadViewsFrom
  *  - lang/            → loadTranslationsFrom
+ *  - database/migrations → loadMigrationsFrom
  *  - app/Console/Commands/*.php → commands() (top-level dir only; no subdirectory scan)
  *  - app/Listeners/*.php        → Event::listen (top-level dir only; no subdirectory scan)
  *
@@ -62,6 +63,7 @@ abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->registerRoutes();
         $this->registerViews();
         $this->registerTranslations();
+        $this->registerMigrations();
         $this->registerCommands();
         $this->registerListeners();
     }
@@ -80,7 +82,9 @@ abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
      * Resolve the addon root directory.
      *
      * Default: 3 levels up from the provider file, which lives at
-     * `{root}/app/Providers/XxxServiceProvider.php`.
+     * `{root}/app/Providers/XxxServiceProvider.php` (PSR-4 maps
+     * `Modules\Name\` → `{root}/app`). Resources (config, routes, views, lang,
+     * database/migrations) live at `{root}`.
      *
      * Override for non-standard layouts or tests.
      */
@@ -212,6 +216,22 @@ abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         if (is_dir($langPath)) {
             $this->loadTranslationsFrom($langPath, $this->addonNamespace());
+        }
+    }
+
+    /**
+     * Register the addon's database migrations so `artisan migrate` runs them
+     * whenever the addon is enabled.
+     *
+     * Convention: `{root}/database/migrations` (lowercase), mirroring a standard
+     * Laravel application and the `modules/*` addon layout.
+     */
+    private function registerMigrations(): void
+    {
+        $migrationsPath = $this->addonBasePath().'/database/migrations';
+
+        if (is_dir($migrationsPath)) {
+            $this->loadMigrationsFrom($migrationsPath);
         }
     }
 

--- a/tests/Feature/Addons/BaseAddonServiceProviderTest.php
+++ b/tests/Feature/Addons/BaseAddonServiceProviderTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
 use PhpvmsAddonFixture\Events\AcmeFixtureEvent;
 use PhpvmsAddonFixture\Listeners\AcmeListener;
 use PhpvmsAddonFixture\Providers\AcmeServiceProvider;
@@ -102,6 +103,19 @@ it('registers the web route so Route::has("acme.fixture") is true', function ():
 
 it('returns "ok" from the acme-fixture route', function (): void {
     $this->get('/acme-fixture')->assertSuccessful()->assertSeeText('ok');
+});
+
+it('registers the addon database/migrations directory with the migrator', function (): void {
+    $registered = collect(app('migrator')->paths())
+        ->contains(fn (string $path): bool => str_ends_with($path, 'acme'.DIRECTORY_SEPARATOR.'database'.DIRECTORY_SEPARATOR.'migrations'));
+
+    expect($registered)->toBeTrue();
+});
+
+it('runs the addon migration on artisan migrate so the table exists', function (): void {
+    Artisan::call('migrate', ['--force' => true]);
+
+    expect(Schema::hasTable('acme_fixture_items'))->toBeTrue();
 });
 
 it('registers the console command so Artisan::all() contains "acme:ping"', function (): void {

--- a/tests/fixtures/Addons/acme/database/migrations/2026_01_01_000000_create_acme_fixture_items_table.php
+++ b/tests/fixtures/Addons/acme/database/migrations/2026_01_01_000000_create_acme_fixture_items_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fixture migration for the acme test addon. Proves the base addon
+ * ServiceProvider registers `{root}/database/migrations` so `artisan migrate`
+ * runs an enabled addon's migrations.
+ */
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('acme_fixture_items', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('acme_fixture_items');
+    }
+};


### PR DESCRIPTION
The base module ServiceProvider auto-wired config, routes, views, translations, commands and listeners but never registered migrations, so an enabled module's migrations were skipped by artisan migrate.

Load migrations from {root}/database/migrations, matching the module app-layout convention. Add coverage proving the path is registered with the migrator and that migrate creates the module table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Addon database migrations are now automatically registered and loaded from addon-specific migration directories, eliminating manual setup requirements and streamlining addon development. This enables addon creators to focus on functionality rather than infrastructure configuration.

* **Tests**
  * Feature tests were added to validate the automatic migration registration system and verify migrations execute properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->