### PR TITLE
feat(airports): bulk-add modal + Enter-to-lookup on ICAO

### DIFF
--- a/app/Filament/Resources/Airports/Actions/LookupAction.php
+++ b/app/Filament/Resources/Airports/Actions/LookupAction.php
@@ -16,6 +16,7 @@ class LookupAction
         return Action::make('lookup')
             ->label(__('airports.lookup'))
             ->icon(Heroicon::OutlinedMagnifyingGlass)
+            ->extraAttributes(['id' => 'airport-icao-lookup'])
             ->action(function (Get $get, Set $set): void {
                 $airport = app(AirportService::class)->lookupAirport($get('icao'));
 

--- a/app/Filament/Resources/Airports/Pages/ListAirports.php
+++ b/app/Filament/Resources/Airports/Pages/ListAirports.php
@@ -8,16 +8,29 @@ use App\Filament\Actions\ImportAction as OldImportAction;
 use App\Filament\Exports\AirportExporter;
 use App\Filament\Imports\AirportImporter;
 use App\Filament\Resources\Airports\AirportResource;
+use App\Models\Airport;
+use App\Services\AirportService;
+use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Actions\ExportAction;
 use Filament\Actions\ImportAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
 use Override;
 
 class ListAirports extends ListRecords
 {
     protected static string $resource = AirportResource::class;
+
+    public string $bulkIcaoInput = '';
+
+    /** @var array<int, array{icao: string, name: string, hub: bool, status: string}> */
+    public array $bulkRows = [];
 
     #[Override]
     protected function getHeaderActions(): array
@@ -39,6 +52,111 @@ class ListAirports extends ListRecords
 
             CreateAction::make()
                 ->icon(Heroicon::OutlinedPlusCircle),
+
+            Action::make('bulkAdd')
+                ->label(__('airports.bulk_add'))
+                ->icon(Heroicon::OutlinedRectangleStack)
+                ->modalHeading(__('airports.bulk_add'))
+                ->modalWidth(Width::TwoExtraLarge)
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel(__('common.close'))
+                ->mountUsing(fn () => $this->resetBulkAdd())
+                ->modalContent(fn (): Factory|View => view('filament.airports.bulk-add-modal')),
         ];
+    }
+
+    /**
+     * Queue the pasted ICAO codes as pending rows, then let the browser drive
+     * lookups one at a time (see processNextBulkAirport) so calls stay
+     * sequential and rate-limited.
+     */
+    public function addBulkAirports(): void
+    {
+        if (!Gate::allows('create', Airport::class)) {
+            Notification::make()->title(__('common.not_authorized'))->danger()->send();
+
+            return;
+        }
+
+        $codes = collect(preg_split('/[\s,]+/', $this->bulkIcaoInput, -1, PREG_SPLIT_NO_EMPTY))
+            ->map(fn (string $code): string => strtoupper(trim($code)))
+            ->filter()
+            ->unique();
+
+        foreach ($codes as $icao) {
+            // Skip codes already listed so re-submitting the box doesn't duplicate rows.
+            if (collect($this->bulkRows)->contains(fn (array $row): bool => $row['icao'] === $icao)) {
+                continue;
+            }
+
+            $this->bulkRows[] = ['icao' => $icao, 'name' => '', 'hub' => false, 'status' => 'pending'];
+        }
+
+        $this->bulkIcaoInput = '';
+        $this->dispatch('bulk-add-start');
+    }
+
+    /**
+     * Look up and persist the next pending row. Returns the number of rows still
+     * pending so the browser knows whether to keep going.
+     */
+    public function processNextBulkAirport(): int
+    {
+        $index = array_find_key($this->bulkRows, fn ($row): bool => $row['status'] === 'pending');
+        if ($index === null) {
+            return 0;
+        }
+
+        $icao = $this->bulkRows[$index]['icao'];
+        $lookup = app(AirportService::class)->lookupAirport($icao);
+
+        if (empty($lookup)) {
+            $this->bulkRows[$index]['status'] = 'error';
+        } else {
+            $existing = Airport::withTrashed()->where('icao', $icao)->first();
+            $status = $existing ? 'updated' : 'added';
+
+            $airport = $existing ?? new Airport();
+            $airport->fill($lookup);
+
+            if ($existing?->trashed()) {
+                $airport->restore();
+            }
+
+            $airport->save();
+
+            $this->bulkRows[$index] = [
+                'icao'   => $airport->icao,
+                'name'   => (string) $airport->name,
+                'hub'    => (bool) $airport->hub,
+                'status' => $status,
+            ];
+        }
+
+        return collect($this->bulkRows)->where('status', 'pending')->count();
+    }
+
+    public function toggleBulkHub(int $index): void
+    {
+        $row = $this->bulkRows[$index] ?? null;
+        if ($row === null || $row['status'] === 'error' || $row['status'] === 'pending') {
+            return;
+        }
+
+        $airport = Airport::where('icao', $row['icao'])->first();
+        if ($airport === null) {
+            return;
+        }
+
+        $airport->hub = !$airport->hub;
+        $airport->save();
+
+        $this->bulkRows[$index]['hub'] = (bool) $airport->hub;
+    }
+
+    public function resetBulkAdd(): void
+    {
+        $this->bulkIcaoInput = '';
+        $this->bulkRows = [];
     }
 }

--- a/app/Filament/Resources/Airports/Schemas/AirportForm.php
+++ b/app/Filament/Resources/Airports/Schemas/AirportForm.php
@@ -30,6 +30,9 @@ class AirportForm
                             ->string()
                             ->length(4)
                             ->columnSpan(2)
+                            ->extraInputAttributes([
+                                'x-on:keydown.enter.prevent' => "document.getElementById('airport-icao-lookup')?.click()",
+                            ])
                             ->hintAction(LookupAction::make()),
 
                         TextInput::make('iata')

--- a/app/Services/AirportService.php
+++ b/app/Services/AirportService.php
@@ -81,7 +81,7 @@ class AirportService extends Service
             return $airport;
         }
 
-        $response = Http::get('https://api.phpvms.net/v1/airports/'.$icao);
+        $response = Http::get(config('phpvms.api_url').'/v1/airports/'.$icao);
 
         if (!$response->successful()) {
             return [];

--- a/config/phpvms.php
+++ b/config/phpvms.php
@@ -16,6 +16,11 @@ return [
     'installed' => env('PHPVMS_INSTALLED', false),
 
     /*
+     * Base URL for the hosted phpVMS API (airport lookups, etc).
+     */
+    'api_url' => env('PHPVMS_API_URL', 'https://api.phpvms.net'),
+
+    /*
      * The site's own language, for anything addressed to everyone rather than
      * to a visitor — Discord channel announcements, for instance.
      *
@@ -78,16 +83,6 @@ return [
      * URL for fetching SimBrief OFP
      */
     'simbrief_ofp_url' => 'https://www.simbrief.com/api/xml.fetcher.php',
-
-    /*
-     * Your vaCentral API key
-     */
-    'vacentral_api_key' => env('VACENTRAL_API_KEY', ''),
-
-    /*
-     * vaCentral API URL. You likely don't need to change this
-     */
-    'vacentral_api_url' => 'https://api.vacentral.net',
 
     /*
      * Misc Settings

--- a/resources/lang/en/airports.php
+++ b/resources/lang/en/airports.php
@@ -22,6 +22,7 @@ return [
     'hub'                         => 'Hub',
     'only_hubs'                   => 'Only Hubs',
 
+    'bulk_add'          => 'Bulk Add',
     'lookup'            => 'Lookup',
     'lookup_successful' => 'Lookup Successful',
     'lookup_failed'     => 'Lookup Failed',

--- a/resources/views/filament/airports/bulk-add-modal.blade.php
+++ b/resources/views/filament/airports/bulk-add-modal.blade.php
@@ -1,0 +1,109 @@
+{{-- Bulk-add airports modal body. State + actions live on the ListAirports page
+     (a Livewire component), so every wire:* here targets that component. The
+     Alpine loop drives lookups one row at a time with a delay, keeping the API
+     calls sequential and rate-limited. --}}
+<div
+    x-data="{
+        rateMs: 300,
+        running: false,
+        async run() {
+            if (this.running) return;
+            this.running = true;
+            try {
+                while (true) {
+                    const remaining = await $wire.processNextBulkAirport();
+                    if (! remaining) break;
+                    await new Promise((resolve) => setTimeout(resolve, this.rateMs));
+                }
+            } finally {
+                this.running = false;
+            }
+        },
+    }"
+    x-on:bulk-add-start.window="run()"
+    class="flex flex-col gap-4"
+>
+    <div class="flex items-start gap-2">
+        <div class="flex-1">
+            <x-filament::input.wrapper>
+                <x-filament::input
+                    type="text"
+                    wire:model="bulkIcaoInput"
+                    x-on:keydown.enter.prevent="$wire.addBulkAirports()"
+                    placeholder="KJFK, EGLL, LFPG…"
+                />
+            </x-filament::input.wrapper>
+        </div>
+
+        <x-filament::button
+            icon="heroicon-o-plus"
+            wire:click="addBulkAirports"
+            wire:loading.attr="disabled"
+            wire:target="addBulkAirports"
+        >
+            {{ __('common.add') }}
+        </x-filament::button>
+    </div>
+
+    @if (filled($this->bulkRows))
+        <div class="overflow-x-auto rounded-xl ring-1 ring-gray-950/5 dark:ring-white/10">
+            <table class="w-full text-start text-sm">
+                <thead>
+                    <tr class="bg-gray-50 dark:bg-white/5">
+                        <th class="px-3 py-2 text-start font-medium text-gray-700 dark:text-gray-200">ICAO</th>
+                        <th class="px-3 py-2 text-start font-medium text-gray-700 dark:text-gray-200">{{ __('common.name') }}</th>
+                        <th class="px-3 py-2 text-center font-medium text-gray-700 dark:text-gray-200">{{ __('airports.hub') }}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-white/10">
+                    @foreach ($this->bulkRows as $i => $row)
+                        <tr wire:key="bulk-airport-{{ $row['icao'] }}">
+                            <td class="px-3 py-2 font-medium text-gray-950 dark:text-white">
+                                <span class="inline-flex items-center gap-1.5">
+                                    {{ $row['icao'] }}
+
+                                    @switch($row['status'])
+                                        @case('pending')
+                                            <x-filament::loading-indicator class="h-4 w-4 text-gray-400" />
+                                            @break
+                                        @case('updated')
+                                            <span title="{{ __('common.updated') }}">
+                                                <x-filament::icon icon="heroicon-m-arrow-path" class="h-4 w-4 text-warning-500" />
+                                            </span>
+                                            @break
+                                        @case('error')
+                                            <span title="{{ __('airports.no_airport_found', ['icao' => $row['icao']]) }}">
+                                                <x-filament::icon icon="heroicon-m-exclamation-circle" class="h-4 w-4 text-danger-500" />
+                                            </span>
+                                            @break
+                                        @default
+                                            <span title="{{ __('common.added') }}">
+                                                <x-filament::icon icon="heroicon-m-check-circle" class="h-4 w-4 text-success-500" />
+                                            </span>
+                                    @endswitch
+                                </span>
+                            </td>
+                            <td class="px-3 py-2 text-gray-700 dark:text-gray-300">
+                                @if ($row['status'] === 'error')
+                                    <span class="text-danger-500">{{ __('airports.lookup_failed') }}</span>
+                                @elseif ($row['status'] === 'pending')
+                                    <span class="text-gray-400">…</span>
+                                @else
+                                    {{ $row['name'] }}
+                                @endif
+                            </td>
+                            <td class="px-3 py-2 text-center">
+                                @unless (in_array($row['status'], ['error', 'pending'], true))
+                                    <x-filament::input.checkbox
+                                        wire:click="toggleBulkHub({{ $i }})"
+                                        @checked($row['hub'])
+                                    />
+                                @endunless
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+</div>

--- a/tests/Feature/Filament/AirportBulkAddTest.php
+++ b/tests/Feature/Filament/AirportBulkAddTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Airports\Pages\ListAirports;
+use App\Models\Airport;
+use Database\Seeders\RolesPermissionsSeeder;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+// Use codes that are absent from the sample-data airports so the tests stay
+// hermetic regardless of what is already seeded in the shared testing DB.
+beforeEach(function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+    $this->actingAs(createAdminUser());
+
+    Http::fake([
+        'api.phpvms.net/v1/airports/ZZZA' => Http::response([
+            'icao'      => 'ZZZA', 'iata' => 'ZZA', 'name' => 'Alpha Field',
+            'city'      => 'Alphaville', 'country' => 'US', 'region' => 'NY', 'tz' => 'America/New_York',
+            'elevation' => 13, 'lat' => 40.6413, 'lon' => -73.7781,
+        ]),
+        'api.phpvms.net/v1/airports/ZZZB' => Http::response([
+            'icao'      => 'ZZZB', 'iata' => 'ZZB', 'name' => 'Bravo Field',
+            'city'      => 'Bravotown', 'country' => 'GB', 'region' => 'ENG', 'tz' => 'Europe/London',
+            'elevation' => 83, 'lat' => 51.4706, 'lon' => -0.4619,
+        ]),
+        // Unknown code -> non-successful response -> empty lookup -> error row.
+        'api.phpvms.net/v1/airports/ZZZX' => Http::response(null, 404),
+    ]);
+});
+
+it('queues pasted codes as pending rows, then creates airports one at a time', function (): void {
+    $component = Livewire::test(ListAirports::class)
+        ->set('bulkIcaoInput', 'zzza, zzzb')
+        ->call('addBulkAirports');
+
+    // Both queued as pending, input cleared, nothing persisted yet.
+    expect(collect($component->get('bulkRows'))->pluck('status')->all())->toBe(['pending', 'pending']);
+    $component->assertSet('bulkIcaoInput', '');
+    expect(Airport::firstWhere('icao', 'ZZZA'))->toBeNull()
+        ->and(Airport::firstWhere('icao', 'ZZZB'))->toBeNull();
+
+    // Drive the lookups the way the browser loop does.
+    $component->call('processNextBulkAirport')->assertReturned(1);
+    $component->call('processNextBulkAirport')->assertReturned(0);
+
+    expect(Airport::firstWhere('icao', 'ZZZA')?->name)->toBe('Alpha Field')
+        ->and(Airport::firstWhere('icao', 'ZZZB')?->name)->toBe('Bravo Field');
+
+    expect(collect($component->get('bulkRows'))->pluck('status')->all())->toBe(['added', 'added']);
+})->group('filament');
+
+it('flags an existing airport as updated and overwrites its lookup fields', function (): void {
+    Airport::factory()->create(['icao' => 'ZZZA', 'name' => 'Stale Name', 'hub' => false]);
+
+    $component = Livewire::test(ListAirports::class)
+        ->set('bulkIcaoInput', 'ZZZA')
+        ->call('addBulkAirports')
+        ->call('processNextBulkAirport');
+
+    expect($component->get('bulkRows')[0]['status'])->toBe('updated')
+        ->and(Airport::firstWhere('icao', 'ZZZA')->name)->toBe('Alpha Field');
+})->group('filament');
+
+it('marks a failed lookup as an error and saves nothing', function (): void {
+    $component = Livewire::test(ListAirports::class)
+        ->set('bulkIcaoInput', 'ZZZX')
+        ->call('addBulkAirports')
+        ->call('processNextBulkAirport')
+        ->assertReturned(0);
+
+    expect($component->get('bulkRows')[0]['status'])->toBe('error')
+        ->and(Airport::firstWhere('icao', 'ZZZX'))->toBeNull();
+})->group('filament');
+
+it('persists the hub flag when a row is toggled', function (): void {
+    $component = Livewire::test(ListAirports::class)
+        ->set('bulkIcaoInput', 'ZZZA')
+        ->call('addBulkAirports')
+        ->call('processNextBulkAirport');
+
+    expect(Airport::firstWhere('icao', 'ZZZA')->hub)->toBeFalse();
+
+    $component->call('toggleBulkHub', 0);
+
+    expect(Airport::firstWhere('icao', 'ZZZA')->fresh()->hub)->toBeTrue()
+        ->and($component->get('bulkRows')[0]['hub'])->toBeTrue();
+})->group('filament');
+
+it('opens the bulk-add modal and resets any prior rows', function (): void {
+    Livewire::test(ListAirports::class)
+        ->set('bulkRows', [['icao' => 'ZZZA', 'name' => 'x', 'hub' => false, 'status' => 'added']])
+        ->mountAction('bulkAdd')
+        ->assertActionMounted('bulkAdd')
+        ->assertSet('bulkRows', []);
+})->group('filament');


### PR DESCRIPTION
## Summary

Adds a **Bulk Add** action to the admin airports list, alongside a couple of related airport-lookup improvements.

- **Bulk Add modal** (header action on the airports list). Paste one ICAO or a comma/space/newline-delimited list, hit Enter or **Add**. Each code:
  - is looked up against the phpVMS API and persisted **immediately**;
  - **new** codes are created (green check), **existing** codes are overwritten and flagged **updated** (amber icon + tooltip), **failed** lookups become error rows and are never saved;
  - gets a **hub** checkbox (defaults false) that writes straight back to the record when toggled.
- Lookups run **sequentially and rate-limited**: a small JS loop calls one lookup per Livewire request with a 300ms gap, so rows fill in live (spinner → result) without one long blocking request.
- **Enter-to-lookup**: the ICAO field on the add/edit airport form now triggers the existing lookup action on Enter (scoped to the field, not a global keybinding).
- **Config extraction**: the hosted API base URL is now `config('phpvms.api_url')` (`PHPVMS_API_URL`, default `https://api.phpvms.net`) instead of a hardcoded string.

Lookups and hub toggles key on the `icao` column (not the `id` primary key), so they survive a future change to the `id` column.

## Test plan

`tests/Feature/Filament/AirportBulkAddTest.php` (5 tests, all passing):

1. Pasted codes queue as pending rows, then create airports one at a time.
2. An existing airport is flagged `updated` and its lookup fields overwritten.
3. A failed lookup becomes an `error` row and saves nothing.
4. Toggling the hub checkbox persists to the DB.
5. Opening the modal resets any prior rows.

Manual: open Airports → **Bulk Add**, paste `KJFK, EGLL, ZZZZ`, confirm rows fill in live, the bad code errors, and the hub toggle sticks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk-add workflow for entering and processing multiple airport ICAO codes.
  * Displays lookup progress, results, errors, and hub-selection controls for each airport.
  * Pressing Enter in the ICAO field now triggers lookup.
* **Improvements**
  * Airport API requests can now use a configurable API URL.
  * Added support for identifying the ICAO lookup action for improved interaction handling.
* **Bug Fixes**
  * Existing airport records are updated appropriately during bulk additions.
  * Failed lookups no longer create incomplete airport records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->