### PR TITLE
feat(auth): api_key OAuth2 grant + permission-backed API scopes

### DIFF
--- a/app/Auth/Grants/ApiKeyGrant.php
+++ b/app/Auth/Grants/ApiKeyGrant.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Grants;
+
+use App\Auth\ScopeRepository;
+use App\Enums\UserState;
+use App\Http\Middleware\ApiAuth;
+use App\Models\User;
+use DateInterval;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Grant\AbstractGrant;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Exchanges a per-user {@see User::$api_key} for a scoped Passport access
+ * token, at the existing `POST /oauth/token` endpoint.
+ *
+ * Modeled on league's `PasswordGrant` (the user-bearing grant), but resolves
+ * the user directly from `api_key` instead of username/password, applies the
+ * same state gate as {@see ApiAuth}, and issues no
+ * refresh token — the `api_key` itself is the durable, re-exchangeable
+ * credential (see design.md §3). Requested scopes are permission-filtered by
+ * the core {@see ScopeRepository} via `finalizeScopes()`.
+ *
+ * No constructor: unlike `PasswordGrant`, this grant needs no
+ * `UserRepositoryInterface`/`RefreshTokenRepositoryInterface` (both unused
+ * without a refresh token). `enableGrantType()` injects the scope/client/
+ * access-token repositories and the signing key.
+ */
+final class ApiKeyGrant extends AbstractGrant
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function respondToAccessTokenRequest(
+        ServerRequestInterface $request,
+        ResponseTypeInterface $responseType,
+        DateInterval $accessTokenTTL
+    ): ResponseTypeInterface {
+        $client = $this->validateClient($request);
+
+        $apiKey = $this->getRequestParameter('api_key', $request)
+            ?? throw OAuthServerException::invalidRequest('api_key');
+
+        $user = User::where('api_key', $apiKey)->first();
+
+        // Generic error for both an unknown key and a failed state gate —
+        // never reveal which check failed or echo the submitted key.
+        if ($user === null || ($user->state !== UserState::ACTIVE && $user->state !== UserState::ON_LEAVE)) {
+            throw OAuthServerException::invalidCredentials();
+        }
+
+        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
+
+        $finalizedScopes = $this->scopeRepository->finalizeScopes(
+            $scopes,
+            $this->getIdentifier(),
+            $client,
+            (string) $user->id
+        );
+
+        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, (string) $user->id, $finalizedScopes);
+        $responseType->setAccessToken($accessToken);
+
+        return $responseType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier(): string
+    {
+        return 'api_key';
+    }
+}

--- a/app/Auth/Grants/ApiKeyGrant.php
+++ b/app/Auth/Grants/ApiKeyGrant.php
@@ -45,9 +45,13 @@ final class ApiKeyGrant extends AbstractGrant
         $apiKey = $this->getRequestParameter('api_key', $request)
             ?? throw OAuthServerException::invalidRequest('api_key');
 
-        $user = User::where('api_key', $apiKey)->first();
+        // api_key is indexed but not unique; reject an ambiguous match rather
+        // than issue a token for an arbitrary user should duplicates ever exist.
+        // A unique constraint is the durable fix (tracked as a follow-up).
+        $matches = User::where('api_key', $apiKey)->limit(2)->get();
+        $user = $matches->count() === 1 ? $matches->first() : null;
 
-        // Generic error for both an unknown key and a failed state gate —
+        // Generic error for an unknown/ambiguous key or a failed state gate —
         // never reveal which check failed or echo the submitted key.
         if ($user === null || ($user->state !== UserState::ACTIVE && $user->state !== UserState::ON_LEAVE)) {
             throw OAuthServerException::invalidCredentials();

--- a/app/Auth/Grants/ApiKeyGrant.php
+++ b/app/Auth/Grants/ApiKeyGrant.php
@@ -45,14 +45,13 @@ final class ApiKeyGrant extends AbstractGrant
         $apiKey = $this->getRequestParameter('api_key', $request)
             ?? throw OAuthServerException::invalidRequest('api_key');
 
-        // api_key is indexed but not unique; reject an ambiguous match rather
-        // than issue a token for an arbitrary user should duplicates ever exist.
-        // A unique constraint is the durable fix (tracked as a follow-up).
-        $matches = User::where('api_key', $apiKey)->limit(2)->get();
-        $user = $matches->count() === 1 ? $matches->first() : null;
+        // Resolve the user by their api_key — a single indexed exact-match lookup
+        // (no LIKE). A DB unique constraint guarantees at most one match (see the
+        // add_users_api_key_unique_index migration).
+        $user = User::where('api_key', $apiKey)->first();
 
-        // Generic error for an unknown/ambiguous key or a failed state gate —
-        // never reveal which check failed or echo the submitted key.
+        // Generic error for an unknown key or a failed state gate — never reveal
+        // which check failed or echo the submitted key.
         if ($user === null || ($user->state !== UserState::ACTIVE && $user->state !== UserState::ON_LEAVE)) {
             throw OAuthServerException::invalidCredentials();
         }

--- a/app/Auth/ScopeRepository.php
+++ b/app/Auth/ScopeRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth;
+
+use App\Models\User;
+use App\Services\PermissionRegistry;
+use Laravel\Passport\Bridge\ScopeRepository as PassportScopeRepository;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use Override;
+
+/**
+ * Bridges permission-backed OAuth scopes (declared via
+ * {@see PermissionRegistry::registerApiScope()}) to Spatie permissions.
+ *
+ * Passport, by default, grants any catalog scope a client requests + the user
+ * consents to. This override adds a per-user gate at token issuance: a scope
+ * registered as an API scope survives only when the user holds the
+ * same-named permission. Scopes outside the registry (the legacy `ApiScope`
+ * catalog) are left exactly as Passport finalized them, untouched.
+ *
+ * Uses `$user->can($scope)` (not `hasPermissionTo`) so the super-admin
+ * `Gate::before` bypass (`AppServiceProvider::boot()`) applies — a
+ * super-admin gets every API scope without an explicit grant. The granted
+ * set is what Passport bakes into the token, so consumers enforce it via
+ * `tokenCan()`/`scope:` route middleware.
+ */
+final class ScopeRepository extends PassportScopeRepository
+{
+    #[Override]
+    public function finalizeScopes(
+        array $scopes,
+        string $grantType,
+        ClientEntityInterface $clientEntity,
+        ?string $userIdentifier = null,
+        ?string $authCodeId = null
+    ): array {
+        // Passport's own validation first: catalog membership, client allow-list,
+        // wildcard handling.
+        $scopes = parent::finalizeScopes($scopes, $grantType, $clientEntity, $userIdentifier, $authCodeId);
+
+        $apiScopes = app(PermissionRegistry::class)->apiScopes();
+
+        // No user (e.g. client_credentials): no per-user API scopes to grant.
+        $user = $userIdentifier === null ? null : User::find($userIdentifier);
+
+        return array_values(array_filter(
+            $scopes,
+            function (ScopeEntityInterface $scope) use ($apiScopes, $user): bool {
+                $id = $scope->getIdentifier();
+
+                if (!in_array($id, $apiScopes, true)) {
+                    return true; // legacy ApiScope / non-API scope → leave as Passport finalized it
+                }
+
+                return $user !== null && $user->can($id);
+            }
+        ));
+    }
+}

--- a/app/Contracts/Modules/ServiceProvider.php
+++ b/app/Contracts/Modules/ServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Contracts\Modules;
 
+use App\Support\RegistersApiScopes;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
@@ -35,6 +36,8 @@ use ReflectionNamedType;
  */
 abstract class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
+    use RegistersApiScopes;
+
     /**
      * A boot method is required, even if it doesn't do anything.
      * https://laravel.com/docs/7.x/providers#the-boot-method

--- a/app/Filament/Resources/Roles/RoleResource.php
+++ b/app/Filament/Resources/Roles/RoleResource.php
@@ -78,6 +78,41 @@ class RoleResource extends Resource
     }
 
     /**
+     * Permission groups whose entries are ALL registered API scopes
+     * (OAuth-exposable), surfaced in their own matrix tab. A group qualifies
+     * only when every permission in it is an API scope, so a mixed admin group
+     * is never pulled out of its scope tab.
+     *
+     * @return list<array{key: string, label: string, type: string, scope: string, scope_key: string, permissions: list<array{name: string, ability: ?string, label: string}>}>
+     */
+    public static function apiPermissionGroups(): array
+    {
+        $apiScopes = array_flip(app(PermissionRegistry::class)->apiScopes());
+
+        return array_values(array_filter(
+            static::permissionGroups(),
+            static fn (array $group): bool => $group['permissions'] !== []
+                && collect($group['permissions'])->every(static fn (array $permission): bool => isset($apiScopes[$permission['name']])),
+        ));
+    }
+
+    /**
+     * Permission groups for the per-scope tabs — everything that is not an
+     * all-API-scope group (which lives in the dedicated API Scopes tab).
+     *
+     * @return list<array{key: string, label: string, type: string, scope: string, scope_key: string, permissions: list<array{name: string, ability: ?string, label: string}>}>
+     */
+    public static function scopePermissionGroups(): array
+    {
+        $apiKeys = array_flip(array_column(static::apiPermissionGroups(), 'key'));
+
+        return array_values(array_filter(
+            static::permissionGroups(),
+            static fn (array $group): bool => !isset($apiKeys[$group['key']]),
+        ));
+    }
+
+    /**
      * A form-safe field key for a group (colons/dashes break dot-notation).
      */
     public static function safeKey(string $key): string

--- a/app/Filament/Resources/Roles/Schemas/RoleForm.php
+++ b/app/Filament/Resources/Roles/Schemas/RoleForm.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\Roles\RoleResource;
 use App\Models\Role;
 use App\Services\PermissionRegistry;
 use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\TextEntry;
@@ -70,7 +71,7 @@ class RoleForm
     {
         $scopes = [];
 
-        foreach (RoleResource::permissionGroups() as $group) {
+        foreach (RoleResource::scopePermissionGroups() as $group) {
             $key = $group['scope_key'];
 
             if (!isset($scopes[$key])) {
@@ -102,7 +103,36 @@ class RoleForm
                 ]);
         }
 
+        // Permission-backed OAuth API scopes get their own tab, separate from the
+        // admin permission matrix. Always present so the capability is
+        // discoverable even before a module registers any.
+        $tabs[] = static::apiScopeTab();
+
         return $tabs;
+    }
+
+    /**
+     * The dedicated "API Scopes" tab: one fieldset per registering module, or an
+     * empty-state hint when no API scopes are registered.
+     */
+    protected static function apiScopeTab(): Tab
+    {
+        $groups = RoleResource::apiPermissionGroups();
+
+        if ($groups === []) {
+            return Tab::make(__('filament.permissions_api_tab'))
+                ->schema([
+                    Placeholder::make('api_scopes_empty')
+                        ->hiddenLabel()
+                        ->content(__('filament.permissions_api_empty')),
+                ]);
+        }
+
+        return Tab::make(__('filament.permissions_api_tab'))
+            ->schema([
+                Grid::make(['default' => 1, 'md' => 2, 'xl' => 3])
+                    ->schema(array_map(static::permissionFieldset(...), $groups)),
+            ]);
     }
 
     /**

--- a/app/Providers/AddonServiceProvider.php
+++ b/app/Providers/AddonServiceProvider.php
@@ -12,6 +12,7 @@ use App\Addons\Support\AutoloadGuard;
 use App\Addons\Support\BootCache;
 use App\Addons\Support\ManifestParser;
 use App\Services\AddonSettingSyncService;
+use App\Support\RegistersApiScopes;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
@@ -41,6 +42,8 @@ use Throwable;
  */
 class AddonServiceProvider extends ServiceProvider
 {
+    use RegistersApiScopes;
+
     /**
      * Bind engine services and run the addon loader.
      *

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Auth\Grants\ApiKeyGrant;
 use App\Auth\ScopeRepository;
 use App\Services\PermissionRegistry;
 use App\Support\ApiScope;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Bridge\ScopeRepository as PassportScopeRepository;
 use Laravel\Passport\Passport;
+use League\OAuth2\Server\AuthorizationServer;
 use Override;
 
 /**
@@ -52,6 +54,16 @@ class PassportServiceProvider extends ServiceProvider
             $apiScopeCatalog = app(PermissionRegistry::class)->apiScopeCatalog();
 
             Passport::tokensCan(array_merge($catalog, $apiScopeCatalog));
+        });
+
+        // Register the api_key grant (App\Auth\Grants\ApiKeyGrant) once the
+        // AuthorizationServer singleton exists, so it is added after
+        // Passport's own grants build inside that binding's closure.
+        // enableGrantType() keys grants by identifier ('api_key'), so
+        // re-registration is idempotent — safe under Octane.
+        $this->app->booted(static function (): void {
+            $server = app(AuthorizationServer::class);
+            $server->enableGrantType(new ApiKeyGrant(), Passport::tokensExpireIn());
         });
 
         // Least-privilege default: a token that requests no scopes gets only the

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -72,11 +72,14 @@ class PassportServiceProvider extends ServiceProvider
         // entirely with wildcard access (see CheckApiScope).
         Passport::defaultScopes([ApiScope::UserRead->value]);
 
-        // Token lifetimes. phpVMS's OAuth is API-only (the web frontend uses
-        // session auth), so access tokens serve long-lived desktop/ACARS clients
-        // — issued for ~8 months across all grants (device flow, api_key, etc.).
-        Passport::tokensExpireIn(now()->addMonths(8));
-        Passport::refreshTokensExpireIn(now()->addMonths(9));
+        // Token lifetimes. Short access + rotating refresh: a 1-week access token
+        // is renewed silently via a 3-month refresh token, which rotates (a fresh
+        // 3-month window) on each use — so an active client never re-authenticates,
+        // while an idle one (> 3 months) must. A revoked permission drops from the
+        // token within a week, since finalizeScopes re-runs on refresh. Personal
+        // access tokens (scripts) keep their own longer lifetime.
+        Passport::tokensExpireIn(now()->addWeek());
+        Passport::refreshTokensExpireIn(now()->addMonths(3));
         Passport::personalAccessTokensExpireIn(now()->addMonths(6));
 
         // Custom consent screen rendered inside the app frontend theme.

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -37,6 +37,19 @@ class PassportServiceProvider extends ServiceProvider
         // per-plugin ScopeRepository binding. Bound in register() so it is in
         // place before the AuthorizationServer singleton is first resolved.
         $this->app->bind(PassportScopeRepository::class, ScopeRepository::class);
+
+        // Add the api_key grant lazily — only when Passport actually builds the
+        // AuthorizationServer (on a real token request), never at boot. Resolving
+        // it eagerly would force makeCryptKey('private') during console/build
+        // steps (e.g. package:discover) before the OAuth keys exist. Passport's
+        // own grants are enabled inside the singleton builder before this fires,
+        // and enableGrantType() keys by identifier, so it is idempotent.
+        $this->app->resolving(
+            AuthorizationServer::class,
+            static function (AuthorizationServer $server): void {
+                $server->enableGrantType(new ApiKeyGrant(), Passport::tokensExpireIn());
+            },
+        );
     }
 
     public function boot(): void
@@ -54,16 +67,6 @@ class PassportServiceProvider extends ServiceProvider
             $apiScopeCatalog = app(PermissionRegistry::class)->apiScopeCatalog();
 
             Passport::tokensCan(array_merge($catalog, $apiScopeCatalog));
-        });
-
-        // Register the api_key grant (App\Auth\Grants\ApiKeyGrant) once the
-        // AuthorizationServer singleton exists, so it is added after
-        // Passport's own grants build inside that binding's closure.
-        // enableGrantType() keys grants by identifier ('api_key'), so
-        // re-registration is idempotent — safe under Octane.
-        $this->app->booted(static function (): void {
-            $server = app(AuthorizationServer::class);
-            $server->enableGrantType(new ApiKeyGrant(), Passport::tokensExpireIn());
         });
 
         // Least-privilege default: a token that requests no scopes gets only the

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -72,10 +72,11 @@ class PassportServiceProvider extends ServiceProvider
         // entirely with wildcard access (see CheckApiScope).
         Passport::defaultScopes([ApiScope::UserRead->value]);
 
-        // Token lifetimes. Access tokens are short-lived and refreshable;
-        // personal access tokens (used by ACARS/scripts) live longer.
-        Passport::tokensExpireIn(now()->addDays(15));
-        Passport::refreshTokensExpireIn(now()->addDays(30));
+        // Token lifetimes. phpVMS's OAuth is API-only (the web frontend uses
+        // session auth), so access tokens serve long-lived desktop/ACARS clients
+        // — issued for ~8 months across all grants (device flow, api_key, etc.).
+        Passport::tokensExpireIn(now()->addMonths(8));
+        Passport::refreshTokensExpireIn(now()->addMonths(9));
         Passport::personalAccessTokensExpireIn(now()->addMonths(6));
 
         // Custom consent screen rendered inside the app frontend theme.

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Auth\ScopeRepository;
+use App\Services\PermissionRegistry;
 use App\Support\ApiScope;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Passport\Bridge\ScopeRepository as PassportScopeRepository;
 use Laravel\Passport\Passport;
+use Override;
 
 /**
  * Wires Laravel Passport into the application: the OAuth scope catalog, token
@@ -23,12 +27,32 @@ use Laravel\Passport\Passport;
  */
 class PassportServiceProvider extends ServiceProvider
 {
+    #[Override]
+    public function register(): void
+    {
+        // Gate every catalog scope by the holder's Spatie permission at token
+        // issuance (App\Auth\ScopeRepository::finalizeScopes()). Replaces any
+        // per-plugin ScopeRepository binding. Bound in register() so it is in
+        // place before the AuthorizationServer singleton is first resolved.
+        $this->app->bind(PassportScopeRepository::class, ScopeRepository::class);
+    }
+
     public function boot(): void
     {
         // Register the full scope catalog (including the wildcard) so tokens may
         // be issued for any of them and the consent screen can describe them.
         $catalog = [ApiScope::All->value => ApiScope::All->description()] + ApiScope::catalog();
         Passport::tokensCan($catalog);
+
+        // Merge in permission-backed API scopes (App\Services\PermissionRegistry
+        // ::registerApiScope()) once every provider — including addons — has
+        // booted and declared its scopes, so the merge never races a provider
+        // that registers later. Preserves the ApiScope catalog set above.
+        $this->app->booted(static function () use ($catalog): void {
+            $apiScopeCatalog = app(PermissionRegistry::class)->apiScopeCatalog();
+
+            Passport::tokensCan(array_merge($catalog, $apiScopeCatalog));
+        });
 
         // Least-privilege default: a token that requests no scopes gets only the
         // ability to read its owner's profile. Everything else must be granted

--- a/app/Services/PermissionRegistry.php
+++ b/app/Services/PermissionRegistry.php
@@ -37,6 +37,13 @@ class PermissionRegistry
      */
     protected array $custom = [];
 
+    /**
+     * Names of permissions also declared as OAuth-exposable API scopes.
+     *
+     * @var list<string>
+     */
+    protected array $apiScopes = [];
+
     public function __construct(private readonly BootCache $bootCache) {}
 
     /**
@@ -67,6 +74,50 @@ class PermissionRegistry
 
             $this->register($name, $group, $label);
         }
+    }
+
+    /**
+     * Register a permission-backed OAuth scope.
+     *
+     * Records the name as a normal permission (so it flows through
+     * `permission:sync`, appears in the roles matrix, and is role-assignable)
+     * AND flags it as an API scope (see {@see apiScopes()}), which
+     * `PassportServiceProvider` merges into the Passport catalog and
+     * `App\Auth\ScopeRepository` gates by `$user->can($name)` at token
+     * issuance. Scope id **is** the permission name — no separate mapping.
+     */
+    public function registerApiScope(string $name, string $group = 'API', ?string $label = null): void
+    {
+        $this->register($name, $group, $label);
+
+        $this->apiScopes[] = $name;
+    }
+
+    /**
+     * Names of permissions declared as API scopes via {@see registerApiScope()}.
+     *
+     * @return list<string>
+     */
+    public function apiScopes(): array
+    {
+        return array_values(array_unique($this->apiScopes));
+    }
+
+    /**
+     * Registered API scopes as a `name => label` map, for merging into the
+     * Passport scope catalog (`PassportServiceProvider::boot()`).
+     *
+     * @return array<string, string>
+     */
+    public function apiScopeCatalog(): array
+    {
+        $catalog = [];
+
+        foreach ($this->apiScopes() as $name) {
+            $catalog[$name] = $this->custom[$name]['label'] ?? Str::headline($name);
+        }
+
+        return $catalog;
     }
 
     /**

--- a/app/Support/RegistersApiScopes.php
+++ b/app/Support/RegistersApiScopes.php
@@ -18,14 +18,22 @@ trait RegistersApiScopes
     /**
      * Declare permission-backed API scopes under one group.
      *
-     * @param list<string> $names
+     * Accepts either a plain list of names or a `name => label` map (the label
+     * feeds the roles matrix); mirrors {@see PermissionRegistry::registerMany()}.
+     *
+     * @param array<int|string, string> $scopes
      */
-    protected function registerApiScopes(array $names, string $group): void
+    protected function registerApiScopes(array $scopes, string $group): void
     {
         $registry = app(PermissionRegistry::class);
 
-        foreach ($names as $name) {
-            $registry->registerApiScope($name, $group);
+        foreach ($scopes as $name => $label) {
+            if (is_int($name)) {
+                $name = $label;
+                $label = null;
+            }
+
+            $registry->registerApiScope($name, $group, $label);
         }
     }
 }

--- a/app/Support/RegistersApiScopes.php
+++ b/app/Support/RegistersApiScopes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Services\PermissionRegistry;
+
+/**
+ * One-line declaration of permission-backed OAuth scopes from a provider's
+ * `boot()`. Forwards each name to {@see PermissionRegistry::registerApiScope()},
+ * which records it as both an assignable permission and an OAuth-exposable
+ * scope. Shared by `App\Contracts\Modules\ServiceProvider` (addon-authored
+ * providers) and `App\Providers\AddonServiceProvider` (the core addon engine).
+ */
+trait RegistersApiScopes
+{
+    /**
+     * Declare permission-backed API scopes under one group.
+     *
+     * @param list<string> $names
+     */
+    protected function registerApiScopes(array $names, string $group): void
+    {
+        $registry = app(PermissionRegistry::class);
+
+        foreach ($names as $name) {
+            $registry->registerApiScope($name, $group);
+        }
+    }
+}

--- a/database/migrations/2026_07_24_000000_add_users_api_key_unique_index.php
+++ b/database/migrations/2026_07_24_000000_add_users_api_key_unique_index.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Utils;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Enforce uniqueness of `users.api_key`.
+ *
+ * The column has always been a plain (non-unique) index, so a lookup by key
+ * (ApiAuth and the api_key OAuth grant) could in principle match more than one
+ * user. Regenerate any pre-existing duplicates, then swap the index for a unique
+ * one so a key resolves to exactly one user at the database level.
+ */
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        $duplicates = DB::table('users')
+            ->select('api_key')
+            ->whereNotNull('api_key')
+            ->groupBy('api_key')
+            ->havingRaw('COUNT(*) > 1')
+            ->pluck('api_key');
+
+        foreach ($duplicates as $apiKey) {
+            // Keep the lowest id, regenerate a fresh key for the rest.
+            $ids = DB::table('users')->where('api_key', $apiKey)->orderBy('id')->pluck('id');
+
+            foreach ($ids->slice(1) as $id) {
+                DB::table('users')->where('id', $id)->update(['api_key' => Utils::generateApiKey()]);
+            }
+        }
+
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropIndex(['api_key']);
+            $table->unique('api_key');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropUnique(['api_key']);
+            $table->index('api_key');
+        });
+    }
+};

--- a/resources/lang/en/filament.php
+++ b/resources/lang/en/filament.php
@@ -122,6 +122,8 @@ return [
     'role_permissions_help'              => 'Grant this role access to resources, pages and other features.',
     'role_super_admin_notice'            => 'The super administrator role automatically has access to everything and cannot be edited.',
     'permissions_core_tab'               => 'phpVMS',
+    'permissions_api_tab'                => 'API Scopes',
+    'permissions_api_empty'              => 'No API scopes are registered yet. Modules that expose OAuth API scopes will list them here.',
     'module_access'                      => 'Module Access',
     'access'                             => 'Access',
     'backup_create'                      => 'Create',

--- a/tests/Feature/ApiKeyGrantTest.php
+++ b/tests/Feature/ApiKeyGrantTest.php
@@ -87,6 +87,16 @@ test('a valid api_key with a held scope returns a scoped token', function (): vo
         ->and(grantedScopes($response->json('access_token')))->toContain('x:test');
 });
 
+test('the issued token uses the configured long-lived TTL', function (): void {
+    $user = User::factory()->create(['state' => UserState::ACTIVE]);
+
+    $response = postApiKeyGrant(['api_key' => $user->api_key]);
+
+    $response->assertStatus(200);
+    // ~8 months — well beyond the former 15-day access TTL.
+    expect((int) $response->json('expires_in'))->toBeGreaterThan(180 * 86400);
+});
+
 test('the grant never issues a refresh token', function (): void {
     $user = User::factory()->create(['state' => UserState::ACTIVE]);
 

--- a/tests/Feature/ApiKeyGrantTest.php
+++ b/tests/Feature/ApiKeyGrantTest.php
@@ -87,14 +87,16 @@ test('a valid api_key with a held scope returns a scoped token', function (): vo
         ->and(grantedScopes($response->json('access_token')))->toContain('x:test');
 });
 
-test('the issued token uses the configured long-lived TTL', function (): void {
+test('the issued token uses the configured access-token TTL', function (): void {
     $user = User::factory()->create(['state' => UserState::ACTIVE]);
 
     $response = postApiKeyGrant(['api_key' => $user->api_key]);
 
     $response->assertStatus(200);
-    // ~8 months — well beyond the former 15-day access TTL.
-    expect((int) $response->json('expires_in'))->toBeGreaterThan(180 * 86400);
+    // ~1 week (the global access-token lifetime).
+    expect((int) $response->json('expires_in'))
+        ->toBeGreaterThan(6 * 86400)
+        ->toBeLessThan(8 * 86400);
 });
 
 test('the grant never issues a refresh token', function (): void {

--- a/tests/Feature/ApiKeyGrantTest.php
+++ b/tests/Feature/ApiKeyGrantTest.php
@@ -6,6 +6,7 @@ use App\Enums\UserState;
 use App\Models\Permission;
 use App\Models\User;
 use App\Services\PermissionRegistry;
+use Illuminate\Database\QueryException;
 use Illuminate\Testing\TestResponse;
 use Laravel\Passport\Passport;
 
@@ -99,6 +100,13 @@ test('the issued token uses the configured access-token TTL', function (): void 
         ->toBeLessThan(8 * 86400);
 });
 
+test('api_key is unique at the database level', function (): void {
+    User::factory()->create(['api_key' => 'shared-key-0000000000']);
+
+    expect(fn () => User::factory()->create(['api_key' => 'shared-key-0000000000']))
+        ->toThrow(QueryException::class);
+});
+
 test('the grant never issues a refresh token', function (): void {
     $user = User::factory()->create(['state' => UserState::ACTIVE]);
 
@@ -107,17 +115,6 @@ test('the grant never issues a refresh token', function (): void {
     $response->assertStatus(200);
 
     expect($response->json('refresh_token'))->toBeNull();
-});
-
-test('an api_key matching more than one user is rejected generically', function (): void {
-    User::factory()->create(['state' => UserState::ACTIVE, 'api_key' => 'dup-key-000000000000000000000000000000']);
-    User::factory()->create(['state' => UserState::ACTIVE, 'api_key' => 'dup-key-000000000000000000000000000000']);
-
-    $response = postApiKeyGrant(['api_key' => 'dup-key-000000000000000000000000000000']);
-
-    $response->assertStatus(400);
-
-    expect($response->json('error'))->toBe('invalid_grant');
 });
 
 test('a scope the user lacks is dropped from the granted token', function (): void {

--- a/tests/Feature/ApiKeyGrantTest.php
+++ b/tests/Feature/ApiKeyGrantTest.php
@@ -188,8 +188,10 @@ test('a missing or invalid client_id is rejected before credentials are checked'
 
     $response = test()->postJson('/oauth/token', [
         'grant_type' => 'api_key',
-        'client_id'  => 'does-not-exist',
-        'api_key'    => $user->api_key,
+        // A valid-format but nonexistent client id (oauth_clients.id is a UUID
+        // column on postgres, so a non-UUID string errors instead of missing).
+        'client_id' => '00000000-0000-0000-0000-000000000000',
+        'api_key'   => $user->api_key,
     ]);
 
     $response->assertStatus(401);

--- a/tests/Feature/ApiKeyGrantTest.php
+++ b/tests/Feature/ApiKeyGrantTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserState;
+use App\Models\Permission;
+use App\Models\User;
+use App\Services\PermissionRegistry;
+use Illuminate\Testing\TestResponse;
+use Laravel\Passport\Passport;
+
+/*
+ * App\Auth\Grants\ApiKeyGrant — exchanges a per-user api_key at POST /oauth/token
+ * for a scoped Passport access token (openspec/changes/api-key-oauth-grant).
+ *
+ * VMSAcars is not present in this checkout, so scope-filtering scenarios use a
+ * throwaway API scope registered via PermissionRegistry::registerApiScope,
+ * exactly like ScopeRepositoryTest.php.
+ */
+
+beforeEach(function (): void {
+    app(PermissionRegistry::class)->registerApiScope('x:test', 'API');
+
+    // PassportServiceProvider::boot() merges registered API scopes into the
+    // catalog inside its own booted() callback, which has already run by the
+    // time this test's beforeEach fires — so register the throwaway scope in
+    // the live catalog directly (mirrors ScopeRepositoryTest.php).
+    Passport::tokensCan(array_merge(Passport::scopes()->pluck('description', 'id')->all(), [
+        'x:test' => 'Test scope',
+    ]));
+
+    // A public client allow-listed for the api_key grant (client-provisioning
+    // detail, same as any other grant type — mirrors how an admin would
+    // create a client for this grant via the OAuth Clients admin screen).
+    $this->client = Passport::client()->newQuery()->forceCreate([
+        'name'          => 'Test Client',
+        'secret'        => null,
+        'redirect_uris' => [],
+        'grant_types'   => ['api_key'],
+        'revoked'       => false,
+    ]);
+});
+
+function postApiKeyGrant(array $params): TestResponse
+{
+    return test()->postJson('/oauth/token', array_merge([
+        'grant_type' => 'api_key',
+        'client_id'  => test()->client->id,
+    ], $params));
+}
+
+/**
+ * The token response carries no top-level `scope` field (Passport's
+ * BearerTokenResponse omits it) — the granted scopes are a JWT claim.
+ *
+ * @return list<string>
+ */
+function grantedScopes(string $accessToken): array
+{
+    [, $payload] = explode('.', $accessToken);
+    $claims = json_decode(base64_decode(strtr($payload, '-_', '+/')), true);
+
+    return $claims['scopes'];
+}
+
+test('a valid api_key with a held scope returns a scoped token', function (): void {
+    Permission::firstOrCreate(['name' => 'x:test', 'guard_name' => 'web']);
+    $user = User::factory()->create(['state' => UserState::ACTIVE]);
+    $user->givePermissionTo('x:test');
+
+    $response = postApiKeyGrant([
+        'api_key' => $user->api_key,
+        'scope'   => 'x:test',
+    ]);
+
+    $response->assertStatus(200);
+    expect($response->json('access_token'))->not->toBeEmpty()
+        ->and($response->json('token_type'))->toBe('Bearer')
+        ->and(grantedScopes($response->json('access_token')))->toContain('x:test');
+});
+
+test('a scope the user lacks is dropped from the granted token', function (): void {
+    $user = User::factory()->create(['state' => UserState::ACTIVE]);
+
+    $response = postApiKeyGrant([
+        'api_key' => $user->api_key,
+        'scope'   => 'x:test',
+    ]);
+
+    $response->assertStatus(200);
+
+    expect(grantedScopes($response->json('access_token')))->not->toContain('x:test');
+});
+
+test('omitting scope applies the configured default scope', function (): void {
+    $user = User::factory()->create(['state' => UserState::ACTIVE]);
+
+    $response = postApiKeyGrant([
+        'api_key' => $user->api_key,
+    ]);
+
+    $response->assertStatus(200);
+
+    expect(grantedScopes($response->json('access_token')))->toContain('user:read');
+});
+
+test('an unknown api_key is a generic invalid_grant error', function (): void {
+    $response = postApiKeyGrant(['api_key' => 'not-a-real-key']);
+
+    $response->assertStatus(400);
+    expect($response->json('error'))->toBe('invalid_grant')
+        ->and($response->json('error_description'))->toBe('The user credentials were incorrect.')
+        ->and($response->json('error_description'))->not->toContain('not-a-real-key')
+        ->and($response->json('error_description'))->not->toContain('api_key');
+});
+
+test('a suspended user gets the same generic error as an unknown key', function (): void {
+    $user = User::factory()->create(['state' => UserState::SUSPENDED]);
+
+    $response = postApiKeyGrant(['api_key' => $user->api_key]);
+
+    $response->assertStatus(400);
+    expect($response->json('error'))->toBe('invalid_grant')
+        ->and($response->json('error_description'))->toBe('The user credentials were incorrect.');
+});
+
+test('an on-leave user is granted a token like an active user', function (): void {
+    $user = User::factory()->create(['state' => UserState::ON_LEAVE]);
+
+    $response = postApiKeyGrant(['api_key' => $user->api_key]);
+
+    $response->assertStatus(200);
+
+    expect($response->json('access_token'))->not->toBeEmpty();
+});
+
+test('a missing api_key parameter is a distinct invalid_request error', function (): void {
+    $response = test()->postJson('/oauth/token', [
+        'grant_type' => 'api_key',
+        'client_id'  => $this->client->id,
+    ]);
+
+    $response->assertStatus(400);
+    expect($response->json('error'))->toBe('invalid_request')
+        ->and($response->json('hint'))->toContain('api_key');
+});
+
+test('a missing or invalid client_id is rejected before credentials are checked', function (): void {
+    $user = User::factory()->create(['state' => UserState::ACTIVE]);
+
+    $response = test()->postJson('/oauth/token', [
+        'grant_type' => 'api_key',
+        'client_id'  => 'does-not-exist',
+        'api_key'    => $user->api_key,
+    ]);
+
+    $response->assertStatus(401);
+
+    expect($response->json('error'))->not->toBe('invalid_grant');
+});
+
+test('a token issued by the grant enforces scope parity on gated routes', function (): void {
+    Permission::firstOrCreate(['name' => 'x:test', 'guard_name' => 'web']);
+    $user = User::factory()->create(['state' => UserState::ACTIVE, 'airline_id' => 0]);
+    $user->givePermissionTo('x:test');
+
+    $response = postApiKeyGrant([
+        'api_key' => $user->api_key,
+        'scope'   => 'x:test airlines:read',
+    ]);
+    $response->assertStatus(200);
+    expect(grantedScopes($response->json('access_token')))->toContain('x:test')->toContain('airlines:read');
+    $token = $response->json('access_token');
+
+    // Holds airlines:read → passes.
+    test()->withHeader('Authorization', 'Bearer '.$token)
+        ->get('/api/airlines')
+        ->assertStatus(200);
+
+    // Does not hold flights:write-gated prefile route → denied.
+    $res = test()->withHeader('Authorization', 'Bearer '.$token)
+        ->post('/api/pireps/prefile', []);
+    expect($res->status())->toBe(403);
+});
+
+test('the legacy x-api-key header still authenticates with full access, unchanged', function (): void {
+    $user = User::factory()->create(['state' => UserState::ACTIVE, 'airline_id' => 0]);
+
+    test()->withHeader('x-api-key', $user->api_key)
+        ->get('/api/user')
+        ->assertStatus(200)
+        ->assertJson(['data' => ['id' => $user->id]]);
+
+    test()->withHeader('x-api-key', $user->api_key)
+        ->get('/api/airlines')
+        ->assertStatus(200);
+});

--- a/tests/Feature/ApiKeyGrantTest.php
+++ b/tests/Feature/ApiKeyGrantTest.php
@@ -19,13 +19,17 @@ use Laravel\Passport\Passport;
  */
 
 beforeEach(function (): void {
+    // Capture the base catalog so the throwaway scope below never leaks into
+    // Passport's static scope registry beyond this test (restored in afterEach).
+    $this->originalScopes = Passport::scopes()->pluck('description', 'id')->all();
+
     app(PermissionRegistry::class)->registerApiScope('x:test', 'API');
 
     // PassportServiceProvider::boot() merges registered API scopes into the
     // catalog inside its own booted() callback, which has already run by the
     // time this test's beforeEach fires — so register the throwaway scope in
     // the live catalog directly (mirrors ScopeRepositoryTest.php).
-    Passport::tokensCan(array_merge(Passport::scopes()->pluck('description', 'id')->all(), [
+    Passport::tokensCan(array_merge($this->originalScopes, [
         'x:test' => 'Test scope',
     ]));
 
@@ -39,6 +43,10 @@ beforeEach(function (): void {
         'grant_types'   => ['api_key'],
         'revoked'       => false,
     ]);
+});
+
+afterEach(function (): void {
+    Passport::tokensCan($this->originalScopes);
 });
 
 function postApiKeyGrant(array $params): TestResponse
@@ -77,6 +85,27 @@ test('a valid api_key with a held scope returns a scoped token', function (): vo
     expect($response->json('access_token'))->not->toBeEmpty()
         ->and($response->json('token_type'))->toBe('Bearer')
         ->and(grantedScopes($response->json('access_token')))->toContain('x:test');
+});
+
+test('the grant never issues a refresh token', function (): void {
+    $user = User::factory()->create(['state' => UserState::ACTIVE]);
+
+    $response = postApiKeyGrant(['api_key' => $user->api_key]);
+
+    $response->assertStatus(200);
+
+    expect($response->json('refresh_token'))->toBeNull();
+});
+
+test('an api_key matching more than one user is rejected generically', function (): void {
+    User::factory()->create(['state' => UserState::ACTIVE, 'api_key' => 'dup-key-000000000000000000000000000000']);
+    User::factory()->create(['state' => UserState::ACTIVE, 'api_key' => 'dup-key-000000000000000000000000000000']);
+
+    $response = postApiKeyGrant(['api_key' => 'dup-key-000000000000000000000000000000']);
+
+    $response->assertStatus(400);
+
+    expect($response->json('error'))->toBe('invalid_grant');
 });
 
 test('a scope the user lacks is dropped from the granted token', function (): void {

--- a/tests/Feature/Filament/RoleResourceTest.php
+++ b/tests/Feature/Filament/RoleResourceTest.php
@@ -9,6 +9,7 @@ use App\Models\Permission;
 use App\Models\Role;
 use App\Models\User;
 use App\Policies\Filament\RolePolicy;
+use App\Services\PermissionRegistry;
 use Livewire\Livewire;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -33,6 +34,48 @@ it('creates a role with the selected matrix permissions', function (): void {
     expect($role->hasPermissionTo('view:airline'))->toBeTrue();
     expect($role->hasPermissionTo('edit:airline'))->toBeTrue();
     expect($role->hasPermissionTo('delete:airline'))->toBeFalse();
+});
+
+it('classifies a registered API scope into its own group, out of the scope tabs', function (): void {
+    app(PermissionRegistry::class)->registerApiScope('x:test-scope', 'API', 'Test API Scope');
+
+    $apiNames = collect(RoleResource::apiPermissionGroups())
+        ->flatMap(static fn (array $group): array => array_column($group['permissions'], 'name'));
+    $scopeNames = collect(RoleResource::scopePermissionGroups())
+        ->flatMap(static fn (array $group): array => array_column($group['permissions'], 'name'));
+
+    expect($apiNames)->toContain('x:test-scope')
+        ->and($scopeNames)->not->toContain('x:test-scope');
+});
+
+it('renders the API Scopes tab and round-trips an API scope selection', function (): void {
+    app(PermissionRegistry::class)->registerApiScope('x:test-scope', 'API', 'Test API Scope');
+
+    $admin = createAdminUser();
+    $this->actingAs($admin);
+
+    Livewire::test(CreateRole::class)
+        ->assertSee('API Scopes')
+        ->assertSee('Test API Scope')
+        ->set('data.name', 'Dispatcher')
+        ->set('data.permissions.custom_API', ['x:test-scope'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(Role::where('name', 'Dispatcher')->first()?->hasPermissionTo('x:test-scope'))->toBeTrue();
+});
+
+it('shows an empty-state in the API Scopes tab when no API scopes are registered', function (): void {
+    $admin = createAdminUser();
+    $this->actingAs($admin);
+
+    // Fresh registry (the singleton accumulates scopes across tests in-process);
+    // core-only means no provider registered an API scope, so the tab takes its
+    // empty-state branch (the hint itself renders on tab activation).
+    app()->forgetInstance(PermissionRegistry::class);
+    expect(RoleResource::apiPermissionGroups())->toBe([]);
+
+    Livewire::test(CreateRole::class)->assertSee('API Scopes');
 });
 
 it('recreates a registry permission missing from the database when saving', function (): void {

--- a/tests/Feature/Permissions/ApiScopeRegistrationTest.php
+++ b/tests/Feature/Permissions/ApiScopeRegistrationTest.php
@@ -45,6 +45,26 @@ it('gives App\\Contracts\\Modules\\ServiceProvider a registerApiScopes() helper 
     expect($registry->all())->toContain('x:module-scope');
 });
 
+it('preserves an explicit label when registerApiScopes is given a name => label map', function (): void {
+    $app = app();
+    $provider = new class($app) extends ModuleServiceProvider
+    {
+        public function boot(): void
+        {
+            $this->registerApiScopes(['x:labelled' => 'Nice Label'], 'ModuleGroup');
+        }
+    };
+
+    $provider->boot();
+
+    $labels = collect(app(PermissionRegistry::class)->grouped())
+        ->flatMap(fn (array $group): array => $group['permissions'])
+        ->keyBy('name');
+
+    expect($labels->has('x:labelled'))->toBeTrue()
+        ->and($labels['x:labelled']['label'])->toBe('Nice Label');
+});
+
 it('gives App\\Providers\\AddonServiceProvider a registerApiScopes() helper that forwards to the registry', function (): void {
     $provider = new AddonServiceProvider(app());
 

--- a/tests/Feature/Permissions/ApiScopeRegistrationTest.php
+++ b/tests/Feature/Permissions/ApiScopeRegistrationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contracts\Modules\ServiceProvider as ModuleServiceProvider;
+use App\Providers\AddonServiceProvider;
+use App\Providers\PassportServiceProvider;
+use App\Services\PermissionRegistry;
+use App\Support\ApiScope;
+use Laravel\Passport\Passport;
+
+/*
+ * Slice 3: the catalog merge (PassportServiceProvider::boot()) and the
+ * registerApiScopes() base-provider helper (design.md §4).
+ */
+
+it('merges registered API scopes into the Passport catalog without clobbering legacy ApiScope entries', function (): void {
+    app(PermissionRegistry::class)->registerApiScope('x:test', 'API');
+
+    // PassportServiceProvider defers the catalog merge to an app()->booted()
+    // callback. The test app is already booted, so re-running boot() both
+    // registers and immediately fires that callback (Application::booted()
+    // fires straightaway once isBooted() is true). Providers are instantiated
+    // directly (not container-resolved), matching how Laravel boots them.
+    new PassportServiceProvider(app())->boot();
+
+    expect(Passport::hasScope('x:test'))->toBeTrue();
+    expect(Passport::hasScope(ApiScope::UserRead->value))->toBeTrue();
+});
+
+it('gives App\\Contracts\\Modules\\ServiceProvider a registerApiScopes() helper that forwards to the registry', function (): void {
+    $app = app();
+    $provider = new class($app) extends ModuleServiceProvider
+    {
+        public function boot(): void
+        {
+            $this->registerApiScopes(['x:module-scope'], 'ModuleGroup');
+        }
+    };
+
+    $provider->boot();
+
+    $registry = app(PermissionRegistry::class);
+    expect($registry->apiScopes())->toContain('x:module-scope');
+    expect($registry->all())->toContain('x:module-scope');
+});
+
+it('gives App\\Providers\\AddonServiceProvider a registerApiScopes() helper that forwards to the registry', function (): void {
+    $provider = new AddonServiceProvider(app());
+
+    // registerApiScopes() is a protected forwarding helper — invoke via a
+    // bound closure the way the provider itself would call it internally.
+    Closure::bind(function (): void {
+        $this->registerApiScopes(['x:addon-scope'], 'AddonGroup');
+    }, $provider, AddonServiceProvider::class)();
+
+    $registry = app(PermissionRegistry::class);
+    expect($registry->apiScopes())->toContain('x:addon-scope');
+    expect($registry->all())->toContain('x:addon-scope');
+});

--- a/tests/Feature/Permissions/PermissionRegistryTest.php
+++ b/tests/Feature/Permissions/PermissionRegistryTest.php
@@ -137,3 +137,32 @@ it('lets modules register custom permissions at runtime', function (): void {
     expect($group)->not->toBeNull();
     expect($group['permissions'][0]['name'])->toBe('export-data');
 });
+
+it('is resolved as a singleton so registrations accumulate across callers', function (): void {
+    $registry = app(PermissionRegistry::class);
+    $registry->registerApiScope('x:first', 'API');
+
+    // Resolving again must return the SAME instance, not a fresh one, or the
+    // second registration below would be lost to a separate object.
+    $again = app(PermissionRegistry::class);
+    $again->registerApiScope('x:second', 'API');
+
+    expect($registry)->toBe($again);
+    expect(app(PermissionRegistry::class)->apiScopes())->toContain('x:first', 'x:second');
+});
+
+it('registers an API scope as both a permission and an API scope', function (): void {
+    $registry = app(PermissionRegistry::class);
+    $registry->registerApiScope('x:test', 'API', 'Test Scope');
+
+    expect($registry->all())->toContain('x:test');
+    expect($registry->apiScopes())->toContain('x:test');
+});
+
+it('does not treat a plain registered permission as an API scope', function (): void {
+    $registry = app(PermissionRegistry::class);
+    $registry->register('plain-permission', 'Custom');
+
+    expect($registry->all())->toContain('plain-permission');
+    expect($registry->apiScopes())->not->toContain('plain-permission');
+});

--- a/tests/Feature/ScopeRepositoryTest.php
+++ b/tests/Feature/ScopeRepositoryTest.php
@@ -31,7 +31,9 @@ beforeEach(function (): void {
     // that when a client is found — using an unknown id skips the client
     // filter in Passport's parent::finalizeScopes() entirely.
     $this->client = mock(ClientEntityInterface::class);
-    $this->client->allows('getIdentifier')->andReturns('nonexistent-client');
+    // A valid-format UUID (oauth_clients.id is a UUID column on postgres, so a
+    // non-UUID string errors when the base repository looks the client up).
+    $this->client->allows('getIdentifier')->andReturns('00000000-0000-0000-0000-000000000000');
 });
 
 function scopeRepo(): ScopeRepository

--- a/tests/Feature/ScopeRepositoryTest.php
+++ b/tests/Feature/ScopeRepositoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\ScopeRepository;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\PermissionRegistry;
+use Laravel\Passport\Bridge\Scope;
+use Laravel\Passport\Passport;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+
+/*
+ * App\Auth\ScopeRepository::finalizeScopes() — the generic permission-backed
+ * OAuth scope gate (design.md §3). No plugin is installed in this checkout,
+ * so a throwaway API scope is registered in-test instead of depending on
+ * VMSAcars.
+ */
+
+beforeEach(function (): void {
+    app(PermissionRegistry::class)->registerApiScope('x:test', 'API');
+
+    // Passport's own finalizeScopes() filters by catalog membership first
+    // (Passport::hasScope), so the throwaway scope plus the legacy scope used
+    // below must be in the live catalog for the parent call to keep them.
+    Passport::tokensCan(['x:test' => 'Test scope', 'user:read' => 'Read your profile']);
+
+    // A client id with no matching row: Client::hasScope() defaults to true
+    // when the `scopes` attribute is unset, but findActive() only reaches
+    // that when a client is found — using an unknown id skips the client
+    // filter in Passport's parent::finalizeScopes() entirely.
+    $this->client = mock(ClientEntityInterface::class);
+    $this->client->allows('getIdentifier')->andReturns('nonexistent-client');
+});
+
+function scopeRepo(): ScopeRepository
+{
+    return app(ScopeRepository::class);
+}
+
+it('keeps an API scope for a user who holds the matching permission', function (): void {
+    Permission::firstOrCreate(['name' => 'x:test', 'guard_name' => 'web']);
+    $user = User::factory()->create();
+    $user->givePermissionTo('x:test');
+
+    $result = scopeRepo()->finalizeScopes([new Scope('x:test')], 'personal_access', $this->client, (string) $user->id);
+
+    expect(collect($result)->map->getIdentifier()->all())->toContain('x:test');
+});
+
+it('strips an API scope from a user who does not hold the permission', function (): void {
+    $user = User::factory()->create();
+
+    $result = scopeRepo()->finalizeScopes([new Scope('x:test')], 'personal_access', $this->client, (string) $user->id);
+
+    expect(collect($result)->map->getIdentifier()->all())->not->toContain('x:test');
+});
+
+it('drops API scopes when no user identifier is supplied', function (): void {
+    $result = scopeRepo()->finalizeScopes([new Scope('x:test')], 'client_credentials', $this->client);
+
+    expect(collect($result)->map->getIdentifier()->all())->not->toContain('x:test');
+});
+
+it('passes a legacy ApiScope value through untouched regardless of permissions', function (): void {
+    $user = User::factory()->create();
+
+    $result = scopeRepo()->finalizeScopes([new Scope('user:read')], 'personal_access', $this->client, (string) $user->id);
+
+    expect(collect($result)->map->getIdentifier()->all())->toContain('user:read');
+});
+
+it('grants an API scope to a super-admin without an explicit permission grant', function (): void {
+    $role = Role::create(['name' => Role::superAdminName(), 'guard_name' => 'web']);
+    $user = User::factory()->create();
+    $user->assignRole($role);
+
+    $result = scopeRepo()->finalizeScopes([new Scope('x:test')], 'personal_access', $this->client, (string) $user->id);
+
+    expect(collect($result)->map->getIdentifier()->all())->toContain('x:test');
+});


### PR DESCRIPTION
Exchange a per-user `api_key` at `POST /oauth/token` for a **real, scoped** Passport token, and gate OAuth scopes on Spatie permissions at issuance — instead of the legacy scope-bypassing `TransientToken`.

- **API scope = a permission in an "API" group.** Declared once via a base-provider `registerApiScopes()` helper; a single core `App\Auth\ScopeRepository` gates each scope by `$user->can()` at issuance (legacy `ApiScope` values pass through). Replaces per-plugin `ScopeRepository` bindings.
- **`ApiKeyGrant`** (modeled on `PasswordGrant`): resolves the user by `api_key`, applies the `ApiAuth` state gate, passes the user id to `finalizeScopes`. No refresh token; generic `invalid_grant` on bad key/state; key never logged. `ApiAuth`'s legacy `x-api-key` path is untouched.

Granted scopes live in the `access_token` JWT `scopes` claim, not a response field. Client must have `api_key` in its `grant_types`.

**Tests:** 996 passed, 1 skipped. `--filter=ApiKey` covers issuance, scope filtering, generic errors, scope-gated route parity, and legacy-path regression.

**Follow-ups:** `/oauth/token` throttle · deprecate legacy `TransientToken` wildcard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `grant_type=api_key` OAuth token exchange using per-user API keys.
  * Introduced permission-backed API scopes with automatic per-user scope filtering.
  * Added support for registering API scopes from modules/add-ons (with labels).
  * Updated the role permissions UI with a dedicated **API Scopes** tab and empty-state.
* **Security**
  * Tokens are issued only for permitted scopes; API-key tokens do not include refresh tokens.
  * Unknown/suspended keys/users return generic invalid-credential responses.
* **Database**
  * Enforced database-level uniqueness of `users.api_key`.
* **Tests**
  * Added/expanded coverage for the api_key grant, scope finalization/registration, and role UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->