### PR TITLE
[8.x] fix(migration): widen expenses.flight_type before JSON conversion

### DIFF
--- a/database/migrations/2026_05_09_095409_convert_flight_type_to_json_on_expenses_table.php
+++ b/database/migrations/2026_05_09_095409_convert_flight_type_to_json_on_expenses_table.php
@@ -11,7 +11,14 @@ return new class() extends Migration
      */
     public function up(): void
     {
-        // 1. Convert existing comma-separated strings to JSON arrays
+        // 1. Widen the column first so the JSON representation fits during conversion.
+        // The original VARCHAR(50) is too small for the encoded array once an expense
+        // has many flight types (e.g. all of them), which would truncate/fail the update.
+        Schema::table('expenses', function (Blueprint $table): void {
+            $table->text('flight_type')->nullable()->change();
+        });
+
+        // 2. Convert existing comma-separated strings to JSON arrays
         DB::table('expenses')->orderBy('id')->chunk(100, function ($expenses): void {
             foreach ($expenses as $expense) {
                 // Only process if it has a value and isn't already a JSON array
@@ -32,7 +39,7 @@ return new class() extends Migration
             }
         });
 
-        // 2. Officially change the column type to JSON
+        // 3. Officially change the column type to JSON
         // Note: You must have doctrine/dbal installed for this step on older Laravel versions
 
         if (DB::getDriverName() === 'pgsql') {


### PR DESCRIPTION
## Summary

Fixes #2266.

The `2026_05_09_095409_convert_flight_type_to_json_on_expenses_table` migration wrote encoded JSON arrays into `expenses.flight_type` while the column was still `VARCHAR(50)`, only changing the type to JSON *afterwards*. An expense with many flight types (e.g. all of them) produces a JSON string longer than 50 characters, so on MySQL/MariaDB the `UPDATE` failed:

```
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'flight_type' at row 1
```

SQLite doesn't enforce column length, which is why the test suite didn't catch it.

## Fix

Widen the column to `text` **before** the data conversion, then convert the comma-separated values to JSON, then finalize the column as `JSON`. The pgsql path (`ALTER ... TYPE JSON USING flight_type::json`) now runs against a `text` column instead of the constrained varchar.

## Testing

The failure is driver-specific (MySQL/MariaDB length enforcement) and can't be reproduced on the in-memory SQLite used by the suite, so no meaningful regression test is possible there. Verified that the full migration set still applies cleanly (existing Expense tests pass under `RefreshDatabase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of existing flight type values during database upgrades.
  * Preserved compatibility for empty or null flight type entries while converting values to JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->