### PR TITLE
fix(pireps): clear stale ACARS track and logs when reusing a duplicate prefile

### DIFF
--- a/app/Services/PirepService.php
+++ b/app/Services/PirepService.php
@@ -153,6 +153,12 @@ class PirepService extends Service
             if ($pirep->cancelled) {
                 throw new \App\Exceptions\PirepCancelled($pirep);
             }
+
+            // Clear the reused leg's old track and logs so a restarted flight
+            // doesn't inherit a stale flight path or fused log.
+            Acars::where('pirep_id', $pirep->id)
+                ->whereIn('type', [AcarsType::FLIGHT_PATH, AcarsType::LOG])
+                ->delete();
         }
 
         $pirep->status = PirepStatus::INITIATED;

--- a/tests/Feature/PIREPTest.php
+++ b/tests/Feature/PIREPTest.php
@@ -493,6 +493,39 @@ test('duplicate pireps', function (): void {
     expect($dupe_pirep)->toBeFalse();
 });
 
+test('prefile clears stale acars data when reusing a duplicate pirep', function (): void {
+    // An un-closed leg reused as a duplicate must not bleed its old track/logs
+    // into the restarted flight.
+    $pirep = createPirep();
+    apiAs($pirep->user);
+
+    $payload = $pirep->toArray();
+    $payload = transformData($payload);
+
+    // First leg: prefiled, never filed or cancelled.
+    $response = $this->post('/api/pireps/prefile', $payload);
+    $response->assertStatus(200);
+    $pirep_id = $response->json()['data']['id'];
+
+    // Give it a track and a log entry.
+    Acars::factory()->create(['pirep_id' => $pirep_id, 'type' => AcarsType::FLIGHT_PATH]);
+    Acars::factory()->create(['pirep_id' => $pirep_id, 'type' => AcarsType::LOG]);
+
+    $stale = fn (): int => Acars::where('pirep_id', $pirep_id)
+        ->whereIn('type', [AcarsType::FLIGHT_PATH, AcarsType::LOG])
+        ->count();
+
+    expect($stale())->toBe(2);
+
+    // Restart the same flight: prefile reuses the in-progress PIREP...
+    $response = $this->post('/api/pireps/prefile', $payload);
+    $response->assertStatus(200);
+    expect($response->json()['data']['id'])->toEqual($pirep_id);
+
+    // ...with its stale track and logs cleared.
+    expect($stale())->toBe(0);
+});
+
 test('cancel via api', function (): void {
     $pirep = createPirep();
 

--- a/tests/Feature/PIREPTest.php
+++ b/tests/Feature/PIREPTest.php
@@ -507,9 +507,10 @@ test('prefile clears stale acars data when reusing a duplicate pirep', function 
     $response->assertStatus(200);
     $pirep_id = $response->json()['data']['id'];
 
-    // Give it a track and a log entry.
+    // Give it a track and a log entry, plus a planned route that must survive.
     Acars::factory()->create(['pirep_id' => $pirep_id, 'type' => AcarsType::FLIGHT_PATH]);
     Acars::factory()->create(['pirep_id' => $pirep_id, 'type' => AcarsType::LOG]);
+    Acars::factory()->create(['pirep_id' => $pirep_id, 'type' => AcarsType::ROUTE]);
 
     $stale = fn (): int => Acars::where('pirep_id', $pirep_id)
         ->whereIn('type', [AcarsType::FLIGHT_PATH, AcarsType::LOG])
@@ -522,8 +523,9 @@ test('prefile clears stale acars data when reusing a duplicate pirep', function 
     $response->assertStatus(200);
     expect($response->json()['data']['id'])->toEqual($pirep_id);
 
-    // ...with its stale track and logs cleared.
+    // ...with its stale track and logs cleared, but the planned route intact.
     expect($stale())->toBe(0);
+    expect(Acars::where('pirep_id', $pirep_id)->where('type', AcarsType::ROUTE)->count())->toBe(1);
 });
 
 test('cancel via api', function (): void {


### PR DESCRIPTION
## Problem

When a flight doesn't close out (the PIREP is left `IN_PROGRESS` after a divert or abort) and the same flight is restarted within the duplicate-check window, `PirepService::prefile()` adopts the previous PIREP as a "duplicate" and reuses it **wholesale** — keeping the prior leg's ACARS rows.

The result is a "fused" flight: the previous leg's `FLIGHT_PATH` points remain attached, so the live map draws a stray inbound track line into the new departure airport, and the previous leg's `LOG` rows (Touchdown / Landed / Diverted) bleed into the new flight's log.

Reported from an ACARS client (UVAcars), but the cause is server-side — the API serves the reused PIREP's stale track and log:

![Fused flight: stray inbound line to the new departure and a flight log mixing the previous diverted leg's events](https://raw.githubusercontent.com/flythebluesky/phpvms/pr-assets/fused-flight-bug.png)

## Root cause

In `PirepService::prefile()`, the duplicate-reuse branch (`$pirep = $dupe_pirep;`) only resets `status`; it never clears the reused PIREP's accumulated ACARS data. `findDuplicate()` matches on user + airline + flight number + dep/arr within `pireps.duplicate_check_time` and excludes only `CANCELLED`, so a still-`IN_PROGRESS` leg from a never-filed flight qualifies and gets adopted with its old track/logs intact.

The line and log are both rebuilt from those rows (`GeoService::getFeatureFromAcars()` reads every `FLIGHT_PATH` row for the PIREP; the log reads its `LOG` rows), which is why the stale data surfaces in the client.

## Fix

When reusing a duplicate PIREP, delete its `FLIGHT_PATH` and `LOG` ACARS rows so the restarted flight starts clean. The planned `ROUTE` is left intact. This is a no-op for the legitimate double-submit case (a freshly prefiled PIREP has no positions yet).

## Testing

- New feature test `prefile clears stale acars data when reusing a duplicate pirep` — confirmed it fails without the fix (stale rows remain) and passes with it.
- `tests/Feature/PIREPTest.php` — 16 passed (88 assertions), no regressions.
- `vendor/bin/pint --test` and `vendor/bin/phpstan analyse` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a duplicate prefiled entry is reused, the system now clears any stale tracking (flight path) and logging data associated with the reused segment, preventing restarted flights from inheriting old ACARS details.
* **Tests**
  * Added a feature test to verify reused prefile requests remove stale flight path/log ACARS records while preserving unrelated entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->