### PR TITLE
fix(addons): resolve this app's Composer ClassLoader, not the first one

### DIFF
--- a/app/Addons/AddonAutoLoader.php
+++ b/app/Addons/AddonAutoLoader.php
@@ -112,14 +112,34 @@ class AddonAutoLoader
     }
 
     /**
-     * Return the Composer ClassLoader instance from the global autoload stack.
+     * Return this application's Composer ClassLoader.
      *
-     * Composer registers its loader as [$classLoaderInstance, 'loadClass'].
+     * Composer's ClassLoader is not a singleton, and phar-distributed tools
+     * (PHPStan, PHPUnit) register their own — usually *prepended*, so it sits
+     * ahead of ours in the autoload stack. Picking the first loader off that
+     * stack therefore returns the tool's loader rather than ours, which is
+     * doubly wrong: its classmap is authoritative (tripping the mode guard
+     * with a message about an autoloader that was never the problem), and any
+     * addPsr4() call lands on a loader that is discarded when the tool exits,
+     * so addons silently fail to load.
      *
-     * @throws RuntimeException when no ClassLoader is found in the autoload stack
+     * getRegisteredLoaders() is keyed by vendor directory and only ever
+     * contains loaders booted from a real vendor/autoload.php, so looking ours
+     * up by path identifies it unambiguously. The stack scan stays as a
+     * fallback for the case where our loader was registered without going
+     * through Composer's initializer (as some test harnesses do).
+     *
+     * @throws RuntimeException when no ClassLoader is found
      */
     public function classLoader(): ClassLoader
     {
+        $loaders = ClassLoader::getRegisteredLoaders();
+        $ours = $loaders[base_path('vendor')] ?? null;
+
+        if ($ours instanceof ClassLoader) {
+            return $ours;
+        }
+
         foreach (spl_autoload_functions() as $entry) {
             if (is_array($entry) && $entry[0] instanceof ClassLoader) {
                 return $entry[0];

--- a/tests/Unit/Addons/AddonLoaderTest.php
+++ b/tests/Unit/Addons/AddonLoaderTest.php
@@ -261,3 +261,48 @@ class AddonLoaderTestProviderBeta extends ServiceProvider
     #[Override]
     public function register(): void {}
 }
+
+// ---------------------------------------------------------------------------
+// Loader resolution vs. foreign autoloaders
+// ---------------------------------------------------------------------------
+
+/**
+ * Phar-distributed tools (PHPStan, PHPUnit) register their own Composer
+ * ClassLoader and prepend it, so it sits ahead of ours in the autoload stack.
+ * classLoader() must still return *our* loader: the foreign one is
+ * classmap-authoritative (which would trip the mode guard) and is thrown away
+ * when the tool exits (so addPsr4 on it would silently lose the addon).
+ */
+it('classLoader() returns our loader, not a foreign one prepended to the stack', function (): void {
+    $ours = ClassLoader::getRegisteredLoaders()[base_path('vendor')] ?? null;
+    expect($ours)->toBeInstanceOf(ClassLoader::class);
+
+    $foreign = new ClassLoader();
+    $foreign->setClassMapAuthoritative(true);
+    $foreign->register(true); // prepend, as a phar bootstrap does
+
+    try {
+        $resolved = loaderWithRows([])->classLoader();
+
+        expect($resolved)->toBe($ours)
+            ->and($resolved->isClassMapAuthoritative())->toBeFalse();
+    } finally {
+        $foreign->unregister();
+    }
+});
+
+it('does not report authoritative mode when only a foreign loader is authoritative', function (): void {
+    $foreign = new ClassLoader();
+    $foreign->setClassMapAuthoritative(true);
+    $foreign->register(true);
+
+    try {
+        // Would throw AutoloadModeException if the foreign loader were picked.
+        loaderWithRows([addonRow('Modules\\ForeignProbe', app_path('Addons'))])
+            ->register(app());
+    } finally {
+        $foreign->unregister();
+    }
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

`AddonAutoLoader::classLoader()` returned the **first** Composer `ClassLoader` in the global autoload stack. Composer's `ClassLoader` isn't a singleton — phar-distributed tools (PHPStan, PHPUnit) register their own and *prepend* it, so the scan returned the tool's loader rather than this application's.

Two consequences:

1. **The autoload-mode guard false-positives.** Phar loaders are built optimized, so `isClassMapAuthoritative()` is true and the app aborts at bootstrap with a message telling you to re-run `composer dump-autoload` — about an autoloader that was never the problem. `composer.json` already sets `"classmap-authoritative": false`. Concretely: `vendor/bin/phpstan` could not bootstrap this app at all.
2. **Addon namespaces register on the wrong loader.** `registerClasses()` calls `addPsr4()` on the same loader. A foreign loader is discarded when the tool exits, so addons silently fail to load — precisely the failure the guard exists to prevent, reached by a different route.

The fix looks the loader up by vendor directory via `getRegisteredLoaders()`, which only ever contains loaders booted from a real `vendor/autoload.php`. That is the strategy `AutoloadGuard::resolveRegisteredLoader()` already used, but it was never reached because `AddonAutoLoader` always passes a loader explicitly. The stack scan remains as a fallback.

Developer-tooling impact only — a normal web request has just one loader registered.

## Test plan

Two regression tests in `tests/Unit/Addons/AddonLoaderTest.php` that prepend a foreign classmap-authoritative loader, mirroring a phar bootstrap.

Confirmed they actually catch the bug:

- **without the fix:** both fail — `2 failed, 9 passed`, the second with `AutoloadModeException`, the exact reported symptom
- **with the fix:** `11 passed (20 assertions)`
- the 9 pre-existing tests pass either way, so no behaviour change to normal resolution

End-to-end: `vendor/bin/phpstan analyse` now reports `[OK] No errors`. Before the fix it died during bootstrap and could not analyse anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Composer loader detection to select the application’s loader when other loaders are present.
  * Prevented addon loading from incorrectly failing when a foreign authoritative loader is prepended.
  * Added a clear error when no suitable Composer loader can be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->