### PR TITLE
ci: fix the broken test

### DIFF
--- a/tests/Feature/HasNanoIdsTest.php
+++ b/tests/Feature/HasNanoIdsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Contracts\Model;
 use App\Models\File;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 
 /*
@@ -57,15 +56,34 @@ it('reports a non-incrementing string key', function (): void {
         ->and($file->getIncrementing())->toBeFalse();
 });
 
-it('rejects an invalid nano id during route-model binding', function (): void {
-    (new File())->resolveRouteBinding('not a valid id!');
-})->throws(ModelNotFoundException::class);
+it('returns null for an unknown id during route-model binding', function (): void {
+    // Route binding no longer rejects keys purely on Nano ID format — the
+    // database decides existence. An id that matches no row resolves to null
+    // (a 404 over HTTP), it does not throw.
+    expect(new File()->resolveRouteBinding('not a valid id!'))->toBeNull();
+});
 
 it('resolves a valid nano id during route-model binding', function (): void {
     $file = File::factory()->create();
 
-    $resolved = (new File())->resolveRouteBinding($file->id);
+    $resolved = new File()->resolveRouteBinding($file->id);
 
     expect($resolved)->not->toBeNull()
         ->and($resolved->id)->toBe($file->id);
+});
+
+it('resolves a legacy non-format primary key during route-model binding', function (): void {
+    // Regression guard: tables still hold pre-migration keys (v7 UUIDs, older
+    // Nano IDs with a different alphabet/length) that fail Str::isNanoid().
+    // These are valid rows and must still resolve — the strict format gate used
+    // to 404 every one of them (e.g. admin PIREP view/edit links).
+    $legacyId = 'fc4b672f-7a5d-4a2b-a0ee-0e4b74a3c143';
+    $file = File::factory()->create(['id' => $legacyId]);
+
+    expect(Str::isNanoid($legacyId))->toBeFalse();
+
+    $resolved = new File()->resolveRouteBinding($file->id);
+
+    expect($resolved)->not->toBeNull()
+        ->and($resolved->id)->toBe($legacyId);
 });

--- a/tests/Feature/HasNanoIdsTest.php
+++ b/tests/Feature/HasNanoIdsTest.php
@@ -73,11 +73,13 @@ it('resolves a valid nano id during route-model binding', function (): void {
 });
 
 it('resolves a legacy non-format primary key during route-model binding', function (): void {
-    // Regression guard: tables still hold pre-migration keys (v7 UUIDs, older
-    // Nano IDs with a different alphabet/length) that fail Str::isNanoid().
-    // These are valid rows and must still resolve — the strict format gate used
-    // to 404 every one of them (e.g. admin PIREP view/edit links).
-    $legacyId = 'fc4b672f-7a5d-4a2b-a0ee-0e4b74a3c143';
+    // Regression guard: tables still hold pre-migration keys — older Nano IDs
+    // generated with a different (mixed-case) alphabet that fail today's
+    // lowercase-only Str::isNanoid(). These are valid rows and must still
+    // resolve; the strict format gate used to 404 every one of them (e.g. admin
+    // PIREP view/edit links). Uppercase keeps this out of the current alphabet
+    // while still fitting the 16-char id column.
+    $legacyId = 'ABCDEF0123456789';
     $file = File::factory()->create(['id' => $legacyId]);
 
     expect(Str::isNanoid($legacyId))->toBeFalse();

--- a/tests/Feature/Permissions/ModulePanelAccessTest.php
+++ b/tests/Feature/Permissions/ModulePanelAccessTest.php
@@ -6,14 +6,28 @@ use App\Models\Permission;
 use App\Models\User;
 use App\Services\PermissionRegistry;
 use Filament\Panel;
-use Modules\VMSAcars\Filament\Pages\Rules;
+
+/*
+|--------------------------------------------------------------------------
+| Module panel access gating
+|--------------------------------------------------------------------------
+|
+| PermissionRegistry derives a panel's module-access key from the *namespace*
+| of its registered components (Modules\<Name>\...), so these tests use a fake
+| module-namespaced class string. Nothing here depends on a real addon being
+| installed — the class only needs to live under the Modules\ tree.
+|
+*/
+
+// Fake module page — never instantiated; only its namespace is inspected.
+const FAKE_MODULE_PAGE = 'Modules\\FakeModule\\Filament\\Pages\\FakePage';
 
 it("derives the module key from a panel's module-namespaced components", function (): void {
     $panel = Panel::make()
-        ->id('vmsacars::admin')
-        ->pages([Rules::class]);
+        ->id('fakemodule::admin')
+        ->pages([FAKE_MODULE_PAGE]);
 
-    expect(app(PermissionRegistry::class)->moduleKeyForPanel($panel))->toBe('vmsacars');
+    expect(app(PermissionRegistry::class)->moduleKeyForPanel($panel))->toBe('fakemodule');
 });
 
 it('returns null for a core panel', function (): void {
@@ -24,14 +38,14 @@ it('returns null for a core panel', function (): void {
 
 it('gates a module panel on its access permission', function (): void {
     $panel = Panel::make()
-        ->id('vmsacars::admin')
-        ->pages([Rules::class]);
+        ->id('fakemodule::admin')
+        ->pages([FAKE_MODULE_PAGE]);
 
-    Permission::firstOrCreate(['name' => 'access:vmsacars', 'guard_name' => 'web']);
+    Permission::firstOrCreate(['name' => 'access:fakemodule', 'guard_name' => 'web']);
 
     $user = User::factory()->create();
     expect($user->canAccessPanel($panel))->toBeFalse();
 
-    $user->givePermissionTo('access:vmsacars');
+    $user->givePermissionTo('access:fakemodule');
     expect($user->fresh()->canAccessPanel($panel))->toBeTrue();
 });

--- a/tests/Feature/Permissions/PermissionRegistryTest.php
+++ b/tests/Feature/Permissions/PermissionRegistryTest.php
@@ -67,6 +67,8 @@ it('attributes app classes to the core scope and module classes to their module'
     $registry = app(PermissionRegistry::class);
 
     expect($registry->moduleOf(User::class))->toBeNull();
+    // Plain class strings — moduleOf() only inspects the namespace, so no real
+    // addon needs to be installed.
     expect($registry->moduleOf(Rule::class))->toBe('VMSAcars');
     expect($registry->moduleOf('Modules\\Awards\\Filament\\Pages\\Foo'))->toBe('Awards');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route-based lookups for Nano IDs: invalid keys now fail gracefully with no result instead of producing an error.
  * Ensured legacy (older, non-Nano ID) primary keys that exist in the database continue to resolve correctly.

* **Tests**
  * Updated and expanded automated coverage to prevent regressions in both Nano ID and legacy key resolution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->