### PR TITLE
[8.x] fix(finance): keep the journal relation fresh after initJournal()

### DIFF
--- a/app/Traits/JournalTrait.php
+++ b/app/Traits/JournalTrait.php
@@ -44,6 +44,12 @@ trait JournalTrait
 
             $journal->refresh();
 
+            // The `!$this->journal` guard above lazy-loaded the relation and cached
+            // it as null. Saving through the relation does not update that cache, so
+            // without this the model keeps returning null for ->journal until it is
+            // reloaded from the database. Reflect the freshly-created journal here.
+            $this->setRelation('journal', $journal);
+
             return $journal;
         }
 

--- a/tests/Unit/JournalTraitTest.php
+++ b/tests/Unit/JournalTraitTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Airline;
+
+/*
+ * Regression coverage for JournalTrait::initJournal().
+ *
+ * The `!$this->journal` guard inside initJournal() lazy-loads the journal
+ * relation and caches it as null. Saving the new journal through the relation
+ * does not refresh that cache, so the creating model previously kept returning
+ * null for ->journal until it was reloaded from the database.
+ */
+
+test('initJournal populates the journal relation on the same instance', function (): void {
+    // Creating a model that uses JournalTrait fires the `created` hook, which
+    // calls initJournal(). The freshly-created instance must expose the journal
+    // immediately, without a reload from the database.
+    $airline = Airline::factory()->create();
+
+    expect($airline->relationLoaded('journal'))->toBeTrue()
+        ->and($airline->journal)->not->toBeNull()
+        ->and($airline->journal->exists)->toBeTrue();
+
+    // The cached relation must be the row that was actually persisted, i.e. the
+    // same journal a fresh reload from the database resolves to.
+    expect($airline->journal->id)->toBe($airline->fresh()->journal->id);
+});


### PR DESCRIPTION
The `!$this->journal` guard in JournalTrait::initJournal() lazy-loads the journal relation and caches it as null. Saving the newly created journal through the relation does not update that cache, so the creating model kept returning null for ->journal until it was reloaded from the database.

Set the relation on the instance after saving, and add a regression test asserting the journal is available immediately after creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created journals now appear immediately on the same record without requiring a refresh.
  * Fixed an issue where the journal relation could remain `null` in memory after creation.
* **Tests**
  * Added a regression test to confirm the journal is loaded right away and persists correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->