### PR TITLE
[8.x] fix(deps): require pcntl extension in composer.json

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -43,8 +43,11 @@ ARG WWWGROUP=1000
 # Switch to root so we can do root things
 USER root
 
-# Install missing extensions with root permissions
-RUN install-php-extensions intl bcmath
+# Install missing extensions with root permissions.
+# pcntl is deliberately not in composer.json's `require`: shared hosts commonly
+# ship without it and would fail the platform check on `composer install`. Octane
+# needs it here, so the runtime image installs it explicitly.
+RUN install-php-extensions intl bcmath pcntl
 
 # Install mariadb client (required for backups)
 RUN apt-get update; \

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "ext-bcmath": "*",
     "ext-pdo": "*",
     "ext-intl": "*",
-    "ext-pcntl": "*",
     "ext-zip": "*",
     "fisharebest/ext-calendar": "^2.5",
     "symfony/polyfill-iconv": "*",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "ext-bcmath": "*",
     "ext-pdo": "*",
     "ext-intl": "*",
+    "ext-pcntl": "*",
     "ext-zip": "*",
     "fisharebest/ext-calendar": "^2.5",
     "symfony/polyfill-iconv": "*",

--- a/railpack.json
+++ b/railpack.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://schema.railpack.com",
   "steps": {
+    "extensions": {
+      "commands": ["...", "install-php-extensions pcntl"]
+    },
     "build": {
       "commands": ["...", "php artisan filament:assets"]
     }


### PR DESCRIPTION
Octane requires pcntl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added required PHP process-control support to production builds.
  * Improved compatibility with Laravel Octane and Composer platform requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->