### PR TITLE
[8.x] fix(logging): scope cron_daily channel to scheduler and queue worker

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -40,6 +40,7 @@ use Filament\View\PanelsRenderHook;
 use Hidehalo\Nanoid\Client as NanoidClient;
 use Igaster\LaravelTheme\Facades\Theme;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Foundation\Application;
@@ -50,6 +51,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
@@ -81,6 +83,22 @@ class AppServiceProvider extends ServiceProvider
         // processes — otherwise a stale memoized value could be written back into
         // the shared cache on the next Cache::remember() miss.
         Queue::before(static fn () => app(SettingService::class)->clearMemo());
+
+        // The cron_daily channel (storage/logs/cron.log) is reserved for the
+        // scheduler and the queue worker. Switch the default log channel only
+        // when one of those commands starts, rather than mutating it globally
+        // in routes/console.php: under Octane that global mutation leaked into
+        // every HTTP worker (octane:start is itself an Artisan command that
+        // loads the console routes), sending web request logs to cron.log.
+        // CommandStarting never fires for HTTP requests, so Octane workers keep
+        // the default (daily) channel.
+        Event::listen(CommandStarting::class, static function (CommandStarting $event): void {
+            $cronCommands = ['schedule:run', 'schedule:work', 'queue:work', 'queue:listen'];
+
+            if (in_array($event->command, $cronCommands, true)) {
+                Log::setDefaultDriver('cron_daily');
+            }
+        });
 
         Model::preventLazyLoading(!$this->app->isProduction());
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,10 +10,7 @@ use App\Events\CronNightly;
 use App\Events\CronThirtyMinute;
 use App\Events\CronWeekly;
 use App\Services\CronService;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schedule;
-
-Log::setDefaultDriver('cron_daily');
 
 Schedule::call(static function (): void {
     event(new CronFiveMinute());

--- a/tests/Feature/CronLogChannelTest.php
+++ b/tests/Feature/CronLogChannelTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+function fireCommandStarting(string $command): void
+{
+    event(new CommandStarting($command, new ArrayInput([]), new NullOutput()));
+}
+
+test('the application does not default to the cron_daily channel', function (): void {
+    // Regression: routes/console.php used to call Log::setDefaultDriver('cron_daily')
+    // at file-load time, permanently switching the process-wide default channel.
+    // Under Octane (octane:start is an Artisan command that loads the console
+    // routes) this leaked into every HTTP worker, sending web logs to cron.log.
+    expect(Log::getDefaultDriver())->not->toBe('cron_daily');
+});
+
+test('the scheduler switches the default log channel to cron_daily', function (): void {
+    Log::setDefaultDriver('daily');
+
+    fireCommandStarting('schedule:run');
+
+    expect(Log::getDefaultDriver())->toBe('cron_daily');
+});
+
+test('the queue worker switches the default log channel to cron_daily', function (): void {
+    Log::setDefaultDriver('daily');
+
+    fireCommandStarting('queue:work');
+
+    expect(Log::getDefaultDriver())->toBe('cron_daily');
+});
+
+test('other console commands keep the default log channel', function (): void {
+    Log::setDefaultDriver('daily');
+
+    fireCommandStarting('route:list');
+
+    expect(Log::getDefaultDriver())->toBe('daily');
+});


### PR DESCRIPTION
## Problem

When running under Octane, **all HTTP request logs were written to `storage/logs/cron.log`** (the `cron_daily` channel) instead of `laravel.log` (the `daily` channel). The `cron_daily` channel is meant to be used only by the scheduler and the queue worker.

## Root cause

`routes/console.php` called `Log::setDefaultDriver('cron_daily')` at file-load time:

```php
Log::setDefaultDriver('cron_daily');
```

`Log::setDefaultDriver()` mutates process-wide state (it also writes `logging.default` into the config). Under PHP-FPM this was harmless — web requests never load the console routes. But `octane:start` is itself an Artisan command, so bootstrapping its console kernel loads `routes/console.php` and permanently flips the default log channel. Octane's long-lived workers then inherit `cron_daily` for the life of the worker, routing every HTTP request's logs to `cron.log`.

This is the classic Octane footgun: never leak global/process state across requests.

## Fix

Remove the global mutation from `routes/console.php` and switch the default channel via a `CommandStarting` listener that only fires for the scheduler and queue worker commands (`schedule:run`, `schedule:work`, `queue:work`, `queue:listen`). `CommandStarting` never dispatches for HTTP requests, so Octane workers keep the `daily` channel while the scheduler and queue worker still log to `cron_daily`.

## Tests

Added `tests/Feature/CronLogChannelTest.php`:
- the application no longer defaults to `cron_daily`
- `schedule:run` and `queue:work` switch the default channel to `cron_daily`
- other console commands keep the default channel

## Notes

`App\Contracts\CronCommand` still calls `Log::setDefaultDriver('cron')` in its constructor, but it has no subclasses and `cron` isn't a defined channel — left untouched as it's unrelated dead code, out of scope for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled tasks and queue workers now use the dedicated daily cron log channel.
  * Regular application activity and unrelated console commands continue using the configured default logging channel.
* **Tests**
  * Added coverage verifying logging behavior for scheduled tasks, queue workers, and unrelated commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->