### PR TITLE
[8.x] fix(ci): use CACHE_STORE so tests get a per-process cache

### DIFF
--- a/.github/scripts/phpunit.xml
+++ b/.github/scripts/phpunit.xml
@@ -33,7 +33,7 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file" force="true"/>
         <env name="BCRYPT_ROUNDS" value="4" force="true"/>
         <env name="BROADCAST_CONNECTION" value="null" force="true"/>
-        <env name="CACHE_DRIVER" value="array" force="true"/>
+        <env name="CACHE_STORE" value="array" force="true"/>
         <env name="DB_CONNECTION" value="sqlite" force="true"/>
         <env name="DB_DATABASE" value=":memory:" force="true"/>
         <env name="DB_URL" value="" force="true"/>

--- a/tests/Feature/CacheStoreGuardTest.php
+++ b/tests/Feature/CacheStoreGuardTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Cache\ArrayStore;
+use Spatie\Permission\PermissionRegistrar;
+
+test('tests run against an in-memory cache store', function (): void {
+    // Both phpunit.xml files force CACHE_STORE=array so that every test process
+    // gets its own cache. Any persistent store (file, database) is shared by all
+    // parallel workers, which leaks spatie's cached permission map between
+    // workers that each have their own database — surfacing as random
+    // "no permission named X" errors and model_has_permissions FK violations.
+    expect(config('cache.default'))->toBe('array')
+        ->and(app(PermissionRegistrar::class)->getCacheRepository()->getStore())
+        ->toBeInstanceOf(ArrayStore::class);
+});


### PR DESCRIPTION
## The flake

CI fails randomly with one of two errors, and passes on re-run ([example run](https://github.com/phpvms/phpvms/actions/runs/29352966100) — first four attempts):

```
There is no permission named `access:fakemodule` for guard `web`.
```

```
SQLSTATE[23503]: Foreign key violation: 7 ERROR: insert or update on table "model_has_permissions"
violates foreign key constraint "model_has_permissions_permission_id_foreign"
DETAIL: Key (permission_id)=(191) is not present in table "permissions".
(Connection: pgsql, Database: phpvms_test_4)
```

## Root cause

`.github/scripts/phpunit.xml`, which CI copies over the repo's `phpunit.xml`, set:

```xml
<env name="CACHE_DRIVER" value="array" force="true"/>
```

Laravel 11+ reads the default cache store from `CACHE_STORE`, not `CACHE_DRIVER` — `config/cache.php` is `env('CACHE_STORE', 'database')`. The key was simply ignored, so `.env` (copied from `.github/scripts/env.test`, which sets `CACHE_STORE=file`) won. **CI has been running the entire suite against the file cache in `storage/framework/cache/data`.**

That one directory is shared by every parallel Pest worker, while each worker gets its own database (`phpvms_test_1`…`_4`). Spatie caches the whole permission map — names *and* primary keys — under a single key, `spatie.permission.cache`. So the first worker to write it wins for all the others:

- A worker resolves a permission id out of another worker's map and inserts it into its own database → **FK violation** (id 191 exists in some other worker's DB, not in `phpvms_test_4`).
- Or the cached map was written before a permission the test just created → lookup misses → **"There is no permission named `access:fakemodule`"**.

Both outcomes depend on worker interleaving and whatever the leftover cache file holds, which is why they're random and why a re-run "fixes" them.

The root `phpunit.xml` already used `CACHE_STORE` correctly — the CI copy drifted — so this only ever reproduced in CI.

## The fix

Use the key Laravel actually reads, so each test process gets its own cache:

```diff
-<env name="CACHE_DRIVER" value="array" force="true"/>
+<env name="CACHE_STORE" value="array" force="true"/>
```

## Verification

A probe of the permission registrar's cache store under the CI config:

| | store in use |
|---|---|
| before | `Illuminate\Cache\FileStore` (CI) / `DatabaseStore` (local, no `CACHE_STORE` in `.env`) |
| after | `Illuminate\Cache\ArrayStore` |

`tests/Feature/CacheStoreGuardTest.php` asserts the active store is `array`, mirroring the existing `DatabaseDriverGuardTest`. It was confirmed to **fail** against the old config and **pass** against the fixed one, so the key can't silently drift again. Permission suite: 37 passed, 2 skipped.

## Follow-up worth considering (not in this PR)

This bug exists because `.github/scripts/phpunit.xml` is a near-duplicate of the root `phpunit.xml` that drifted — the root was corrected to `CACHE_STORE` at some point and the CI copy wasn't. They differ only in `force="true"` on the DB vars, an `APP_KEY`, and some `ini` settings, and CI `sed`s the DB vars anyway. Collapsing them into one file would remove this class of bug entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by ensuring tests use an in-memory cache store.
  * Prevented permission cache data from leaking between parallel test processes.

* **Tests**
  * Added coverage verifying the configured cache store and permission cache repository use in-memory storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->