### PR TITLE
[8.x] test(addons): clean up the configured boot cache path, not the real file

### DIFF
--- a/tests/Unit/Addons/AddonRuntimeTest.php
+++ b/tests/Unit/Addons/AddonRuntimeTest.php
@@ -37,24 +37,29 @@ function makeAddonBootCache(array $overrides = []): AddonBootCache
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
+// BootCache reads config('addons.paths.boot_cache'), which tests/Pest.php
+// redirects to a unique temp file per test. Clean up THAT path — never the real
+// base_path('bootstrap/cache/addons.php'): it is a single file shared by every
+// test (and parallel worker), so deleting it here makes later tests boot without
+// the addon registry (ComponentNotFound / CommandNotFound cascades).
 beforeEach(function (): void {
-    $path = base_path('bootstrap/cache/addons.php');
+    $path = config('addons.paths.boot_cache');
     if (file_exists($path)) {
         unlink($path);
     }
 
-    foreach (glob(base_path('bootstrap/cache/addons.php.tmp*')) ?: [] as $tmp) {
+    foreach (glob($path.'.tmp*') ?: [] as $tmp) {
         @unlink($tmp);
     }
 });
 
 afterEach(function (): void {
-    $path = base_path('bootstrap/cache/addons.php');
+    $path = config('addons.paths.boot_cache');
     if (file_exists($path)) {
         unlink($path);
     }
 
-    foreach (glob(base_path('bootstrap/cache/addons.php.tmp*')) ?: [] as $tmp) {
+    foreach (glob($path.'.tmp*') ?: [] as $tmp) {
         @unlink($tmp);
     }
 });
@@ -184,11 +189,14 @@ it('hostile registryId round-trips unchanged through write()/read()', function (
 // No leftover temp files
 // ---------------------------------------------------------------------------
 
-it('leaves no leftover temp files in bootstrap/cache after write()', function (): void {
+it('leaves no leftover temp files after write()', function (): void {
     $runtime = new BootCache();
     $runtime->write([makeAddonBootCache()]);
 
-    $tmpFiles = glob(base_path('bootstrap/cache/addons.php.tmp*')) ?: [];
+    // write() creates its temp file next to the configured boot cache path, so
+    // glob that path — not the hard-coded bootstrap/cache location, which the
+    // per-test config redirect no longer points at.
+    $tmpFiles = glob(config('addons.paths.boot_cache').'.tmp*') ?: [];
 
     expect($tmpFiles)->toBeEmpty();
 });


### PR DESCRIPTION
tests/Pest.php redirects addons.paths.boot_cache to a unique temp file per test, and BootCache honors that config. But AddonRuntimeTest still hard-coded base_path('bootstrap/cache/addons.php') in its setup/teardown and in the leftover-temp-file assertion.

Two problems: the teardown could delete the real, shared bootstrap/cache addons file out from under other tests (ComponentNotFound / CommandNotFound cascades, worse under parallel runs), and the leftover-temp assertion globbed a directory write() never touches, so it passed unconditionally.

Read config('addons.paths.boot_cache') everywhere so the test operates on the redirected per-test path it actually writes to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated addon runtime test cleanup and assertions to follow the configured boot cache location.
  * Improved temporary file handling in test setup/teardown so leftover cache files are removed from the current cache path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->