### PR TITLE
fix(simbrief): restore airframe selection dropped by the seven theme

### DIFF
--- a/resources/views/layouts/seven/flights/simbrief_form.blade.php
+++ b/resources/views/layouts/seven/flights/simbrief_form.blade.php
@@ -17,19 +17,24 @@
                     <div class="col-sm-4">
                       <label for="type">Type</label>
                       <input type="text" class="form-control" value="{{ $aircraft->icao }}" maxlength="4" disabled>
-                      @if(filled($aircraft->simbrief_type))
-                        <input type="hidden" name="type" value="{{ $aircraft->simbrief_type }}">
-                      @elseif(filled($aircraft->subfleet->simbrief_type))
-                        <input type="hidden" name="type" value="{{ $aircraft->subfleet->simbrief_type }}">
-                      @else
-                        <input type="hidden" name="type" value="{{ $aircraft->icao }}">
-                      @endif
+                      <input type="hidden" id="actype" name="type" value="{{ $actype }}">
                     </div>
                     <div class="col-sm-4">
                       <label for="reg">Registration</label>
                       <input type="text" class="form-control" value="{{ $aircraft->registration }}" maxlength="6" disabled>
                       <input type="hidden" name="reg" value="{{ $aircraft->registration }}">
                     </div>
+                    @if($sbairframes)
+                      <div class="col-sm-4">
+                        <label for="sbairframe">SimBrief Airframes</label>
+                        <select name="airframes" id="sbairframe" class="form-select" onchange="CheckAirframe()">
+                          <option value="">Select an airframe if required...</option>
+                          @foreach($sbairframes as $af)
+                            <option value="{{ $af->airframe_id }}">{{ $af->name }}</option>
+                          @endforeach
+                        </select>
+                      </div>
+                    @endif
                   </div>
                     @if(empty($pax_load_sheet) && empty($cargo_load_sheet) && empty($tpayload) && empty($tpaxload))
                     <div class="alert alert-warning mt-4 text-center" role="alert">
@@ -135,7 +140,7 @@
               </div>
 
               {{-- Prepare Form Fields For SimBrief --}}
-                <input type="hidden" name="acdata" value="{'paxwgt':{{ round($pax_weight) }}, 'bagwgt': {{ round($bag_weight) }}}">
+                <input type="hidden" name="acdata" id="acdata" value="{{ $acdata }}">
                 @if($tpaxfig)
                   <input type="hidden" name="pax" value="{{ $tpaxfig }}">
                 @elseif(!$tpaxfig && $tcargoload)
@@ -382,6 +387,34 @@
 @endsection
 @section('scripts')
 <script src="{{public_asset('/assets/global/js/simbrief.apiv1.js')}}"></script>
+@if($sbairframes)
+<script type="text/javascript">
+  // ******
+  // Change Aircraft Type According to Airframe selection
+  // And remove pax and baggage weights from acdata
+  function CheckAirframe() {
+    let weight = Boolean({{ setting('simbrief.use_standard_weights', false) }})
+    let actype = String("{{ $actype }}");
+    let acdata = String("{{ $acdata }}");
+    acOrig = JSON.parse(acdata.replace(/&quot;/g,'"'));
+    acJson = JSON.parse(acdata.replace(/&quot;/g,'"'));
+    let airframe = document.getElementById("sbairframe").value;
+    if (airframe != "") {
+      document.getElementById("actype").value = airframe
+      if (!weight) {
+        delete acJson.paxwgt
+        delete acJson.bagwgt
+        document.getElementById("acdata").value = JSON.stringify(acJson)
+      }
+    } else {
+      document.getElementById("actype").value = actype
+      if (!weight) {
+        document.getElementById("acdata").value = JSON.stringify(acOrig)
+      }
+    }
+  }
+</script>
+@endif
 <script type="text/javascript">
   // ******
   // Disable Submitting a fixed flight level for Stepclimb option to work


### PR DESCRIPTION
## Problem

Selecting an aircraft with linked SimBrief airframes and generating an OFP always produces a plan for the generic base type (e.g. `A21N`) — a custom airframe such as the Fenix A321 CFM SL never activates, even though it exists in `simbrief_airframes` and is linked to the aircraft by ICAO.

## Root cause

The seven theme (#1921) rewrote `simbrief_form.blade.php` from a pre-#1892 copy of the old default theme, silently dropping the SimBrief Airframes feature that had merged five weeks earlier. `SimBriefController::generate()` still computes and passes `sbairframes`, `sbaircraft`, `acdata`, and `actype` to the view, but the seven form never references them: it re-implements the `type` fallback inline and hardcodes `acdata` to pax/bag weights only. With no way to send an `airframe_id` as the `type` parameter, SimBrief can never resolve a saved airframe.

## Fix

Port the airframe selection from the old theme's form (last working at `5862b406`) into the seven theme:

- Render a **SimBrief Airframes** select next to Type/Registration when the aircraft has linked airframes.
- Restore `CheckAirframe()`: selecting an airframe swaps the hidden `type` field to its `airframe_id` (which is what activates the saved profile) and strips pax/bag weights from `acdata` unless `simbrief.use_standard_weights` is set; deselecting restores both.
- Wire the hidden `type` and `acdata` fields to the controller's `$actype` / `$acdata` instead of hardcoding them, so the full airframe payload (MZFW/MTOW/MLW/hexcode/maxpax) is sent again.

The `sbaircraft` climb/cruise/descent profile selectors also dropped in #1921 are left for a follow-up to keep this focused on the regression.

![SimBrief form with the restored airframe dropdown, Fenix A321 CFM SL selected](https://raw.githubusercontent.com/flythebluesky/phpvms/pr-assets/simbrief-airframe-form.png)

## Testing

- Verified end-to-end on a fresh dev install: the dropdown renders with the aircraft's linked airframes; selecting one swaps the hidden `type` to its `airframe_id` (`B744` → `123456_999888`) and removes `paxwgt`/`bagwgt` from `acdata`; deselecting restores the originals.
- `php artisan view:cache` compiles all Blade templates cleanly.
- No backend changes; no tests render this view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional airframe selector to help choose the correct aircraft type when available.
  * Improved flight form data handling so aircraft type and registration are filled more reliably.

* **Bug Fixes**
  * Updated passenger and baggage weight values to use server-provided data, reducing mismatches in submitted flight details.
  * Improved form behavior so standard weight fields are excluded when they are not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->