### PR TITLE
[8.x] feat(addons): add per-addon settings management

### DIFF
--- a/app/Console/Commands/AddonsSyncSettings.php
+++ b/app/Console/Commands/AddonsSyncSettings.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\AddonSettingSyncService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Throwable;
+
+#[AsCommand(name: 'phpvms:addons-sync-settings', description: "Sync enabled addons' declared settings into the addon_settings table")]
+class AddonsSyncSettings extends Command
+{
+    /**
+     * Upsert every enabled addon's declared settings schema.
+     *
+     * Deterministic counterpart to the boot-time sync — for CI, deploys, and
+     * tests, where the web-boot prime path is skipped (D-17). Idempotent:
+     * preserves user-edited values, reconciles metadata.
+     */
+    public function handle(AddonSettingSyncService $sync): int
+    {
+        try {
+            $this->components->task('Syncing addon settings', static function () use ($sync): void {
+                $sync->sync();
+            });
+        } catch (Throwable $throwable) {
+            $this->components->error('Addon settings sync failed: '.$throwable->getMessage());
+            Log::error('Addon settings sync failed', ['exception' => $throwable]);
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Contracts/Addons/HasSettings.php
+++ b/app/Contracts/Addons/HasSettings.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Addons;
+
+/**
+ * Implemented by an addon's service provider to declare configurable settings.
+ *
+ * The declared schema is synced into the `addon_settings` table on boot (see
+ * App\Services\AddonSettingSyncService): new keys are inserted with their
+ * `default` as the initial value, metadata is reconciled to the declared
+ * schema, and existing user-edited values are preserved.
+ *
+ * Read values back with the global helpers `addon_setting()` /
+ * `addon_setting_save()`, addressing the addon by its manifest `alias` or
+ * `registry_id`. Each declared setting is editable from the shared
+ * App\Filament\Pages\AddonSettings page inherited by the addon's panel.
+ *
+ * Example:
+ *
+ *     public function settings(): array
+ *     {
+ *         return [
+ *             [
+ *                 'key'         => 'api_token',
+ *                 'name'        => 'API Token',
+ *                 'default'     => '',
+ *                 'group'       => 'general',
+ *                 'type'        => 'text',
+ *                 'options'     => '',
+ *                 'description' => 'Token used to authenticate with the remote service',
+ *                 'order'       => 0,
+ *             ],
+ *         ];
+ *     }
+ */
+interface HasSettings
+{
+    /**
+     * Return the addon's settings schema.
+     *
+     * Each entry is an associative array. Only `key` is required; the rest fall
+     * back to sensible defaults during sync:
+     *
+     *  - `key`         (required) string  Machine key, normalized to lower-case
+     *                                     with dots collapsed to underscores.
+     *  - `name`        (optional) string  Human-readable label (defaults to the key).
+     *  - `default`     (optional) scalar  Initial value for new keys (defaults to '').
+     *  - `group`       (optional) string  Tab group on the settings page (defaults to 'general').
+     *  - `type`        (optional) string  Field type: text|string|boolean|bool|int|integer|
+     *                                     number|float|date|select (defaults to 'text').
+     *  - `options`     (optional) string  Comma-separated options for `select` (e.g. 'a,b=Bee').
+     *  - `description` (optional) string  Help text shown under the field.
+     *  - `order`       (optional) int     Sort order within the group.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function settings(): array;
+}

--- a/app/Contracts/Modules/PanelProvider.php
+++ b/app/Contracts/Modules/PanelProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Contracts\Modules;
 
 use App\Enums\NavigationGroup;
+use App\Filament\Pages\AddonSettings;
 use App\Filament\Plugins\ClearCachesPlugin;
 use App\Filament\Plugins\LanguageSwitcherPlugin;
 use App\Filament\Plugins\PanelSwitcherPlugin;
@@ -98,6 +99,9 @@ abstract class PanelProvider extends FilamentPanelProvider
             ])
             ->pages([
                 Dashboard::class,
+                // Shared settings editor; auto-hidden unless this addon has
+                // registered settings (see AddonSettings::canAccess()).
+                AddonSettings::class,
             ])
             ->plugins([
                 PanelSwitcherPlugin::make(),

--- a/app/Filament/Pages/AddonSettings.php
+++ b/app/Filament/Pages/AddonSettings.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use App\Enums\Ability;
+use App\Enums\NavigationGroup;
+use App\Filament\Concerns\AuthorizesAccess;
+use App\Models\Addon;
+use App\Models\AddonSetting;
+use App\Services\AddonSettingService;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Pages\Concerns\InteractsWithFormActions;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\EmbeddedSchema;
+use Filament\Schemas\Components\Form;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Exceptions\Halt;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Override;
+use UnitEnum;
+
+/**
+ * Shared, core-hosted settings page inherited by every addon's Filament panel.
+ *
+ * A single page class serves all addons: it resolves the owning addon from the
+ * current panel id (which equals the addon's moduleKey/alias) and shows only
+ * that addon's settings. It is registered into each module panel by
+ * App\Contracts\Modules\PanelProvider; on the core admin panel the panel id
+ * resolves to no addon, so the page is hidden and inaccessible there.
+ *
+ * @property-read Schema $form
+ */
+class AddonSettings extends Page
+{
+    use AuthorizesAccess;
+    use InteractsWithFormActions;
+
+    protected static string|UnitEnum|null $navigationGroup = NavigationGroup::Config;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog8Tooth;
+
+    protected static ?int $navigationSort = 99;
+
+    public ?array $data = [];
+
+    /**
+     * Addon settings expose a single `edit` ability gating the save action.
+     * Page access itself is gated by the addon's panel (`access:{module-key}`,
+     * resolved in User::canAccessPanel()) — reaching the page already means the
+     * user can access the module — so no separate `view` ability is declared.
+     *
+     * @return array<int, Ability>
+     */
+    public static function getPermissionAbilities(): array
+    {
+        return [Ability::Edit];
+    }
+
+    /**
+     * The page is only available inside a panel whose id resolves to an addon
+     * that has at least one registered setting. Module access is enforced one
+     * level up by User::canAccessPanel(); editing additionally requires the
+     * `edit:addon-settings` permission (see canEdit()).
+     */
+    #[Override]
+    public static function canAccess(): bool
+    {
+        $addon = self::currentAddon();
+
+        if (!$addon instanceof Addon) {
+            return false;
+        }
+
+        return AddonSetting::query()->where('addon_id', $addon->id)->exists();
+    }
+
+    #[Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canAccess();
+    }
+
+    public function mount(): void
+    {
+        abort_unless(static::canAccess(), 403);
+
+        $this->fillForm();
+    }
+
+    #[Override]
+    public function content(Schema $schema): Schema
+    {
+        return $schema->components([
+            Form::make([EmbeddedSchema::make('form')])
+                ->id('form')
+                ->livewireSubmitHandler('save')
+                ->footer([
+                    $this->getFormActionsComponents(),
+                ]),
+        ]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components($this->getFormSchema())
+            ->statePath('data');
+    }
+
+    protected function fillForm(): void
+    {
+        $formattedData = [];
+
+        foreach ($this->settings() as $setting) {
+            $formattedData[$setting->key] = $setting->value;
+        }
+
+        $this->form->fill($formattedData);
+    }
+
+    public function save(): void
+    {
+        abort_unless(static::canEdit(), 403);
+
+        $addon = self::currentAddon();
+        abort_unless($addon instanceof Addon, 403);
+
+        try {
+            $data = $this->form->getState();
+
+            DB::transaction(function () use ($addon, $data): void {
+                $service = app(AddonSettingService::class);
+
+                foreach ($data as $key => $value) {
+                    $service->storeById($addon->id, $key, $value);
+                }
+            });
+
+            Notification::make()
+                ->success()
+                ->title('Settings saved successfully')
+                ->send();
+        } catch (Halt) {
+            return;
+        }
+    }
+
+    public function getFormActionsComponents(): Actions
+    {
+        return Actions::make([
+            $this->getSaveFormAction(),
+        ]);
+    }
+
+    protected function getSaveFormAction(): Action
+    {
+        return Action::make('save')
+            ->label(__('filament-panels::resources/pages/edit-record.form.actions.save.label'))
+            ->submit('save')
+            ->visible(static::canEdit())
+            ->keyBindings(['mod+s']);
+    }
+
+    protected function getFormSchema(): array
+    {
+        $tabs = [];
+
+        foreach ($this->settings()->groupBy('group') as $group => $settings) {
+            $tabs[] = Tab::make(Str::ucfirst((string) $group))
+                ->schema(
+                    $settings->map(fn (AddonSetting $setting): DatePicker|Toggle|TextInput|Select => $this->fieldFor($setting))->toArray()
+                );
+        }
+
+        return [
+            Tabs::make('addon_settings')
+                ->tabs($tabs)
+                ->columnSpanFull()
+                ->disabled(!static::canEdit()),
+        ];
+    }
+
+    /**
+     * Build the form field for a single setting, by type.
+     */
+    protected function fieldFor(AddonSetting $setting): DatePicker|Toggle|TextInput|Select
+    {
+        if ($setting->type === 'date') {
+            return DatePicker::make($setting->key)
+                ->label($setting->name)
+                ->helperText($setting->description)
+                ->format('Y-m-d')
+                ->native(false);
+        }
+
+        if ($setting->type === 'boolean' || $setting->type === 'bool') {
+            return Toggle::make($setting->key)
+                ->label($setting->name)
+                ->helperText($setting->description)
+                ->offIcon(Heroicon::XCircle)
+                ->offColor('danger')
+                ->onIcon(Heroicon::CheckCircle)
+                ->onColor('success');
+        }
+
+        if ($setting->type === 'int' || $setting->type === 'integer') {
+            return TextInput::make($setting->key)
+                ->label($setting->name)
+                ->helperText($setting->description)
+                ->integer();
+        }
+
+        if ($setting->type === 'number' || $setting->type === 'float') {
+            return TextInput::make($setting->key)
+                ->label($setting->name)
+                ->helperText($setting->description)
+                ->numeric()
+                ->step(0.01);
+        }
+
+        if ($setting->type === 'select') {
+            return Select::make($setting->key)
+                ->label($setting->name)
+                ->helperText($setting->description)
+                ->options(list_to_assoc(explode(',', (string) $setting->options)));
+        }
+
+        return TextInput::make($setting->key)
+            ->label($setting->name)
+            ->helperText($setting->description)
+            ->string();
+    }
+
+    /**
+     * The current addon's settings (excluding hidden), ordered for display.
+     *
+     * @return Collection<int, AddonSetting>
+     */
+    protected function settings(): Collection
+    {
+        $addon = self::currentAddon();
+
+        if (!$addon instanceof Addon) {
+            return AddonSetting::query()->whereRaw('1 = 0')->get();
+        }
+
+        return AddonSetting::query()
+            ->where('addon_id', $addon->id)
+            ->where('type', '!=', 'hidden')
+            ->orderBy('order')
+            ->get();
+    }
+
+    /**
+     * Resolve the addon that owns the current panel, or null on the core panel.
+     */
+    protected static function currentAddon(): ?Addon
+    {
+        $panelId = Filament::getCurrentPanel()?->getId();
+
+        return app(AddonSettingService::class)->resolveAddon($panelId);
+    }
+
+    #[Override]
+    public static function getNavigationLabel(): string
+    {
+        return trans_choice('common.setting', 2);
+    }
+
+    #[Override]
+    public function getTitle(): string
+    {
+        return trans_choice('common.setting', 2);
+    }
+}

--- a/app/Filament/Pages/AddonSettings.php
+++ b/app/Filament/Pages/AddonSettings.php
@@ -86,7 +86,10 @@ class AddonSettings extends Page
             return false;
         }
 
-        return AddonSetting::query()->where('addon_id', $addon->id)->exists();
+        return AddonSetting::query()
+            ->where('addon_id', $addon->id)
+            ->where('type', '!=', 'hidden')
+            ->exists();
     }
 
     #[Override]

--- a/app/Models/Addon.php
+++ b/app/Models/Addon.php
@@ -8,6 +8,7 @@ use App\Addons\Models\AddonManifest;
 use App\Contracts\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Override;
 use Str;
@@ -76,6 +77,16 @@ class Addon extends Model
             'enabled'      => 'boolean',
             'installed_at' => 'datetime',
         ];
+    }
+
+    /**
+     * The settings declared by this addon.
+     *
+     * @return HasMany<AddonSetting, $this>
+     */
+    public function settings(): HasMany
+    {
+        return $this->hasMany(AddonSetting::class);
     }
 
     /**

--- a/app/Models/AddonSetting.php
+++ b/app/Models/AddonSetting.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Contracts\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A single setting belonging to one addon.
+ *
+ * Mirrors the typed columns of {@see Setting} but scoped per addon via
+ * `addon_id`. Settings are declared by an addon's service provider (see
+ * App\Contracts\Addons\HasSettings) and synced into this table on boot.
+ *
+ * @property int         $id
+ * @property int         $addon_id
+ * @property string|null $alias
+ * @property int         $order
+ * @property string      $key
+ * @property string      $name
+ * @property string|null $value
+ * @property string|null $default
+ * @property string|null $group
+ * @property string|null $type
+ * @property string|null $options
+ * @property string|null $description
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Addon $addon
+ *
+ * @method static Builder<static>|AddonSetting newModelQuery()
+ * @method static Builder<static>|AddonSetting newQuery()
+ * @method static Builder<static>|AddonSetting query()
+ *
+ * @mixin \Eloquent
+ */
+class AddonSetting extends Model
+{
+    use HasFactory;
+
+    public $table = 'addon_settings';
+
+    protected $fillable = [
+        'addon_id',
+        'alias',
+        'order',
+        'key',
+        'name',
+        'value',
+        'default',
+        'group',
+        'type',
+        'options',
+        'description',
+    ];
+
+    /**
+     * Normalize a setting key the same way the core Setting model does:
+     * lower-cased with dots collapsed to underscores.
+     */
+    public static function formatKey(string $key): string
+    {
+        return str_replace('.', '_', strtolower($key));
+    }
+
+    /**
+     * The addon that owns this setting.
+     *
+     * @return BelongsTo<Addon, $this>
+     */
+    public function addon(): BelongsTo
+    {
+        return $this->belongsTo(Addon::class);
+    }
+}

--- a/app/Providers/AddonServiceProvider.php
+++ b/app/Providers/AddonServiceProvider.php
@@ -11,8 +11,11 @@ use App\Addons\Support\AddonAssetLinker;
 use App\Addons\Support\AutoloadGuard;
 use App\Addons\Support\BootCache;
 use App\Addons\Support\ManifestParser;
+use App\Services\AddonSettingSyncService;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Override;
+use Throwable;
 
 /**
  * Wires the addon engine into application boot.
@@ -85,6 +88,28 @@ class AddonServiceProvider extends ServiceProvider
     {
         if (!$this->app->runningInConsole()) {
             $this->app->make(AddonDiscoveryService::class)->primeIfNeeded();
+            $this->syncAddonSettings();
+        }
+    }
+
+    /**
+     * Sync enabled addons' declared settings into the addon_settings table.
+     *
+     * Runs once per worker boot (not per request), alongside the cache prime.
+     * Guarded by a table-existence check so it no-ops before the addon-settings
+     * migration has run (fresh install / pre-migrate boot), and swallows any
+     * error so settings sync can never break application boot.
+     */
+    private function syncAddonSettings(): void
+    {
+        try {
+            if (!Schema::hasTable('addon_settings')) {
+                return;
+            }
+
+            $this->app->make(AddonSettingSyncService::class)->sync();
+        } catch (Throwable) {
+            // Never let settings sync halt boot — it self-heals next boot.
         }
     }
 }

--- a/app/Providers/AddonServiceProvider.php
+++ b/app/Providers/AddonServiceProvider.php
@@ -12,6 +12,7 @@ use App\Addons\Support\AutoloadGuard;
 use App\Addons\Support\BootCache;
 use App\Addons\Support\ManifestParser;
 use App\Services\AddonSettingSyncService;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Override;
@@ -108,8 +109,12 @@ class AddonServiceProvider extends ServiceProvider
             }
 
             $this->app->make(AddonSettingSyncService::class)->sync();
-        } catch (Throwable) {
-            // Never let settings sync halt boot — it self-heals next boot.
+        } catch (Throwable $throwable) {
+            // Never let settings sync halt boot — it self-heals next boot —
+            // but surface the failure so persistent drift is observable.
+            Log::warning('Addon settings sync failed during boot; continuing startup.', [
+                'exception' => $throwable,
+            ]);
         }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Models\Role;
 use App\Models\User;
 use App\Notifications\Channels\Discord\DiscordWebhook;
 use App\Policies\Filament\ActivityPolicy;
+use App\Services\AddonSettingService;
 use App\Services\ModuleService;
 use App\Services\PermissionRegistry;
 use App\Services\RouteForge\Contracts\LintRule;
@@ -208,6 +209,10 @@ class AppServiceProvider extends ServiceProvider
         ));
 
         $this->app->singleton(ModuleService::class);
+
+        // Per-addon settings read/write. Stateless/Octane-safe; bound as a
+        // singleton so the `addon_setting()` helper reuses one instance.
+        $this->app->singleton(AddonSettingService::class);
 
         // Permission registry: modules register custom permissions into the
         // same instance during boot(), so it must be a singleton.

--- a/app/Services/AddonSettingService.php
+++ b/app/Services/AddonSettingService.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Addons\Support\BootCache;
+use App\Contracts\Service;
+use App\Exceptions\SettingNotFound;
+use App\Models\Addon;
+use App\Models\AddonSetting;
+use App\Services\Concerns\CastsSettingValue;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Read/write access to per-addon settings stored in `addon_settings`.
+ *
+ * An addon is addressed by a handle that resolves as either its manifest
+ * `alias` or `registry_id` (alias is universal; bundled addons have a null
+ * registry_id). Reads are typed via {@see CastsSettingValue} and cached per
+ * resolved addon + key, so the helper observes the same value regardless of
+ * which handle was used.
+ *
+ * Stateless and Octane-safe: no mutable instance state; all caching lives in
+ * the application cache.
+ */
+class AddonSettingService extends Service
+{
+    use CastsSettingValue;
+
+    public function __construct(private readonly BootCache $bootCache) {}
+
+    /**
+     * Retrieve a typed setting value for the addon identified by $handle.
+     *
+     * @throws SettingNotFound when the addon or key cannot be resolved.
+     */
+    public function retrieve(string $handle, string $key): mixed
+    {
+        $addonId = $this->resolveAddonId($handle);
+
+        if ($addonId === null) {
+            throw new SettingNotFound($handle.' addon not found');
+        }
+
+        $formattedKey = AddonSetting::formatKey($key);
+
+        if (app()->environment('production')) {
+            $cache = config('cache.keys.ADDON_SETTINGS');
+
+            return Cache::remember(
+                $cache['key'].$addonId.'.'.$formattedKey,
+                $cache['time'],
+                fn (): mixed => $this->read($addonId, $formattedKey),
+            );
+        }
+
+        return $this->read($addonId, $formattedKey);
+    }
+
+    /**
+     * Persist a value for the addon identified by $handle and invalidate its
+     * cached value. Returns the value on success, or null when the addon/key
+     * does not exist (settings are created by the sync, not by store()).
+     */
+    public function store(string $handle, string $key, mixed $value): mixed
+    {
+        $addonId = $this->resolveAddonId($handle);
+
+        if ($addonId === null) {
+            return null;
+        }
+
+        return $this->storeById($addonId, $key, $value);
+    }
+
+    /**
+     * Persist a value for a known addon id. Returns the value on success, or
+     * null when the key does not exist. Invalidates the cached value.
+     */
+    public function storeById(int $addonId, string $key, mixed $value): mixed
+    {
+        $formattedKey = AddonSetting::formatKey($key);
+
+        $setting = AddonSetting::query()
+            ->where('addon_id', $addonId)
+            ->where('key', $formattedKey)
+            ->first(['id', 'value']);
+
+        if ($setting === null) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            $value = $value ? 1 : 0;
+        }
+
+        if ($value !== null) {
+            $setting->value = (string) $value;
+            $setting->save();
+
+            $this->forgetCache($addonId, $formattedKey);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Alias for store() that always returns the value.
+     */
+    public function save(string $handle, string $key, mixed $value): mixed
+    {
+        return $this->store($handle, $key, $value);
+    }
+
+    /**
+     * All settings for an addon, ordered for display.
+     *
+     * @return Collection<int, AddonSetting>
+     */
+    public function all(int $addonId): Collection
+    {
+        return AddonSetting::query()
+            ->where('addon_id', $addonId)
+            ->orderBy('order')
+            ->get();
+    }
+
+    /**
+     * Resolve a handle (alias or registry_id) to its Addon model, or null.
+     */
+    public function resolveAddon(?string $handle): ?Addon
+    {
+        if ($handle === null || $handle === '') {
+            return null;
+        }
+
+        $addonId = $this->resolveAddonId($handle);
+
+        return $addonId === null ? null : Addon::query()->find($addonId);
+    }
+
+    /**
+     * Resolve a handle to an addon id.
+     *
+     * Tries the addons table first (registry_id, then name), then falls back to
+     * the boot cache for the manifest `alias` — which is not stored on the
+     * addons table — mapping the matched entry back to its addon row.
+     */
+    public function resolveAddonId(string $handle): ?int
+    {
+        if ($handle === '') {
+            return null;
+        }
+
+        $id = Addon::query()->where('registry_id', $handle)->value('id')
+            ?? Addon::query()->where('name', $handle)->value('id');
+
+        if ($id !== null) {
+            return (int) $id;
+        }
+
+        $entry = $this->bootCache->all()->first(
+            fn ($e): bool => $e->alias === $handle
+                || $e->registryId === $handle
+                || $e->name === $handle
+        );
+
+        if ($entry === null) {
+            return null;
+        }
+
+        $query = Addon::query();
+
+        if ($entry->registryId !== null) {
+            $query->where('registry_id', $entry->registryId);
+        } else {
+            $query->where('namespace', $entry->namespace);
+        }
+
+        $resolved = $query->value('id');
+
+        return $resolved === null ? null : (int) $resolved;
+    }
+
+    /**
+     * Fetch and cast a single setting value.
+     *
+     * @throws SettingNotFound when the key has no row for the addon.
+     */
+    private function read(int $addonId, string $formattedKey): mixed
+    {
+        $setting = AddonSetting::query()
+            ->where('addon_id', $addonId)
+            ->where('key', $formattedKey)
+            ->first(['type', 'value']);
+
+        if ($setting === null) {
+            throw new SettingNotFound($formattedKey.' not found');
+        }
+
+        return $this->castSettingValue($setting->type, $setting->value);
+    }
+
+    private function forgetCache(int $addonId, string $formattedKey): void
+    {
+        $cache = config('cache.keys.ADDON_SETTINGS');
+
+        if (is_array($cache) && isset($cache['key'])) {
+            Cache::forget($cache['key'].$addonId.'.'.$formattedKey);
+        }
+    }
+}

--- a/app/Services/AddonSettingSyncService.php
+++ b/app/Services/AddonSettingSyncService.php
@@ -51,31 +51,26 @@ class AddonSettingSyncService extends Service
      */
     private function syncEntry(AddonBootCache $entry): void
     {
-        $schema = $this->collectSchema($entry);
-
-        if ($schema === []) {
-            return;
-        }
-
         $addonId = $this->resolveAddonId($entry);
 
         if ($addonId === null) {
             return;
         }
 
-        $rows = [];
-        $declaredKeys = [];
+        // Key by normalized key so duplicate declarations (multiple providers,
+        // or repeated entries) collapse to one row — last declaration wins —
+        // which keeps the (addon_id, key) upsert from failing on duplicates.
+        $rowsByKey = [];
 
-        foreach ($schema as $order => $setting) {
+        foreach ($this->collectSchema($entry) as $order => $setting) {
             if (!isset($setting['key'])) {
                 continue;
             }
 
             $key = AddonSetting::formatKey((string) $setting['key']);
-            $declaredKeys[] = $key;
             $default = $this->stringify($setting['default'] ?? '');
 
-            $rows[] = [
+            $rowsByKey[$key] = [
                 'addon_id'    => $addonId,
                 'alias'       => $entry->alias,
                 'key'         => $key,
@@ -90,18 +85,18 @@ class AddonSettingSyncService extends Service
             ];
         }
 
-        if ($rows === []) {
-            return;
+        if ($rowsByKey !== []) {
+            // Preserve existing `value`; reconcile everything else (mirrors SettingsSeeder).
+            AddonSetting::upsert(
+                array_values($rowsByKey),
+                uniqueBy: ['addon_id', 'key'],
+                update: ['alias', 'name', 'default', 'group', 'order', 'type', 'options', 'description'],
+            );
         }
 
-        // Preserve existing `value`; reconcile everything else (mirrors SettingsSeeder).
-        AddonSetting::upsert(
-            $rows,
-            uniqueBy: ['addon_id', 'key'],
-            update: ['alias', 'name', 'default', 'group', 'order', 'type', 'options', 'description'],
-        );
-
-        $this->logOrphans($addonId, $declaredKeys);
+        // Always run, even when the addon now declares nothing, so keys it
+        // previously persisted are reported as orphans (kept, not deleted).
+        $this->logOrphans($addonId, array_keys($rowsByKey));
     }
 
     /**

--- a/app/Services/AddonSettingSyncService.php
+++ b/app/Services/AddonSettingSyncService.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Addons\Models\AddonBootCache;
+use App\Addons\Support\BootCache;
+use App\Contracts\Addons\HasSettings;
+use App\Contracts\Service;
+use App\Models\Addon;
+use App\Models\AddonSetting;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Synchronizes each enabled addon's declared settings schema into the
+ * `addon_settings` table.
+ *
+ * For every enabled boot-cache entry, resolves its addon row, finds any
+ * service provider implementing {@see HasSettings}, and upserts the declared
+ * schema: new keys are inserted with their `default` as the initial value,
+ * metadata (name/group/type/options/description/order/alias) is reconciled,
+ * and existing user-edited `value`s are preserved. Idempotent.
+ *
+ * Orphan rows — keys an addon no longer declares — are logged, not deleted, so
+ * a value is never lost on a transient schema change (D-open-question default).
+ *
+ * Stateless and Octane-safe: no mutable instance state.
+ */
+class AddonSettingSyncService extends Service
+{
+    public function __construct(
+        private readonly Application $app,
+        private readonly BootCache $bootCache,
+    ) {}
+
+    /**
+     * Sync every enabled addon's declared settings.
+     */
+    public function sync(): void
+    {
+        foreach ($this->bootCache->enabled() as $entry) {
+            $this->syncEntry($entry);
+        }
+    }
+
+    /**
+     * Sync a single boot-cache entry.
+     */
+    private function syncEntry(AddonBootCache $entry): void
+    {
+        $schema = $this->collectSchema($entry);
+
+        if ($schema === []) {
+            return;
+        }
+
+        $addonId = $this->resolveAddonId($entry);
+
+        if ($addonId === null) {
+            return;
+        }
+
+        $rows = [];
+        $declaredKeys = [];
+
+        foreach ($schema as $order => $setting) {
+            if (!isset($setting['key'])) {
+                continue;
+            }
+
+            $key = AddonSetting::formatKey((string) $setting['key']);
+            $declaredKeys[] = $key;
+            $default = $this->stringify($setting['default'] ?? '');
+
+            $rows[] = [
+                'addon_id'    => $addonId,
+                'alias'       => $entry->alias,
+                'key'         => $key,
+                'name'        => (string) ($setting['name'] ?? $setting['key']),
+                'value'       => $default,
+                'default'     => $default,
+                'group'       => (string) ($setting['group'] ?? 'general'),
+                'order'       => (int) ($setting['order'] ?? $order),
+                'type'        => (string) ($setting['type'] ?? 'text'),
+                'options'     => (string) ($setting['options'] ?? ''),
+                'description' => $this->stringify($setting['description'] ?? ''),
+            ];
+        }
+
+        if ($rows === []) {
+            return;
+        }
+
+        // Preserve existing `value`; reconcile everything else (mirrors SettingsSeeder).
+        AddonSetting::upsert(
+            $rows,
+            uniqueBy: ['addon_id', 'key'],
+            update: ['alias', 'name', 'default', 'group', 'order', 'type', 'options', 'description'],
+        );
+
+        $this->logOrphans($addonId, $declaredKeys);
+    }
+
+    /**
+     * Merge the settings declared by every HasSettings provider on this entry.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function collectSchema(AddonBootCache $entry): array
+    {
+        $schema = [];
+
+        foreach ($entry->providers as $providerClass) {
+            if ($providerClass === '') {
+                continue;
+            }
+
+            if (!class_exists($providerClass)) {
+                continue;
+            }
+
+            if (!is_a($providerClass, HasSettings::class, true)) {
+                continue;
+            }
+
+            try {
+                /** @var HasSettings $provider */
+                $provider = $this->app->getProvider($providerClass) ?? new $providerClass($this->app);
+                $schema = [...$schema, ...$provider->settings()];
+            } catch (Throwable $throwable) {
+                Log::warning('AddonSettingSync: failed to read settings from '.$providerClass, [
+                    'exception' => $throwable->getMessage(),
+                ]);
+            }
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Resolve the addon row id for a boot-cache entry (registry_id when managed,
+     * namespace when bundled).
+     */
+    private function resolveAddonId(AddonBootCache $entry): ?int
+    {
+        $query = Addon::query();
+
+        if ($entry->registryId !== null) {
+            $query->where('registry_id', $entry->registryId);
+        } else {
+            $query->where('namespace', $entry->namespace);
+        }
+
+        $id = $query->value('id');
+
+        return $id === null ? null : (int) $id;
+    }
+
+    /**
+     * Log (do not delete) rows whose key is no longer declared.
+     *
+     * @param list<string> $declaredKeys
+     */
+    private function logOrphans(int $addonId, array $declaredKeys): void
+    {
+        $orphans = AddonSetting::query()
+            ->where('addon_id', $addonId)
+            ->whereNotIn('key', $declaredKeys)
+            ->pluck('key');
+
+        if ($orphans->isNotEmpty()) {
+            Log::info('AddonSettingSync: addon '.$addonId.' has undeclared settings (kept): '.$orphans->implode(', '));
+        }
+    }
+
+    /**
+     * Normalize a scalar value to a string for storage.
+     */
+    private function stringify(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+}

--- a/app/Services/Concerns/CastsSettingValue.php
+++ b/app/Services/Concerns/CastsSettingValue.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Concerns;
+
+use App\Services\AddonSettingService;
+use App\Services\SettingService;
+use Illuminate\Support\Carbon;
+
+/**
+ * Shared typed-casting for settings stored as strings.
+ *
+ * Used by both {@see SettingService} (core `settings`) and
+ * {@see AddonSettingService} (`addon_settings`) so the two
+ * settings systems cast identically.
+ */
+trait CastsSettingValue
+{
+    /**
+     * Cast a raw stored string value to its typed PHP representation.
+     */
+    protected function castSettingValue(?string $type, mixed $value): mixed
+    {
+        return match ($type) {
+            'bool', 'boolean'          => in_array($value, ['true', '1', 1], true),
+            'date'                     => Carbon::parse($value),
+            'int', 'integer', 'number' => (int) $value,
+            'float'                    => (float) $value,
+            default                    => $value,
+        };
+    }
+}

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -7,7 +7,7 @@ namespace App\Services;
 use App\Contracts\Service;
 use App\Exceptions\SettingNotFound;
 use App\Models\Setting;
-use Illuminate\Support\Carbon;
+use App\Services\Concerns\CastsSettingValue;
 use Illuminate\Support\Facades\Cache;
 
 /**
@@ -26,6 +26,8 @@ use Illuminate\Support\Facades\Cache;
  */
 class SettingService extends Service
 {
+    use CastsSettingValue;
+
     /**
      * Retrieve a typed setting value.
      *
@@ -41,13 +43,7 @@ class SettingService extends Service
             throw new SettingNotFound($key.' not found');
         }
 
-        return match ($setting->type) {
-            'bool', 'boolean'          => in_array($setting->value, ['true', '1', 1], true),
-            'date'                     => Carbon::parse($setting->value),
-            'int', 'integer', 'number' => (int) $setting->value,
-            'float'                    => (float) $setting->value,
-            default                    => $setting->value,
-        };
+        return $this->castSettingValue($setting->type, $setting->value);
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,6 +2,7 @@
 
 use App\Addons\Support\AddonAssetLinker;
 use App\Models\Addon;
+use App\Services\AddonSettingService;
 use App\Services\KvpService;
 use App\Services\SettingService;
 use Carbon\Carbon;
@@ -179,6 +180,54 @@ if (!function_exists('setting_save')) {
         $settingService->save($key, $value);
 
         return $value;
+    }
+}
+
+/*
+ * Shortcut for retrieving an addon's setting value
+ */
+if (!function_exists('addon_setting')) {
+    /**
+     * Read a setting belonging to an addon.
+     *
+     * The addon is addressed by its manifest `alias` or `registry_id`.
+     *
+     * @param  string     $addon   Addon alias or registry_id
+     * @param  string     $key     Setting key
+     * @param  mixed      $default Returned when the addon/key cannot be resolved
+     * @return mixed|null
+     */
+    function addon_setting(string $addon, string $key, $default = null)
+    {
+        /** @var AddonSettingService $service */
+        $service = app(AddonSettingService::class);
+
+        try {
+            return $service->retrieve($addon, $key);
+        } catch (Throwable) {
+            return $default;
+        }
+    }
+}
+
+/*
+ * Shortcut for persisting an addon's setting value
+ */
+if (!function_exists('addon_setting_save')) {
+    /**
+     * Persist a setting belonging to an addon, invalidating its cached value.
+     *
+     * @param  string     $addon Addon alias or registry_id
+     * @param  string     $key   Setting key
+     * @param  mixed      $value Value to store
+     * @return mixed|null The stored value, or null when the addon/key is unknown
+     */
+    function addon_setting_save(string $addon, string $key, $value): mixed
+    {
+        /** @var AddonSettingService $service */
+        $service = app(AddonSettingService::class);
+
+        return $service->save($addon, $key, $value);
     }
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Addons\Support\AddonAssetLinker;
+use App\Exceptions\SettingNotFound;
 use App\Models\Addon;
 use App\Services\AddonSettingService;
 use App\Services\KvpService;
@@ -204,7 +205,7 @@ if (!function_exists('addon_setting')) {
 
         try {
             return $service->retrieve($addon, $key);
-        } catch (Throwable) {
+        } catch (SettingNotFound) {
             return $default;
         }
     }

--- a/config/cache.php
+++ b/config/cache.php
@@ -149,6 +149,10 @@ return [
             'key'  => 'settings.', // append setting key
             'time' => 60 * 60 * 24, // Cache for 1 day
         ],
+        'ADDON_SETTINGS' => [
+            'key'  => 'addon_settings.', // append "{addon_id}.{key}"
+            'time' => 60 * 60 * 24, // Cache for 1 day
+        ],
         'MODULES' => [
             'key'  => 'modules',
             'time' => 60 * 60 * 24, // Cache for 1 day

--- a/database/factories/AddonSettingFactory.php
+++ b/database/factories/AddonSettingFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/** @noinspection PhpIllegalPsrClassPathInspection */
+
+namespace Database\Factories;
+
+use App\Contracts\Factory;
+use App\Models\Addon;
+use App\Models\AddonSetting;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<AddonSetting>
+ */
+class AddonSettingFactory extends Factory
+{
+    protected $model = AddonSetting::class;
+
+    public function definition(): array
+    {
+        $key = AddonSetting::formatKey(fake()->unique()->word());
+
+        return [
+            'addon_id'    => Addon::factory(),
+            'alias'       => fake()->slug(1),
+            'order'       => 0,
+            'key'         => $key,
+            'name'        => fake()->words(2, true),
+            'value'       => fake()->word(),
+            'default'     => fake()->word(),
+            'group'       => 'general',
+            'type'        => 'text',
+            'options'     => '',
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2026_06_22_000001_create_addon_settings_table.php
+++ b/database/migrations/2026_06_22_000001_create_addon_settings_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Create the per-addon settings table.
+     *
+     * Mirrors the typed columns of the core `settings` table but scopes every
+     * row to an owning addon (`addon_id`). The `alias` column is denormalized
+     * from the addon manifest at sync time for fast helper lookups and display;
+     * `addon_id` is the authoritative scope. Unique on (addon_id, key).
+     */
+    public function up(): void
+    {
+        Schema::create('addon_settings', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('addon_id')->constrained('addons')->cascadeOnDelete();
+            $table->string('alias')->nullable()->index();
+            $table->unsignedInteger('order')->default(99);
+            $table->string('key');
+            $table->string('name');
+            $table->string('value')->nullable();
+            $table->string('default')->nullable();
+            $table->string('group')->nullable();
+            $table->string('type')->nullable();
+            $table->text('options')->nullable();
+            $table->string('description')->nullable();
+            $table->timestamps();
+
+            $table->unique(['addon_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('addon_settings');
+    }
+};

--- a/modules/Sample/Providers/SampleServiceProvider.php
+++ b/modules/Sample/Providers/SampleServiceProvider.php
@@ -2,13 +2,80 @@
 
 namespace Modules\Sample\Providers;
 
+use App\Contracts\Addons\HasSettings;
 use Config;
 use Illuminate\Support\ServiceProvider;
 use Override;
 use Route;
 
-class SampleServiceProvider extends ServiceProvider
+class SampleServiceProvider extends ServiceProvider implements HasSettings
 {
+    /**
+     * Declare the module's settings.
+     *
+     * These are synced into the `addon_settings` table on boot and editable
+     * from the Settings page inside the Sample panel. Read a value anywhere
+     * with `addon_setting('sample', '<key>')` — see sample_setting() in
+     * this module's helpers.php for a usage example.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function settings(): array
+    {
+        return [
+            [
+                'key'         => 'greeting',
+                'name'        => 'Greeting',
+                'default'     => 'Hello from the Sample module!',
+                'group'       => 'general',
+                'type'        => 'text',
+                'options'     => '',
+                'description' => 'Text returned by sample_module_greeting()',
+                'order'       => 0,
+            ],
+            [
+                'key'         => 'enabled',
+                'name'        => 'Feature Enabled',
+                'default'     => 'true',
+                'group'       => 'general',
+                'type'        => 'boolean',
+                'options'     => 'true,false',
+                'description' => 'Toggle the sample feature on or off',
+                'order'       => 1,
+            ],
+            [
+                'key'         => 'max_items',
+                'name'        => 'Max Items',
+                'default'     => '10',
+                'group'       => 'limits',
+                'type'        => 'int',
+                'options'     => '',
+                'description' => 'Maximum number of sample items to show',
+                'order'       => 0,
+            ],
+            [
+                'key'         => 'threshold',
+                'name'        => 'Threshold',
+                'default'     => '0.5',
+                'group'       => 'limits',
+                'type'        => 'float',
+                'options'     => '',
+                'description' => 'A floating-point threshold value',
+                'order'       => 1,
+            ],
+            [
+                'key'         => 'mode',
+                'name'        => 'Mode',
+                'default'     => 'auto',
+                'group'       => 'limits',
+                'type'        => 'select',
+                'options'     => 'auto,manual,off',
+                'description' => 'Operating mode for the sample feature',
+                'order'       => 2,
+            ],
+        ];
+    }
+
     /**
      * Boot the application events.
      *

--- a/modules/Sample/helpers.php
+++ b/modules/Sample/helpers.php
@@ -20,11 +20,30 @@ if (!function_exists('sample_module_greeting')) {
     /**
      * Return a greeting from the Sample module.
      *
-     * Demonstrates that a module-provided global helper is autoloaded and
-     * callable once the module is enabled.
+     * Demonstrates reading an addon setting: the value is declared by
+     * SampleServiceProvider::settings(), editable from the Sample panel's
+     * Settings page, and read here by addon alias. Falls back to a default
+     * when the setting has not been synced yet.
      */
     function sample_module_greeting(): string
     {
-        return 'Hello from the Sample module!';
+        return (string) addon_setting('sample', 'greeting', 'Hello from the Sample module!');
+    }
+}
+
+if (!function_exists('sample_setting')) {
+    /**
+     * Convenience accessor for any Sample module setting.
+     *
+     * Usage example:
+     *     sample_setting('max_items', 10);   // typed int
+     *     sample_setting('enabled', true);   // typed bool
+     *
+     * @param  mixed $default
+     * @return mixed
+     */
+    function sample_setting(string $key, $default = null)
+    {
+        return addon_setting('sample', $key, $default);
     }
 }

--- a/modules/Sample/helpers.php
+++ b/modules/Sample/helpers.php
@@ -38,11 +38,8 @@ if (!function_exists('sample_setting')) {
      * Usage example:
      *     sample_setting('max_items', 10);   // typed int
      *     sample_setting('enabled', true);   // typed bool
-     *
-     * @param  mixed $default
-     * @return mixed
      */
-    function sample_setting(string $key, $default = null)
+    function sample_setting(string $key, mixed $default = null): mixed
     {
         return addon_setting('sample', $key, $default);
     }

--- a/tests/Feature/Addons/AddonSettingsPageTest.php
+++ b/tests/Feature/Addons/AddonSettingsPageTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\AddonSettings;
+use App\Models\Addon;
+use App\Models\AddonSetting;
+use App\Models\Permission;
+use App\Models\User;
+use App\Services\AddonSettingService;
+use App\Services\AddonSettingSyncService;
+use App\Services\PermissionRegistry;
+use Filament\Facades\Filament;
+use Filament\Panel;
+use Modules\Sample\Providers\Filament\SampleAdminPanelProvider;
+
+function sampleSettingsPanel(): Panel
+{
+    return new SampleAdminPanelProvider(app())->panel(Panel::make());
+}
+
+beforeEach(function (): void {
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    app(AddonSettingSyncService::class)->sync();
+});
+
+it('registers the shared AddonSettings page on an addon panel', function (): void {
+    $panel = sampleSettingsPanel();
+
+    expect($panel->getPages())->toContain(AddonSettings::class);
+});
+
+it('resolves the owning addon from the panel id', function (): void {
+    $service = app(AddonSettingService::class);
+
+    expect($service->resolveAddon('sample'))->not->toBeNull()
+        ->and($service->resolveAddon('sample')->namespace)->toBe('Modules\\Sample')
+        ->and($service->resolveAddon('admin'))->toBeNull();
+});
+
+it('grants page access within the addon panel but not on the core panel', function (): void {
+    Filament::setCurrentPanel(sampleSettingsPanel());
+    expect(AddonSettings::canAccess())->toBeTrue();
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    expect(AddonSettings::canAccess())->toBeFalse();
+});
+
+it('scopes settings to the owning addon only', function (): void {
+    $sample = Addon::where('namespace', 'Modules\\Sample')->firstOrFail();
+
+    // A second addon with its own settings must not appear in Sample's scope.
+    $other = Addon::factory()->create(['registry_id' => 'other/addon']);
+    AddonSetting::factory()->create(['addon_id' => $other->id, 'key' => 'secret']);
+
+    $scoped = app(AddonSettingService::class)->all($sample->id);
+
+    expect($scoped)->toHaveCount(5)
+        ->and($scoped->pluck('addon_id')->unique()->all())->toBe([$sample->id]);
+});
+
+it('contributes the edit:addon-settings permission to the registry', function (): void {
+    expect(app(PermissionRegistry::class)->all())->toContain('edit:addon-settings');
+});
+
+it('only allows editing for a user holding edit:addon-settings', function (): void {
+    Permission::firstOrCreate(['name' => 'edit:addon-settings', 'guard_name' => 'web']);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $viewer = User::factory()->create();
+    $editor = User::factory()->create();
+    $editor->givePermissionTo('edit:addon-settings');
+
+    $this->actingAs($viewer);
+    expect(AddonSettings::canEdit())->toBeFalse();
+
+    $this->actingAs($editor);
+    expect(AddonSettings::canEdit())->toBeTrue();
+});

--- a/tests/Feature/Addons/AddonSettingsPageTest.php
+++ b/tests/Feature/Addons/AddonSettingsPageTest.php
@@ -39,6 +39,8 @@ it('resolves the owning addon from the panel id', function (): void {
 });
 
 it('grants page access within the addon panel but not on the core panel', function (): void {
+    $this->actingAs(User::factory()->create());
+
     Filament::setCurrentPanel(sampleSettingsPanel());
     expect(AddonSettings::canAccess())->toBeTrue();
 

--- a/tests/Feature/Addons/AddonSettingsTest.php
+++ b/tests/Feature/Addons/AddonSettingsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Addon;
+use App\Models\AddonSetting;
+use App\Models\Setting;
+use App\Services\AddonSettingService;
+use App\Services\AddonSettingSyncService;
+use Illuminate\Support\Carbon;
+
+/**
+ * Create an addon row plus one setting and return [Addon, AddonSetting].
+ *
+ * @return array{0: Addon, 1: AddonSetting}
+ */
+function makeAddonSetting(array $addon = [], array $setting = []): array
+{
+    $addonModel = Addon::factory()->create($addon);
+    $settingModel = AddonSetting::factory()->create(['addon_id' => $addonModel->id] + $setting);
+
+    return [$addonModel, $settingModel];
+}
+
+// ── Sync (8.1) ──────────────────────────────────────────────────────────────
+
+it('inserts declared keys with their defaults on first sync', function (): void {
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    app(AddonSettingSyncService::class)->sync();
+
+    $sample = Addon::where('namespace', 'Modules\\Sample')->firstOrFail();
+
+    $greeting = AddonSetting::where('addon_id', $sample->id)->where('key', 'greeting')->first();
+
+    expect($greeting)->not->toBeNull()
+        ->and($greeting->value)->toBe('Hello from the Sample module!')
+        ->and($greeting->default)->toBe('Hello from the Sample module!')
+        ->and($greeting->alias)->toBe('sample');
+});
+
+it('preserves a user-edited value but reconciles metadata on re-sync', function (): void {
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    $sync = app(AddonSettingSyncService::class);
+    $sync->sync();
+
+    $sample = Addon::where('namespace', 'Modules\\Sample')->firstOrFail();
+    $row = AddonSetting::where('addon_id', $sample->id)->where('key', 'greeting')->firstOrFail();
+
+    // User edits the value and we corrupt the description to prove it gets reconciled.
+    $row->update(['value' => 'Custom greeting', 'description' => 'stale']);
+
+    $sync->sync();
+    $row->refresh();
+
+    expect($row->value)->toBe('Custom greeting')
+        ->and($row->description)->toBe('Text returned by sample_module_greeting()');
+});
+
+it('is idempotent — repeated syncs do not duplicate rows', function (): void {
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    $sync = app(AddonSettingSyncService::class);
+
+    $sync->sync();
+
+    $sample = Addon::where('namespace', 'Modules\\Sample')->firstOrFail();
+    $countAfterFirst = AddonSetting::where('addon_id', $sample->id)->count();
+
+    $sync->sync();
+    $countAfterSecond = AddonSetting::where('addon_id', $sample->id)->count();
+
+    expect($countAfterFirst)->toBe(5)
+        ->and($countAfterSecond)->toBe($countAfterFirst);
+});
+
+// ── No HasSettings (8.2) ─────────────────────────────────────────────────────
+
+it('registers no rows for an addon whose providers do not declare settings', function (): void {
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    app(AddonSettingSyncService::class)->sync();
+
+    $awards = Addon::where('namespace', 'Modules\\Awards')->first();
+
+    if ($awards === null) {
+        expect(true)->toBeTrue(); // Awards not bundled in this checkout — nothing to assert.
+
+        return;
+    }
+
+    expect(AddonSetting::where('addon_id', $awards->id)->count())->toBe(0);
+});
+
+// ── Helper resolution (8.3) ──────────────────────────────────────────────────
+
+it('resolves a setting by addon alias', function (): void {
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    app(AddonSettingSyncService::class)->sync();
+
+    expect(addon_setting('sample', 'greeting'))->toBe('Hello from the Sample module!');
+});
+
+it('resolves a setting by addon registry_id', function (): void {
+    makeAddonSetting(
+        ['registry_id' => 'vendor/widget', 'name' => 'Widget'],
+        ['key' => 'token', 'value' => 'abc', 'type' => 'text'],
+    );
+
+    expect(addon_setting('vendor/widget', 'token'))->toBe('abc');
+});
+
+it('returns the default for an unknown addon or key', function (): void {
+    expect(addon_setting('does-not-exist', 'k', 'fallback'))->toBe('fallback');
+
+    makeAddonSetting(['registry_id' => 'vendor/widget'], ['key' => 'known']);
+    expect(addon_setting('vendor/widget', 'missing', 'fallback'))->toBe('fallback');
+});
+
+// ── Typed casting (8.4) ──────────────────────────────────────────────────────
+
+it('casts values by type', function (): void {
+    [$addon] = makeAddonSetting(['registry_id' => 'cast/test'], ['key' => 'flag', 'type' => 'boolean', 'value' => '1']);
+    AddonSetting::factory()->create(['addon_id' => $addon->id, 'key' => 'count', 'type' => 'int', 'value' => '42']);
+    AddonSetting::factory()->create(['addon_id' => $addon->id, 'key' => 'ratio', 'type' => 'float', 'value' => '0.25']);
+    AddonSetting::factory()->create(['addon_id' => $addon->id, 'key' => 'day', 'type' => 'date', 'value' => '2026-01-15']);
+
+    expect(addon_setting('cast/test', 'flag'))->toBeTrue()
+        ->and(addon_setting('cast/test', 'count'))->toBe(42)
+        ->and(addon_setting('cast/test', 'ratio'))->toBe(0.25)
+        ->and(addon_setting('cast/test', 'day'))->toBeInstanceOf(Carbon::class);
+});
+
+// ── Write + cache (8.5) ──────────────────────────────────────────────────────
+
+it('persists a value via addon_setting_save and reads it back fresh', function (): void {
+    makeAddonSetting(['registry_id' => 'vendor/widget'], ['key' => 'token', 'value' => 'old', 'type' => 'text']);
+
+    addon_setting_save('vendor/widget', 'token', 'new');
+
+    expect(addon_setting('vendor/widget', 'token'))->toBe('new')
+        ->and(AddonSetting::query()->where('key', 'token')->value('value'))->toBe('new');
+});
+
+it('does not store to an unknown addon or key', function (): void {
+    [$addon] = makeAddonSetting(['registry_id' => 'vendor/widget'], ['key' => 'token', 'value' => 'old']);
+
+    expect(addon_setting_save('nope', 'token', 'x'))->toBeNull()
+        ->and(app(AddonSettingService::class)->store('vendor/widget', 'missing', 'x'))->toBeNull()
+        ->and(AddonSetting::where('addon_id', $addon->id)->where('key', 'token')->value('value'))->toBe('old');
+});
+
+// ── Isolation (8.6) ──────────────────────────────────────────────────────────
+
+it('isolates settings with the same key across addons', function (): void {
+    makeAddonSetting(['registry_id' => 'addon/alpha'], ['key' => 'api_token', 'value' => 'alpha-token', 'type' => 'text']);
+    makeAddonSetting(['registry_id' => 'addon/beta'], ['key' => 'api_token', 'value' => 'beta-token', 'type' => 'text']);
+
+    expect(addon_setting('addon/alpha', 'api_token'))->toBe('alpha-token')
+        ->and(addon_setting('addon/beta', 'api_token'))->toBe('beta-token');
+});
+
+// ── Core settings unaffected (8.8) ──────────────────────────────────────────
+
+it('leaves the core settings table untouched', function (): void {
+    $before = Setting::count();
+
+    $this->artisan('phpvms:addons-prime')->assertSuccessful();
+    app(AddonSettingSyncService::class)->sync();
+
+    expect(Setting::count())->toBe($before)
+        ->and(Setting::where('id', 'like', 'sample%')->count())->toBe(0);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an admin panel page for managing add-on settings, including grouped, tabbed editing and permission-based access.
  * Introduced typed add-on settings with casting for booleans, dates, integers/floats, and select/string fields.
  * Added a console command and automatic sync at boot to provision/update add-on settings in the database.
  * Added global helpers to read and save add-on settings.

* **Tests**
  * Added feature and unit tests covering sync behavior, access control, typed casting, persistence, and add-on isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->