### PR TITLE
[8.x] fix(flights): stop the active() scope shadowing attribute reads

### DIFF
--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -598,9 +598,14 @@ class Flight extends Model
     /**
      * Backwards-compatible alias for the renamed scope. Equivalent to
      * `Flight::visible()`. Kept indefinitely for module compatibility.
+     *
+     * Deliberately uses the `scope` prefix rather than `#[Scope]`: the
+     * `flights.active` column was renamed to `enabled`, so a bare `active()`
+     * method makes `Model::isRelation('active')` return true and Eloquent
+     * invokes it as a relationship with zero arguments on any `$flight->active`
+     * read. The prefix keeps `Flight::active()` working without the collision.
      */
-    #[Scope]
-    protected function active(Builder $query): Builder
+    public function scopeActive(Builder $query): Builder
     {
         return $query->where('visible', true);
     }

--- a/tests/Unit/Models/FlightScopeTest.php
+++ b/tests/Unit/Models/FlightScopeTest.php
@@ -11,6 +11,16 @@ it('active scope produces same SQL as visible scope', function (): void {
     expect($activeSql)->toBe($visibleSql);
 });
 
+it('does not mistake the active scope for a relationship when read as an attribute', function (): void {
+    $flight = new Flight();
+
+    // `flights.active` was renamed to `enabled`, so there is no attribute to
+    // read. Eloquent must not fall through to `getRelationValue()` and invoke
+    // the scope method with zero arguments.
+    expect($flight->isRelation('active'))->toBeFalse()
+        ->and($flight->active)->toBeNull();
+});
+
 it('active scope is a plain alias and does not trigger deprecation notices', function (): void {
     $triggered = false;
     set_error_handler(function ($errno, $errstr) use (&$triggered): void {


### PR DESCRIPTION
Fixes the `ArgumentCountError` thrown when reading `$flight->active`:

```
ArgumentCountError: Too few arguments to function App\Models\Flight::active(),
0 passed in .../Concerns/HasAttributes.php on line 637 and exactly 1 expected
```

## Root cause

`flights.active` was renamed to `enabled` in `2026_05_19_100002_add_bundle_columns_to_flights_table`, and `62d63a3f` left `Flight::active()` behind as a `#[Scope]` alias for `visible()`.

`Model::getAttribute()` then resolves `active` like this:

1. `hasAttribute("active")` — **false**. The column is gone and `active` is not in `casts()`.
2. `method_exists(self::class, "active")` — **false**. Inside the `HasAttributes` trait `self` binds to `Model`, not `Flight`, so the model's own methods are invisible here.
3. `isRelation("active")` — **true**. It is just `method_exists($this, $key)` and has **no `#[Scope]` awareness**, so Eloquent treats the scope as a relationship and calls `$this->active()` with zero arguments.

The collision is specific to the `#[Scope]` attribute style; the old `scopeActive()` naming never collided because the method name and the attribute name were different strings.

## Fix

Revert this one alias to the `scope` prefix. `Flight::active()` still resolves through the scope resolver, but the `active` method name is freed, so `$flight->active` returns null rather than fataling. A comment records why this one intentionally departs from the `#[Scope]` convention.

Note that `$flight->active` returning null (not `enabled`) is the best available behaviour — a method can be a scope or an `Attribute` accessor, not both, since `Model::__callStatic` would invoke the accessor and return an `Attribute` instead of a `Builder`. This matches how the codebase already handles the alias explicitly at the boundary, in `FlightResource` and `FlightExporter`. **Callers should read `enabled`.**

## Tests

Adds a regression test to `FlightScopeTest` asserting `isRelation("active")` is false and `$flight->active` is null. The pre-existing test that `Flight::active()` produces the same SQL as `Flight::visible()` still passes, proving the alias is intact.

```
Tests: 85 passed (237 assertions)   # Unit/Models + FlightTest + SetVisibleFlights + FlightBidFastPath
```

Pint and Larastan clean.

## Follow-ups (not in this PR)

The same `#[Scope]`-shadows-a-missing-column pattern exists elsewhere and fatals identically on property reads:

- `Airport::active()` — no `airports.active` column
- `User::pending()` — no `users.pending` column

`Expense::active()`, `User::active()`, `Airline::active()`, `FlightBundle::visible()` and `Flight::visible()` share the shape but are saved by the column existing (or being in `casts()`), so they only break on unhydrated models. Happy to fix the first two separately if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the flight “active” filter while preserving its existing behavior.
  * Prevented “active” from being incorrectly interpreted as a relationship when accessed on a flight.

* **Tests**
  * Added coverage confirming the active filter works correctly and does not trigger relationship resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->