### PR TITLE
feat(flights): with=bid briefing fast-path + per-request setting() memo

### DIFF
--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -42,6 +42,16 @@ class FlightController extends Controller
         return $this->search($request);
     }
 
+    /**
+     * Return a single flight.
+     *
+     * When the request carries the controlled `with=bid` token, the flight's
+     * `subfleets` is set to just the authenticated pilot's bid aircraft
+     * subfleet(s) with reconciled fares, skipping the accessible-fleet
+     * expansion (the ~234-subfleet source of the slow bid briefing). No bid →
+     * empty subfleets. `bid` is a server-controlled token, never a relation
+     * path passed to Eloquent `->with()`. Without it, behaviour is unchanged.
+     */
     public function get(string $id, Request $request): FlightResource
     {
         /** @var User $user */

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\SearchFlightsRequest;
 use App\Http\Resources\FlightResource;
 use App\Http\Resources\NavdataResource;
 use App\Models\Aircraft;
+use App\Models\Bid;
 use App\Models\Flight;
 use App\Models\SimBrief;
 use App\Models\User;
@@ -40,7 +41,7 @@ class FlightController extends Controller
         return $this->search($request);
     }
 
-    public function get(string $id): FlightResource
+    public function get(string $id, Request $request): FlightResource
     {
         /** @var User $user */
         $user = Auth::user();
@@ -55,10 +56,14 @@ class FlightController extends Controller
             ])
             ->findOrFail($id);
 
-        $flight->setRelation(
-            'subfleets',
-            $flight->accessibleSubfleetsFor($user, ['aircraft', 'fares']),
-        );
+        if ($this->hasBidToken($request)) {
+            $this->loadBidSubfleets($flight, $user->id);
+        } else {
+            $flight->setRelation(
+                'subfleets',
+                $flight->accessibleSubfleetsFor($user, ['aircraft', 'fares']),
+            );
+        }
 
         $flight = $this->fareSvc->getReconciledFaresForFlight($flight);
 
@@ -70,7 +75,9 @@ class FlightController extends Controller
         /** @var User $user */
         $user = Auth::user();
 
-        $query = $this->flightSearchQuery->build($request)
+        $onlyActive = !$request->filled('flight_id');
+
+        $query = $this->flightSearchQuery->build($request, $onlyActive)
             ->whereHas('airline', function ($q): void {
                 $q->where('active', true);
             });
@@ -103,9 +110,11 @@ class FlightController extends Controller
             $relations = explode(',', (string) $request->input('with', ''));
         }
 
+        $withBid = in_array('bid', $relations, true);
+
         $query->with($with);
 
-        if (in_array('subfleets', $relations, true)) {
+        if (!$withBid && in_array('subfleets', $relations, true)) {
             $query->withAccessibleSubfleets($user);
         }
 
@@ -113,10 +122,49 @@ class FlightController extends Controller
         $flights = $query->paginate($perPage);
 
         foreach ($flights as $flight) {
+            if ($withBid) {
+                $this->loadBidSubfleets($flight, $user->id);
+            }
+
             $this->fareSvc->getReconciledFaresForFlight($flight);
         }
 
         return FlightResource::collection($flights);
+    }
+
+    /**
+     * Check whether the request carries the controlled `bid` token in `?with=`.
+     */
+    private function hasBidToken(Request $request): bool
+    {
+        if (!$request->has('with')) {
+            return false;
+        }
+
+        $tokens = array_map(trim(...), explode(',', (string) $request->input('with', '')));
+
+        return in_array('bid', $tokens, true);
+    }
+
+    /**
+     * Resolve the authenticated user's bid(s) on the given flight, load
+     * `bid.aircraft.subfleet.fares`, and set the flight's `subfleets` relation
+     * to exactly those subfleet(s).  No fleet expansion is performed.
+     * A pilot with no bid gets an empty `subfleets` collection.
+     */
+    private function loadBidSubfleets(Flight $flight, int $userId): void
+    {
+        $bids = Bid::where('flight_id', $flight->id)
+            ->where('user_id', $userId)
+            ->with('aircraft.subfleet.fares')
+            ->get();
+
+        $subfleets = $bids->pluck('aircraft.subfleet')
+            ->filter()
+            ->unique('id')
+            ->values();
+
+        $flight->setRelation('subfleets', $subfleets);
     }
 
     /**

--- a/app/Http/Controllers/Api/FlightController.php
+++ b/app/Http/Controllers/Api/FlightController.php
@@ -19,6 +19,7 @@ use App\Services\FareService;
 use App\Services\FlightService;
 use Exception;
 use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
@@ -57,7 +58,7 @@ class FlightController extends Controller
             ->findOrFail($id);
 
         if ($this->hasBidToken($request)) {
-            $this->loadBidSubfleets($flight, $user->id);
+            $this->decorateBidSubfleets([$flight], $user->id);
         } else {
             $flight->setRelation(
                 'subfleets',
@@ -107,7 +108,7 @@ class FlightController extends Controller
 
         $relations = ['subfleets'];
         if ($request->has('with')) {
-            $relations = explode(',', (string) $request->input('with', ''));
+            $relations = array_map(trim(...), explode(',', (string) $request->input('with', '')));
         }
 
         $withBid = in_array('bid', $relations, true);
@@ -121,11 +122,11 @@ class FlightController extends Controller
         $perPage = paginate_limit($request->integer('limit') ?: null);
         $flights = $query->paginate($perPage);
 
-        foreach ($flights as $flight) {
-            if ($withBid) {
-                $this->loadBidSubfleets($flight, $user->id);
-            }
+        if ($withBid) {
+            $this->decorateBidSubfleets($flights->getCollection(), $user->id);
+        }
 
+        foreach ($flights as $flight) {
             $this->fareSvc->getReconciledFaresForFlight($flight);
         }
 
@@ -147,24 +148,38 @@ class FlightController extends Controller
     }
 
     /**
-     * Resolve the authenticated user's bid(s) on the given flight, load
-     * `bid.aircraft.subfleet.fares`, and set the flight's `subfleets` relation
-     * to exactly those subfleet(s).  No fleet expansion is performed.
-     * A pilot with no bid gets an empty `subfleets` collection.
+     * Set each flight's `subfleets` relation to exactly the authenticated
+     * user's bid subfleet(s) on that flight, resolved in a single batched
+     * query. Loads `bid.aircraft.subfleet` with its aircraft + fares — the
+     * same eager set the legacy accessible-fleet path loads, so serialization
+     * (SubfleetResource reads `->aircraft`) does not lazy-load. No fleet
+     * expansion is performed; a flight with no bid gets an empty collection.
+     *
+     * @param iterable<Flight> $flights
      */
-    private function loadBidSubfleets(Flight $flight, int $userId): void
+    private function decorateBidSubfleets(iterable $flights, int $userId): void
     {
-        $bids = Bid::where('flight_id', $flight->id)
+        $flights = collect($flights);
+
+        if ($flights->isEmpty()) {
+            return;
+        }
+
+        $bidsByFlight = Bid::whereIn('flight_id', $flights->pluck('id'))
             ->where('user_id', $userId)
-            ->with('aircraft.subfleet.fares')
-            ->get();
+            ->with('aircraft.subfleet.aircraft', 'aircraft.subfleet.fares')
+            ->get()
+            ->groupBy('flight_id');
 
-        $subfleets = $bids->pluck('aircraft.subfleet')
-            ->filter()
-            ->unique('id')
-            ->values();
+        foreach ($flights as $flight) {
+            $subfleets = ($bidsByFlight->get($flight->id) ?? collect())
+                ->pluck('aircraft.subfleet')
+                ->filter()
+                ->unique('id')
+                ->values();
 
-        $flight->setRelation('subfleets', $subfleets);
+            $flight->setRelation('subfleets', new EloquentCollection($subfleets->all()));
+        }
     }
 
     /**

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -526,6 +526,11 @@ class Flight extends Model
         return $this->hasMany(FlightFieldValue::class, 'flight_id', 'id');
     }
 
+    public function bids(): HasMany
+    {
+        return $this->hasMany(Bid::class, 'flight_id');
+    }
+
     public function simbrief(): BelongsTo
     {
         return $this->belongsTo(SimBrief::class, 'id', 'flight_id');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -52,6 +52,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -75,6 +76,13 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Schema::defaultStringLength(191);
+
+        // The SettingService memo is request-scoped via config/octane.php 'flush',
+        // but a long-running queue worker is not flushed per job. Reset the memo
+        // before each job so a worker observes settings changed by other
+        // processes — otherwise a stale memoized value could be written back into
+        // the shared cache on the next Cache::remember() miss.
+        Queue::before(static fn () => app(SettingService::class)->clearMemo());
 
         Model::preventLazyLoading(!$this->app->isProduction());
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,6 +32,7 @@ use App\Services\RouteForge\Rules\L6OriginEqualsDestination;
 use App\Services\RouteForge\Rules\L7SubfleetsHaveNoFares;
 use App\Services\RouteForge\Rules\L8EventDatesOutsideWindow;
 use App\Services\RouteForge\Rules\L9BatchOver50;
+use App\Services\SettingService;
 use App\Support\ThemeViewFinder;
 use App\Support\Units\Time;
 use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
@@ -209,6 +210,12 @@ class AppServiceProvider extends ServiceProvider
         ));
 
         $this->app->singleton(ModuleService::class);
+
+        // Core settings read/write. Bound as a singleton so the per-request
+        // Tier-1 memo ($memo array) is shared across all setting() calls within
+        // one request. Registered in config/octane.php 'flush' so Octane
+        // discards the instance (empty memo) before each new request.
+        $this->app->singleton(SettingService::class);
 
         // Per-addon settings read/write. Stateless/Octane-safe; bound as a
         // singleton so the `addon_setting()` helper reuses one instance.

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -107,9 +107,9 @@ class SettingService extends Service
     }
 
     /**
-     * Clear all memoized values. Called by AppServiceProvider's DB listener
-     * when any write to the settings table occurs (covering paths that bypass
-     * store(), such as YamlDatabaseService raw DB writes).
+     * Clear all memoized values. Called at request/job boundaries that the
+     * Octane 'flush' does not cover (AppServiceProvider's Queue::before hook)
+     * and after raw settings writes that bypass store() (YamlDatabaseService).
      */
     public function clearMemo(): void
     {

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -23,13 +23,24 @@ use Illuminate\Support\Facades\Cache;
  * The 60-second CacheableRepository layer that the old repo inherited is
  * intentionally not preserved — the only path doing many reads is the
  * `setting()` helper, which has its own application cache.
+ *
+ * Tier-1 memo: $memo caches resolved values for the duration of one request
+ * (keyed by the formatted setting id). The service is bound as a singleton
+ * and registered in config/octane.php 'flush' so Octane discards the instance
+ * (and its memo) before every new request.
  */
 class SettingService extends Service
 {
     use CastsSettingValue;
 
+    /** @var array<string, mixed> Per-request in-process memo, keyed by formatted setting id. */
+    private array $memo = [];
+
     /**
      * Retrieve a typed setting value.
+     *
+     * Resolved values are memoized in $memo for the lifetime of the current
+     * request so repeated reads of the same key hit the source at most once.
      *
      * @throws SettingNotFound when the key has no row in `settings`.
      */
@@ -37,13 +48,17 @@ class SettingService extends Service
     {
         $key = Setting::formatKey($key);
 
+        if (array_key_exists($key, $this->memo)) {
+            return $this->memo[$key];
+        }
+
         $setting = Setting::where('id', $key)->first(['type', 'value']);
 
         if ($setting === null) {
             throw new SettingNotFound($key.' not found');
         }
 
-        return $this->castSettingValue($setting->type, $setting->value);
+        return $this->memo[$key] = $this->castSettingValue($setting->type, $setting->value);
     }
 
     /**
@@ -77,6 +92,7 @@ class SettingService extends Service
             $setting->save();
 
             $this->forgetCache($key);
+            unset($this->memo[$formattedKey]);
         }
 
         return $value;
@@ -88,6 +104,16 @@ class SettingService extends Service
     public function save(string $key, mixed $value): mixed
     {
         return $this->store($key, $value);
+    }
+
+    /**
+     * Clear all memoized values. Called by AppServiceProvider's DB listener
+     * when any write to the settings table occurs (covering paths that bypass
+     * store(), such as YamlDatabaseService raw DB writes).
+     */
+    public function clearMemo(): void
+    {
+        $this->memo = [];
     }
 
     private function forgetCache(string $key): void

--- a/app/Services/YamlDatabaseService.php
+++ b/app/Services/YamlDatabaseService.php
@@ -106,6 +106,12 @@ class YamlDatabaseService extends Service
             }
 
             $this->resetPostgresSequence($table, $id_column);
+
+            // Raw writes here bypass SettingService::store(), so drop the
+            // per-request memo to keep same-request reads coherent.
+            if ($table === 'settings') {
+                app(SettingService::class)->clearMemo();
+            }
         }
 
         return $imported;

--- a/config/octane.php
+++ b/config/octane.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Services\SettingService;
 use Laravel\Octane\Contracts\OperationTerminated;
 use Laravel\Octane\Events\RequestHandled;
 use Laravel\Octane\Events\RequestReceived;
@@ -146,7 +147,7 @@ return [
     ],
 
     'flush' => [
-        //
+        SettingService::class,
     ],
 
     /*

--- a/tests/Feature/FlightBidFastPathTest.php
+++ b/tests/Feature/FlightBidFastPathTest.php
@@ -1,0 +1,245 @@
+<?php
+
+use App\Models\Aircraft;
+use App\Models\Bid;
+use App\Models\Fare;
+use App\Models\Flight;
+use App\Models\Subfleet;
+use App\Models\User;
+use App\Services\FareService;
+
+// ---------------------------------------------------------------------------
+// get() with=bid
+// ---------------------------------------------------------------------------
+
+test('get with bid token returns only bid subfleet and reconciled fares', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $fareSvc = app(FareService::class);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $subfleet = Subfleet::factory()->create();
+    $aircraft = Aircraft::factory()->create(['subfleet_id' => $subfleet->id]);
+
+    $fare = Fare::factory()->create();
+    // Subfleet-level fare override — this is what the API returns (SubfleetResource applies
+    // subfleet pivot; flight-level overrides are recomputed at PIREP-file time).
+    $fareSvc->setForSubfleet($subfleet, $fare, ['price' => 100, 'capacity' => 50]);
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+    $flight->subfleets()->attach($subfleet->id);
+
+    Bid::create([
+        'user_id'     => $user->id,
+        'flight_id'   => $flight->id,
+        'aircraft_id' => $aircraft->id,
+    ]);
+
+    $res = $this->get('/api/flights/'.$flight->id.'?with=bid');
+    $res->assertStatus(200);
+
+    $body = $res->json()['data'];
+    // Subfleet is the bid's subfleet; fare is present with the subfleet-level price.
+    expect($body['subfleets'])->toHaveCount(1)
+        ->and($body['subfleets'][0]['id'])->toBe($subfleet->id)
+        ->and($body['subfleets'][0]['fares'])->toHaveCount(1)
+        ->and((float) $body['subfleets'][0]['fares'][0]['price'])->toEqual(100.0);
+});
+
+test('get with bid token returns empty subfleets when pilot has no bid', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+
+    $res = $this->get('/api/flights/'.$flight->id.'?with=bid');
+    $res->assertStatus(200);
+
+    expect($res->json()['data']['subfleets'])->toBeEmpty();
+});
+
+test('get with bid token only shows the authenticated pilots own bid subfleet', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $pilotA = User::factory()->create();
+    $pilotB = User::factory()->create();
+
+    $subfleetA = Subfleet::factory()->create();
+    $aircraftA = Aircraft::factory()->create(['subfleet_id' => $subfleetA->id]);
+
+    $subfleetB = Subfleet::factory()->create();
+    $aircraftB = Aircraft::factory()->create(['subfleet_id' => $subfleetB->id]);
+
+    $flight = Flight::factory()->create(['airline_id' => $pilotA->airline_id]);
+
+    Bid::create(['user_id' => $pilotA->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraftA->id]);
+    Bid::create(['user_id' => $pilotB->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraftB->id]);
+
+    apiAs($pilotA);
+
+    $res = $this->get('/api/flights/'.$flight->id.'?with=bid');
+    $res->assertStatus(200);
+
+    $subfleets = $res->json()['data']['subfleets'];
+    expect($subfleets)->toHaveCount(1)
+        ->and($subfleets[0]['id'])->toBe($subfleetA->id);
+});
+
+test('get without bid token performs full accessible fleet expansion', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $subfleet1 = Subfleet::factory()->create();
+    $subfleet2 = Subfleet::factory()->create();
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+    $flight->subfleets()->attach([$subfleet1->id, $subfleet2->id]);
+
+    $res = $this->get('/api/flights/'.$flight->id);
+    $res->assertStatus(200);
+
+    // Both pinned subfleets returned via accessibleSubfleetsFor (fleet expansion path)
+    expect($res->json()['data']['subfleets'])->toHaveCount(2);
+});
+
+test('get with bid token skips accessible fleet expansion (behavioral proof)', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    // Two subfleets both pinned to flight
+    $subfleet1 = Subfleet::factory()->create();
+    $subfleet2 = Subfleet::factory()->create();
+    $aircraft1 = Aircraft::factory()->create(['subfleet_id' => $subfleet1->id]);
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+    $flight->subfleets()->attach([$subfleet1->id, $subfleet2->id]);
+
+    // Bid only on subfleet1's aircraft
+    Bid::create(['user_id' => $user->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraft1->id]);
+
+    $res = $this->get('/api/flights/'.$flight->id.'?with=bid');
+    $res->assertStatus(200);
+
+    // Fleet expansion would return 2 subfleets; bid fast-path returns only 1
+    $subfleets = $res->json()['data']['subfleets'];
+    expect($subfleets)->toHaveCount(1)
+        ->and($subfleets[0]['id'])->toBe($subfleet1->id);
+});
+
+// ---------------------------------------------------------------------------
+// search() with=bid
+// ---------------------------------------------------------------------------
+
+test('search with bid token decorates bid flights with subfleet and empty for non-bid flights', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+    updateSetting('pilots.restrict_to_company', false);
+    updateSetting('pilots.only_flights_from_current', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $subfleet = Subfleet::factory()->create();
+    $aircraft = Aircraft::factory()->create(['subfleet_id' => $subfleet->id]);
+
+    $flight1 = Flight::factory()->create(['airline_id' => $user->airline_id]);
+    $flight2 = Flight::factory()->create(['airline_id' => $user->airline_id]);
+
+    Bid::create(['user_id' => $user->id, 'flight_id' => $flight1->id, 'aircraft_id' => $aircraft->id]);
+
+    $res = $this->get('/api/flights/search?with=bid');
+    $res->assertStatus(200);
+
+    $data = collect($res->json()['data']);
+
+    $f1 = $data->firstWhere('id', $flight1->id);
+    $f2 = $data->firstWhere('id', $flight2->id);
+
+    expect($f1)->not()->toBeNull()
+        ->and($f1['subfleets'])->toHaveCount(1)
+        ->and($f1['subfleets'][0]['id'])->toBe($subfleet->id);
+
+    expect($f2)->not()->toBeNull()
+        ->and($f2['subfleets'])->toBeEmpty();
+});
+
+// ---------------------------------------------------------------------------
+// By-id search visibility
+// ---------------------------------------------------------------------------
+
+test('search with flight_id returns invisible flight', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $flight = Flight::factory()->create([
+        'airline_id' => $user->airline_id,
+        'visible'    => false,
+    ]);
+
+    $res = $this->get('/api/flights/search?flight_id='.$flight->id);
+    $res->assertStatus(200);
+
+    $data = $res->json()['data'];
+    expect($data)->toHaveCount(1)
+        ->and($data[0]['id'])->toBe($flight->id);
+});
+
+test('browse search without flight_id hides invisible flights', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pilots.restrict_to_company', false);
+    updateSetting('pilots.only_flights_from_current', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $visible = Flight::factory()->create(['airline_id' => $user->airline_id, 'visible' => true]);
+    $invisible = Flight::factory()->create(['airline_id' => $user->airline_id, 'visible' => false]);
+
+    $res = $this->get('/api/flights/search');
+    $res->assertStatus(200);
+
+    $ids = collect($res->json()['data'])->pluck('id');
+    expect($ids)->toContain($visible->id)
+        ->and($ids)->not()->toContain($invisible->id);
+});
+
+test('search by flight_id with bid token returns invisible flight with bid subfleets', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $subfleet = Subfleet::factory()->create();
+    $aircraft = Aircraft::factory()->create(['subfleet_id' => $subfleet->id]);
+
+    $flight = Flight::factory()->create([
+        'airline_id' => $user->airline_id,
+        'visible'    => false,
+    ]);
+
+    Bid::create(['user_id' => $user->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraft->id]);
+
+    $res = $this->get('/api/flights/search?flight_id='.$flight->id.'&with=bid');
+    $res->assertStatus(200);
+
+    $data = $res->json()['data'];
+    expect($data)->toHaveCount(1)
+        ->and($data[0]['id'])->toBe($flight->id)
+        ->and($data[0]['subfleets'])->toHaveCount(1)
+        ->and($data[0]['subfleets'][0]['id'])->toBe($subfleet->id);
+});

--- a/tests/Feature/FlightBidFastPathTest.php
+++ b/tests/Feature/FlightBidFastPathTest.php
@@ -138,6 +138,37 @@ test('get with bid token skips accessible fleet expansion (behavioral proof)', f
         ->and($subfleets[0]['id'])->toBe($subfleet1->id);
 });
 
+test('get with bid returns all bid subfleets with eager aircraft and no lazy load', function (): void {
+    // Two bids (two aircraft in two subfleets) on one flight. With >= 2 hydrated
+    // subfleets, preventLazyLoading (on outside production) would throw if the
+    // subfleet's aircraft were not eager-loaded when SubfleetResource reads it.
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $subfleetA = Subfleet::factory()->create();
+    $aircraftA = Aircraft::factory()->create(['subfleet_id' => $subfleetA->id]);
+    $subfleetB = Subfleet::factory()->create();
+    $aircraftB = Aircraft::factory()->create(['subfleet_id' => $subfleetB->id]);
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+
+    Bid::create(['user_id' => $user->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraftA->id]);
+    Bid::create(['user_id' => $user->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraftB->id]);
+
+    $res = $this->get('/api/flights/'.$flight->id.'?with=bid');
+    $res->assertStatus(200);
+
+    $subfleets = collect($res->json()['data']['subfleets']);
+    expect($subfleets)->toHaveCount(2)
+        ->and($subfleets->pluck('id')->all())->toContain($subfleetA->id, $subfleetB->id)
+        // aircraft is eager-loaded and serialized (not lazy-loaded)
+        ->and($subfleets->firstWhere('id', $subfleetA->id)['aircraft'])->toHaveCount(1)
+        ->and($subfleets->firstWhere('id', $subfleetB->id)['aircraft'])->toHaveCount(1);
+});
+
 // ---------------------------------------------------------------------------
 // search() with=bid
 // ---------------------------------------------------------------------------

--- a/tests/Feature/FlightBidQueryCountTest.php
+++ b/tests/Feature/FlightBidQueryCountTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use App\Models\Aircraft;
+use App\Models\Bid;
+use App\Models\Fare;
+use App\Models\Flight;
+use App\Models\Subfleet;
+use App\Models\User;
+use App\Services\FareService;
+use App\Services\SettingService;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Reset the request-scoped setting memo so a measured request starts cold, as
+ * it would under Octane (which flushes the singleton per request). Without this
+ * the memo warms across in-test requests and masks the query-count comparison.
+ */
+function freshRequestState(): void
+{
+    app(SettingService::class)->clearMemo();
+    DB::connection()->flushQueryLog();
+}
+
+// Task 4 — end-to-end verification that the `with=bid` fast-path cost is O(bids)
+// and independent of how many subfleets the flight/pilot could otherwise expand.
+
+/**
+ * Build a flight the pilot has a bid on, plus `$extraSubfleets` additional
+ * pinned subfleets (each with an aircraft) that the legacy accessible-fleet
+ * expansion would hydrate. The fast-path must ignore these.
+ */
+function buildBidFlight(User $user, int $extraSubfleets): Flight
+{
+    $subfleet = Subfleet::factory()->create();
+    $aircraft = Aircraft::factory()->create(['subfleet_id' => $subfleet->id]);
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+    $flight->subfleets()->attach($subfleet->id);
+
+    for ($i = 0; $i < $extraSubfleets; $i++) {
+        $extra = Subfleet::factory()->create();
+        Aircraft::factory()->create(['subfleet_id' => $extra->id]);
+        $flight->subfleets()->attach($extra->id);
+    }
+
+    Bid::create([
+        'user_id'     => $user->id,
+        'flight_id'   => $flight->id,
+        'aircraft_id' => $aircraft->id,
+    ]);
+
+    return $flight;
+}
+
+test('get with bid query count is independent of total subfleet count', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $small = buildBidFlight($user, 1);
+    $large = buildBidFlight($user, 25);
+
+    DB::connection()->enableQueryLog();
+
+    freshRequestState();
+    $this->get('/api/flights/'.$small->id.'?with=bid')->assertStatus(200);
+    $smallCount = count(DB::connection()->getQueryLog());
+
+    freshRequestState();
+    $this->get('/api/flights/'.$large->id.'?with=bid')->assertStatus(200);
+    $largeCount = count(DB::connection()->getQueryLog());
+    DB::connection()->disableQueryLog();
+
+    // 1 subfleet vs 26 subfleets → identical query count. The fast-path scales
+    // with the number of bids, not the size of the accessible fleet.
+    expect($largeCount)->toBe($smallCount);
+});
+
+test('search by id with bid query count is independent of total subfleet count', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $small = buildBidFlight($user, 1);
+    $large = buildBidFlight($user, 25);
+
+    DB::connection()->enableQueryLog();
+
+    freshRequestState();
+    $this->get('/api/flights/search?flight_id='.$small->id.'&with=bid')->assertStatus(200);
+    $smallCount = count(DB::connection()->getQueryLog());
+
+    freshRequestState();
+    $this->get('/api/flights/search?flight_id='.$large->id.'&with=bid')->assertStatus(200);
+    $largeCount = count(DB::connection()->getQueryLog());
+    DB::connection()->disableQueryLog();
+
+    expect($largeCount)->toBe($smallCount);
+});
+
+test('bid subfleet fare payload matches the legacy get output for that subfleet', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+
+    $fareSvc = app(FareService::class);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    $subfleet = Subfleet::factory()->create();
+    $aircraft = Aircraft::factory()->create(['subfleet_id' => $subfleet->id]);
+
+    $fare = Fare::factory()->create();
+    $fareSvc->setForSubfleet($subfleet, $fare, ['price' => 100, 'capacity' => 50]);
+
+    $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+    $flight->subfleets()->attach($subfleet->id);
+
+    Bid::create([
+        'user_id'     => $user->id,
+        'flight_id'   => $flight->id,
+        'aircraft_id' => $aircraft->id,
+    ]);
+
+    // Legacy path (accessible-fleet expansion) and fast-path must serialize the
+    // bid subfleet's fares identically.
+    $legacy = $this->get('/api/flights/'.$flight->id)->json('data');
+    $fast = $this->get('/api/flights/'.$flight->id.'?with=bid')->json('data');
+
+    $legacySubfleet = collect($legacy['subfleets'])->firstWhere('id', $subfleet->id);
+    $fastSubfleet = collect($fast['subfleets'])->firstWhere('id', $subfleet->id);
+
+    expect($fastSubfleet)->not->toBeNull()
+        ->and($fastSubfleet['fares'])->toEqual($legacySubfleet['fares']);
+});

--- a/tests/Feature/FlightBidQueryCountTest.php
+++ b/tests/Feature/FlightBidQueryCountTest.php
@@ -102,6 +102,35 @@ test('search by id with bid query count is independent of total subfleet count',
     expect($largeCount)->toBe($smallCount);
 });
 
+test('browse search with bid resolves all bids in a single batched query', function (): void {
+    updateSetting('pireps.restrict_aircraft_to_rank', false);
+    updateSetting('pireps.restrict_aircraft_to_typerating', false);
+    updateSetting('pilots.restrict_to_company', false);
+    updateSetting('pilots.only_flights_from_current', false);
+
+    $user = User::factory()->create();
+    apiAs($user);
+
+    // Several flights the pilot has a bid on — the bid lookup must not be an
+    // N+1 across the returned page.
+    for ($i = 0; $i < 5; $i++) {
+        $subfleet = Subfleet::factory()->create();
+        $aircraft = Aircraft::factory()->create(['subfleet_id' => $subfleet->id]);
+        $flight = Flight::factory()->create(['airline_id' => $user->airline_id]);
+        Bid::create(['user_id' => $user->id, 'flight_id' => $flight->id, 'aircraft_id' => $aircraft->id]);
+    }
+
+    DB::connection()->enableQueryLog();
+    freshRequestState();
+    $this->get('/api/flights/search?with=bid')->assertStatus(200);
+    $bidQueries = collect(DB::connection()->getQueryLog())
+        ->filter(fn (array $q): bool => str_contains((string) $q['query'], 'from "bids"'))
+        ->count();
+    DB::connection()->disableQueryLog();
+
+    expect($bidQueries)->toBe(1);
+});
+
 test('bid subfleet fare payload matches the legacy get output for that subfleet', function (): void {
     updateSetting('pireps.restrict_aircraft_to_rank', false);
     updateSetting('pireps.restrict_aircraft_to_typerating', false);

--- a/tests/Feature/FlightBidQueryCountTest.php
+++ b/tests/Feature/FlightBidQueryCountTest.php
@@ -123,8 +123,10 @@ test('browse search with bid resolves all bids in a single batched query', funct
     DB::connection()->enableQueryLog();
     freshRequestState();
     $this->get('/api/flights/search?with=bid')->assertStatus(200);
+    // Normalize identifier quoting (postgres/sqlite use ", mysql uses `) so the
+    // match is dialect-agnostic across the CI matrix.
     $bidQueries = collect(DB::connection()->getQueryLog())
-        ->filter(fn (array $q): bool => str_contains((string) $q['query'], 'from "bids"'))
+        ->filter(fn (array $q): bool => str_contains(str_replace(['`', '"'], '', (string) $q['query']), 'from bids'))
         ->count();
     DB::connection()->disableQueryLog();
 

--- a/tests/Feature/SettingServiceMemoTest.php
+++ b/tests/Feature/SettingServiceMemoTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\SettingService;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Tests for the in-request SettingService memo (Tier 1 cache).
+ *
+ * The SettingsSeeder runs in beforeEach (Pest.php), so all standard
+ * settings (e.g. 'general.theme') are available.
+ *
+ * Tests run in a non-production environment, so setting() calls
+ * retrieve() directly (no Cache::remember wrapper) — which means
+ * the memo is exercised on every call.
+ */
+it('repeated reads of the same key hit the source at most once', function (): void {
+    DB::enableQueryLog();
+
+    $a = setting('general.theme');
+    $b = setting('general.theme');
+    $c = setting('general.theme');
+
+    $queries = DB::getQueryLog();
+    DB::disableQueryLog();
+
+    // All three reads must return the same value.
+    expect($a)->toBe($b)->toBe($c);
+
+    // Only one DB query should have targeted the settings table for this key.
+    $settingQueries = collect($queries)
+        ->filter(fn (array $q): bool => str_contains((string) $q['query'], 'settings')
+            && in_array('general_theme', $q['bindings'], strict: true))
+        ->count();
+
+    expect($settingQueries)->toBe(1);
+});
+
+it('a write within the same request is observed on subsequent reads', function (): void {
+    $original = setting('general.theme');
+
+    setting_save('general.theme', 'test_dark');
+
+    $updated = setting('general.theme');
+
+    expect($updated)->toBe('test_dark');
+    expect($updated)->not->toBe($original);
+});
+
+it('SettingService is registered in the Octane flush list', function (): void {
+    // Under Octane the singleton (and its memo) is discarded before each
+    // request, so a setting change is observed on the next request.
+    expect(config('octane.flush', []))->toContain(SettingService::class);
+});


### PR DESCRIPTION
## Summary

Bid briefings take ~12 s because `GET /api/flights/{id}` always runs `accessibleSubfleetsFor()`, expanding every subfleet the pilot can fly (234 on the live VA) when only the locked bid aircraft's one subfleet is used.

1. **`with=bid` fast-path** (`get` + `search`): a server-controlled `with` token resolves the pilot's bid → sets `subfleets` to just that subfleet with reconciled fares, skipping the fleet expansion (~5 indexed queries). No bid → empty subfleets. Never passed to Eloquent `->with()`.
2. **By-id search ignores visibility**: `search()` passes `onlyActive = !filled('flight_id')` so `flight_id` lookups reach invisible bid flights (parity with `get()`); browse search still hides them.
3. **Per-request `setting()` memo** (Octane-safe): singleton + `octane.flush`, evicted on write and per queue job. Kills the ~1,900-read `setting()` N+1.

Additive and backward-compatible; both endpoints stay behind `api.auth`, `with=bid` resolves against `Auth::id()` only.

## Test plan

`php artisan test` — 904 passed, 0 failed. Covers: bid/no-bid/cross-user/default, multi-bid serialization, by-id visibility, query count O(bids), payload parity, and the setting memo.