### PR TITLE
[8.x] feat(import): include type ratings in subfleet CSV import/export

### DIFF
--- a/app/Filament/Exports/SubfleetExporter.php
+++ b/app/Filament/Exports/SubfleetExporter.php
@@ -18,7 +18,7 @@ class SubfleetExporter extends Exporter
     #[Override]
     public static function modifyQuery(Builder $query): Builder
     {
-        return $query->with(['fares', 'ranks']);
+        return $query->with(['fares', 'ranks', 'typeratings']);
     }
 
     public static function getColumns(): array
@@ -38,6 +38,7 @@ class SubfleetExporter extends Exporter
             ExportColumn::make('gross_weight'),
             ExportColumn::make('fares')->formatStateUsing(fn (Subfleet $record): string => self::getFares($record)),
             ExportColumn::make('ranks')->formatStateUsing(fn (Subfleet $record): string => self::getRanks($record)),
+            ExportColumn::make('type_ratings')->formatStateUsing(fn (Subfleet $record): string => self::getTypeRatings($record)),
         ];
     }
 
@@ -98,5 +99,18 @@ class SubfleetExporter extends Exporter
         }
 
         return Utils::objectToMultiString($ranks);
+    }
+
+    /**
+     * Return the type ratings linked to this subfleet as a ;-delimited list of IDs
+     */
+    private static function getTypeRatings(Subfleet $subfleet): string
+    {
+        $type_ratings = [];
+        foreach ($subfleet->typeratings as $typerating) {
+            $type_ratings[] = $typerating->id;
+        }
+
+        return Utils::objectToMultiString($type_ratings);
     }
 }

--- a/app/Filament/Imports/SubfleetImporter.php
+++ b/app/Filament/Imports/SubfleetImporter.php
@@ -5,6 +5,7 @@ namespace App\Filament\Imports;
 use App\Models\Fare;
 use App\Models\Rank;
 use App\Models\Subfleet;
+use App\Models\Typerating;
 use App\Services\FareService;
 use App\Services\FleetService;
 use App\Support\Utils;
@@ -60,6 +61,8 @@ class SubfleetImporter extends Importer
                 ->fillRecordUsing(function (): void {}),
             ImportColumn::make('ranks')
                 ->fillRecordUsing(function (): void {}),
+            ImportColumn::make('type_ratings')
+                ->fillRecordUsing(function (): void {}),
         ];
     }
 
@@ -78,6 +81,10 @@ class SubfleetImporter extends Importer
 
         if (array_key_exists('ranks', $this->data) && $this->data['ranks'] != '') {
             $this->processRanks($this->record, $this->data['ranks']);
+        }
+
+        if (array_key_exists('type_ratings', $this->data) && $this->data['type_ratings'] != '') {
+            $this->processTypeRatings($this->record, $this->data['type_ratings']);
         }
     }
 
@@ -133,6 +140,31 @@ class SubfleetImporter extends Importer
             $rank = Rank::firstOrCreate(['id' => $rank_id], ['name' => 'Imported rank '.$rank_id]);
             app(FleetService::class)->addSubfleetToRank($subfleet, $rank, $rank_attributes);
             $rank->save();
+        }
+    }
+
+    /**
+     * Parse all of the type ratings in the multi-format
+     */
+    private function processTypeRatings(Subfleet $subfleet, string $col): void
+    {
+        $type_ratings = Utils::parseMultiColumnValues($col);
+        foreach ($type_ratings as $typerating_id => $typerating_attributes) {
+            if (!\is_array($typerating_attributes)) {
+                $typerating_id = $typerating_attributes;
+            }
+
+            $typerating = Typerating::find($typerating_id);
+            if ($typerating === null) {
+                $typerating = new Typerating([
+                    'name' => 'Imported type rating '.$typerating_id,
+                    'type' => 'Imported type rating '.$typerating_id,
+                ]);
+                $typerating->id = (int) $typerating_id;
+                $typerating->save();
+            }
+
+            app(FleetService::class)->addSubfleetToTypeRating($subfleet, $typerating);
         }
     }
 }

--- a/app/Services/ImportExport/SubfleetExporter.php
+++ b/app/Services/ImportExport/SubfleetExporter.php
@@ -43,6 +43,7 @@ class SubfleetExporter extends ImportExport
         $ret['airline'] = $row->airline->icao;
         $ret['fares'] = $this->getFares($row);
         $ret['ranks'] = $this->getRanks($row);
+        $ret['type_ratings'] = $this->getTypeRatings($row);
 
         return $ret;
     }
@@ -93,6 +94,19 @@ class SubfleetExporter extends ImportExport
         }
 
         return $this->objectToMultiString($ranks);
+    }
+
+    /**
+     * Return the type ratings linked to this subfleet as a ;-delimited list of IDs
+     */
+    protected function getTypeRatings(Subfleet $subfleet): string
+    {
+        $type_ratings = [];
+        foreach ($subfleet->typeratings as $typerating) {
+            $type_ratings[] = $typerating->id;
+        }
+
+        return $this->objectToMultiString($type_ratings);
     }
 
     /**

--- a/app/Services/ImportExport/SubfleetImporter.php
+++ b/app/Services/ImportExport/SubfleetImporter.php
@@ -8,6 +8,7 @@ use App\Contracts\ImportExport;
 use App\Models\Fare;
 use App\Models\Rank;
 use App\Models\Subfleet;
+use App\Models\Typerating;
 use App\Services\FareService;
 use App\Services\FleetService;
 use Exception;
@@ -35,6 +36,7 @@ class SubfleetImporter extends ImportExport
         'ground_handling_multiplier' => 'nullable',
         'fares'                      => 'nullable',
         'ranks'                      => 'nullable',
+        'type_ratings'               => 'nullable',
     ];
 
     private readonly FareService $fareSvc;
@@ -72,6 +74,7 @@ class SubfleetImporter extends ImportExport
 
         $this->processFares($subfleet, $row['fares'] ?? '');
         $this->processRanks($subfleet, $row['ranks'] ?? '');
+        $this->processTypeRatings($subfleet, $row['type_ratings'] ?? '');
 
         $this->log('Imported '.$row['type']);
 
@@ -111,6 +114,34 @@ class SubfleetImporter extends ImportExport
             $rank = Rank::firstOrCreate(['id' => $rank_id], ['name' => 'Imported rank '.$rank_id]);
             $this->fleetSvc->addSubfleetToRank($subfleet, $rank, $rank_attributes);
             $rank->save();
+        }
+    }
+
+    /**
+     * Parse all of the type ratings in the multi-format
+     *
+     * The typerating_subfleet pivot has no extra columns, so the value is a
+     * simple ;-delimited list of type rating IDs.
+     */
+    protected function processTypeRatings(Subfleet $subfleet, string $col): void
+    {
+        $type_ratings = $this->parseMultiColumnValues($col);
+        foreach ($type_ratings as $typerating_id => $typerating_attributes) {
+            if (!\is_array($typerating_attributes)) {
+                $typerating_id = $typerating_attributes;
+            }
+
+            $typerating = Typerating::find($typerating_id);
+            if ($typerating === null) {
+                $typerating = new Typerating([
+                    'name' => 'Imported type rating '.$typerating_id,
+                    'type' => 'Imported type rating '.$typerating_id,
+                ]);
+                $typerating->id = (int) $typerating_id;
+                $typerating->save();
+            }
+
+            $this->fleetSvc->addSubfleetToTypeRating($subfleet, $typerating);
         }
     }
 }

--- a/tests/Feature/ImporterTest.php
+++ b/tests/Feature/ImporterTest.php
@@ -14,12 +14,15 @@ use App\Models\Flight;
 use App\Models\FlightFieldValue;
 use App\Models\Rank;
 use App\Models\Subfleet;
+use App\Models\Typerating;
 use App\Services\ExportService;
 use App\Services\FareService;
 use App\Services\ImportExport\AircraftExporter;
 use App\Services\ImportExport\AirportExporter;
 use App\Services\ImportExport\ExpenseExporter;
 use App\Services\ImportExport\FlightExporter;
+use App\Services\ImportExport\SubfleetExporter;
+use App\Services\ImportExport\SubfleetImporter;
 use App\Services\ImportService;
 use App\Support\Days;
 use Illuminate\Support\Facades\Storage;
@@ -692,6 +695,8 @@ test('subfleet importer', function (): void {
     $fare_business = Fare::factory()->create(['code' => 'B', 'capacity' => 20]);
     $rank_cpt = Rank::factory()->create(['id' => 99, 'name' => 'cpt']);
     $rank_fo = Rank::factory()->create(['id' => 100, 'name' => 'fo']);
+    $typerating_a = Typerating::forceCreate(['id' => 1, 'name' => 'A320 Family', 'type' => 'A320']);
+    $typerating_b = Typerating::forceCreate(['id' => 2, 'name' => 'B747 Family', 'type' => 'B747']);
     $airline = Airline::firstWhere(['icao' => 'VMS']) ?? Airline::factory()->create(['icao' => 'VMS']);
 
     $importer = app(ImportService::class);
@@ -744,6 +749,67 @@ test('subfleet importer', function (): void {
         ->and($fo->acars_pay)->toEqual($rank_fo->acars_pay)
         ->and($fo->manual_pay)->toEqual($rank_fo->manual_pay);
 
+    // get the type ratings and check the pivot associations
+    $type_ratings = $subfleet->typeratings()->get();
+    expect($type_ratings)->toHaveCount(2)
+        ->and($type_ratings->pluck('id')->all())->toEqualCanonicalizing([$typerating_a->id, $typerating_b->id]);
+});
+
+test('subfleet exporter round-trips type ratings', function (): void {
+    Fare::factory()->create(['code' => 'Y']);
+    $airline = Airline::firstWhere(['icao' => 'VMS']) ?? Airline::factory()->create(['icao' => 'VMS']);
+
+    $typerating = Typerating::forceCreate(['id' => 1, 'name' => 'A320 Family', 'type' => 'A320']);
+
+    $with_ratings = Subfleet::factory()->create(['airline_id' => $airline->id, 'type' => 'A32X']);
+    $with_ratings->typeratings()->sync([$typerating->id]);
+
+    $without_ratings = Subfleet::factory()->create(['airline_id' => $airline->id, 'type' => 'B738']);
+
+    $exporter = app(ExportService::class);
+    $importer = app(ImportService::class);
+
+    // Export produces the type ratings for the associated subfleet and an empty cell for the other
+    $exported = new SubfleetExporter()->export($with_ratings);
+    expect($exported)->toHaveKey('type_ratings')
+        ->and($exported['type_ratings'])->toEqual((string) $typerating->id);
+
+    $exported_empty = new SubfleetExporter()->export($without_ratings);
+    expect($exported_empty['type_ratings'])->toEqual('');
+
+    // Round-trip: export both, then re-import and confirm associations are preserved
+    $file = $exporter->exportSubfleets(collect([$with_ratings, $without_ratings]));
+    $status = $importer->importSubfleets($file, delete_previous: false);
+
+    expect($status['success'])->toHaveCount(2)
+        ->and($status['errors'])->toHaveCount(0);
+
+    $reimported = Subfleet::where('type', 'A32X')->first();
+    expect($reimported->typeratings()->pluck('id')->all())->toEqual([$typerating->id]);
+
+    $reimported_empty = Subfleet::where('type', 'B738')->first();
+    expect($reimported_empty->typeratings()->get())->toHaveCount(0);
+});
+
+test('subfleet importer creates missing type ratings', function (): void {
+    Fare::factory()->create(['code' => 'Y']);
+    $airline = Airline::firstWhere(['icao' => 'VMS']) ?? Airline::factory()->create(['icao' => 'VMS']);
+    $subfleet = Subfleet::factory()->create(['airline_id' => $airline->id, 'type' => 'A32X']);
+
+    $importer = new SubfleetImporter();
+    $importer->import([
+        'airline'      => $airline->icao,
+        'type'         => 'A32X',
+        'name'         => 'Airbus A320',
+        'fuel_type'    => null,
+        'type_ratings' => '4242',
+    ], 0);
+
+    $typerating = Typerating::find(4242);
+    expect($typerating)->not->toBeNull();
+
+    $subfleet->refresh();
+    expect($subfleet->typeratings()->pluck('id')->all())->toEqual([4242]);
 });
 
 test('airport special chars importer', function (): void {

--- a/tests/data/subfleets.csv
+++ b/tests/data/subfleets.csv
@@ -1,3 +1,3 @@
-airline,hub_id,type,simbrief_type,name,fuel_type,cost_block_hour,cost_delay_minute,ground_handling_multiplier,fares,ranks
-VMS,KAUS,A32X,,"Airbus A320",,1000,0,200,Y;B?capacity=100&price=500%,99;100?acars_pay=200&manual_pay=100
-VMS,EGPH, ,,"Boeing 747-400",,1000,0,200,Y;B?capacity=100&price=500%,99;100?acars_pay=200&manual_pay=100
+airline,hub_id,type,simbrief_type,name,fuel_type,cost_block_hour,cost_delay_minute,ground_handling_multiplier,fares,ranks,type_ratings
+VMS,KAUS,A32X,,"Airbus A320",,1000,0,200,Y;B?capacity=100&price=500%,99;100?acars_pay=200&manual_pay=100,1;2
+VMS,EGPH, ,,"Boeing 747-400",,1000,0,200,Y;B?capacity=100&price=500%,99;100?acars_pay=200&manual_pay=100,1;2


### PR DESCRIPTION
Add a type_ratings column to the subfleet CSV so type rating associations round-trip through export/import instead of needing manual re-entry after each cycle. Wired through both the legacy ImportExport services and the Filament importer/exporter, serialized as a ;-delimited list of IDs.

Closes #2179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type ratings to subfleet exports as semicolon-delimited values.
  * Added support for importing and associating type ratings with subfleets.
  * Missing type ratings can now be created automatically during import.

* **Bug Fixes**
  * Preserved type-rating associations during export and re-import workflows.

* **Tests**
  * Added coverage for exporting, importing, round-trip preservation, and empty type-rating values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->