### PR TITLE
fix(addons): resolve addon identity by registry_id, and run addon migrations on install

### DIFF
--- a/app/Addons/Services/AddonDiscoveryService.php
+++ b/app/Addons/Services/AddonDiscoveryService.php
@@ -72,7 +72,7 @@ class AddonDiscoveryService
             $rows[] = $this->buildBootCacheRow($m, true);
         }
 
-        $this->bootCache->write($rows);
+        $this->bootCache->write($rows, null, $this->diskFingerprint());
     }
 
     /**
@@ -107,7 +107,7 @@ class AddonDiscoveryService
         // cache was written leaves a schema-valid but data-stale cache that would
         // never rebuild — so its namespace is never registered and its seeder
         // fails class-not-found. The fingerprint check closes that gap.
-        if ($this->bootCache->isFresh() && $this->cacheMatchesDatabase()) {
+        if ($this->bootCache->isFresh() && $this->cacheMatchesDatabase() && $this->cacheMatchesDisk()) {
             return false;
         }
 
@@ -152,6 +152,57 @@ class AddonDiscoveryService
         } catch (Throwable) {
             return null;
         }
+    }
+
+    /**
+     * Whether the boot cache was built from the current state of disk.
+     *
+     * Compares the disk fingerprint stamped into the cache against a freshly
+     * computed one. A null stored fingerprint means the cache predates this
+     * field, which the BootCache::SCHEMA bump already handles by forcing one
+     * rebuild.
+     */
+    private function cacheMatchesDisk(): bool
+    {
+        return $this->bootCache->diskFingerprint() === $this->diskFingerprint();
+    }
+
+    /**
+     * A fingerprint of the addon manifests on disk: for each immediate child
+     * directory of the addons base path, the mtime+size of module.json and
+     * composer.json (both feed a boot-cache entry — namespace and version
+     * derive from composer.json). Hashing the sorted set means an added or
+     * removed addon directory, or an edited manifest, changes the hash.
+     *
+     * databaseFingerprint() cannot see any of this: renaming an addon in its
+     * module.json leaves the addons table untouched, so without a disk
+     * dimension the cache serves the old manifest values forever.
+     */
+    private function diskFingerprint(): string
+    {
+        $base = config('addons.paths.base');
+
+        if (!is_dir($base)) {
+            return sha1('');
+        }
+
+        $parts = [];
+
+        foreach (File::directories($base) as $dir) {
+            foreach (['module.json', 'composer.json'] as $file) {
+                $path = $dir.'/'.$file;
+
+                if (!File::exists($path)) {
+                    continue;
+                }
+
+                $parts[] = $path.'|'.filemtime($path).'|'.filesize($path);
+            }
+        }
+
+        sort($parts);
+
+        return sha1(implode("\n", $parts));
     }
 
     /**
@@ -237,9 +288,9 @@ class AddonDiscoveryService
             }
         }
 
-        // Stamp the DB fingerprint so a later boot can tell this cache still
-        // matches the current addons state (see primeIfNeeded/cacheMatchesDatabase).
-        $this->bootCache->write($cacheRows, $this->databaseFingerprint());
+        // Stamp the DB and disk fingerprints so a later boot can tell this cache
+        // still matches the current addons state (see primeIfNeeded/cacheMatchesDatabase/cacheMatchesDisk).
+        $this->bootCache->write($cacheRows, $this->databaseFingerprint(), $this->diskFingerprint());
     }
 
     /**

--- a/app/Addons/Support/BootCache.php
+++ b/app/Addons/Support/BootCache.php
@@ -26,7 +26,7 @@ class BootCache
      * Cache schema version. Increment when the on-disk shape changes
      * so stale-schema files are treated as absent (D2-09).
      */
-    public const int SCHEMA = 3;
+    public const int SCHEMA = 4;
 
     /**
      * Return enabled addons from the boot cache (DB-free hot path, D-10).
@@ -104,6 +104,29 @@ class BootCache
     }
 
     /**
+     * The disk fingerprint this cache was built from, or null when absent
+     * (fresh-install disk bootstrap), the file is missing/stale-schema, or the
+     * cache predates this field — the SCHEMA bump to 4 forces one rebuild for
+     * that last case, so a null here is only ever transient.
+     *
+     * AddonDiscoveryService compares this against a freshly computed disk
+     * fingerprint to decide whether the cache still reflects the manifests on
+     * disk — editing a module.json used to leave this cache serving stale values forever.
+     */
+    public function diskFingerprint(): ?string
+    {
+        $data = $this->loadEnvelope();
+
+        if ($data === null || ($data['schema'] ?? null) !== self::SCHEMA) {
+            return null;
+        }
+
+        $diskFingerprint = $data['disk_fingerprint'] ?? null;
+
+        return is_string($diskFingerprint) ? $diskFingerprint : null;
+    }
+
+    /**
      * Read the boot cache and return hydrated AddonBootCache rows.
      *
      * Returns an empty array when:
@@ -152,18 +175,21 @@ class BootCache
      *
      * The optional $fingerprint records the state of the DB `addons` table this
      * cache was built from, so a later boot can detect that the DB enabled-set
-     * has diverged and rebuild (see AddonDiscoveryService). BootCache itself
-     * performs no DB reads — the caller computes and passes the value.
+     * has diverged and rebuild (see AddonDiscoveryService). The optional
+     * $diskFingerprint does the same for the manifests on disk.
+     * BootCache itself performs no DB or disk reads — the caller computes and
+     * passes both values.
      *
      * @param list<AddonBootCache> $addons
      */
-    public function write(array $addons, ?string $fingerprint = null): void
+    public function write(array $addons, ?string $fingerprint = null, ?string $diskFingerprint = null): void
     {
         $wrapper = [
-            'schema'       => self::SCHEMA,
-            'generated_at' => gmdate('c'),
-            'fingerprint'  => $fingerprint,
-            'addons'       => array_map(fn (AddonBootCache $e): array => $e->toArray(), $addons),
+            'schema'           => self::SCHEMA,
+            'generated_at'     => gmdate('c'),
+            'fingerprint'      => $fingerprint,
+            'disk_fingerprint' => $diskFingerprint,
+            'addons'           => array_map(fn (AddonBootCache $e): array => $e->toArray(), $addons),
         ];
 
         $content = '<?php'.PHP_EOL.'return '.var_export($wrapper, true).';'.PHP_EOL;

--- a/app/Filament/System/Installer.php
+++ b/app/Filament/System/Installer.php
@@ -496,7 +496,7 @@ class Installer extends Page
             ->schema([
                 StreamEntry::make('output')
                     ->state(fn (): string => $this->migrationOutput)
-                    ->label(__('installer.output'))
+                    ->hiddenLabel()
                     ->viewData([
                         'stream' => $this->stream,
                     ]),

--- a/app/Filament/System/Updater.php
+++ b/app/Filament/System/Updater.php
@@ -34,7 +34,7 @@ class Updater extends Page
         return $schema->components([
             StreamEntry::make('output')
                 ->state(fn (): string => $this->updateOutput)
-                ->label(__('installer.output'))
+                ->hiddenLabel()
                 ->extraAttributes($this->updateStarted ? [] : ['wire:init' => 'runUpdate'])
                 ->viewData([
                     'stream' => $this->stream,

--- a/app/Services/AddonSettingService.php
+++ b/app/Services/AddonSettingService.php
@@ -171,15 +171,21 @@ class AddonSettingService extends Service
             return null;
         }
 
-        $query = Addon::query();
-
+        // Same fallback as AddonSettingSyncService::resolveAddonId(): a manifest
+        // can declare a registry_id that the addon's row does not carry yet —
+        // create_addons_table seeds the column null and only the
+        // backfill_addon_registry_ids data migration fills it. Without falling
+        // through to the unique namespace, every addon_setting() read for that
+        // addon silently returns its default.
         if ($entry->registryId !== null) {
-            $query->where('registry_id', $entry->registryId);
-        } else {
-            $query->where('namespace', $entry->namespace);
+            $resolved = Addon::query()->where('registry_id', $entry->registryId)->value('id');
+
+            if ($resolved !== null) {
+                return (int) $resolved;
+            }
         }
 
-        $resolved = $query->value('id');
+        $resolved = Addon::query()->where('namespace', $entry->namespace)->value('id');
 
         return $resolved === null ? null : (int) $resolved;
     }

--- a/app/Services/AddonSettingSyncService.php
+++ b/app/Services/AddonSettingSyncService.php
@@ -136,20 +136,27 @@ class AddonSettingSyncService extends Service
     }
 
     /**
-     * Resolve the addon row id for a boot-cache entry (registry_id when managed,
-     * namespace when bundled).
+     * Resolve the addon row id for a boot-cache entry (registry_id when
+     * declared, namespace when not).
+     *
+     * A declared registry_id that matches no row (e.g. an install predating the
+     * registry_id backfill) falls through to the namespace lookup instead of
+     * returning null, and logs a warning — a silent no-op would otherwise leave
+     * every declared setting missing with no signal at all.
      */
     private function resolveAddonId(AddonBootCache $entry): ?int
     {
-        $query = Addon::query();
-
         if ($entry->registryId !== null) {
-            $query->where('registry_id', $entry->registryId);
-        } else {
-            $query->where('namespace', $entry->namespace);
+            $id = Addon::query()->where('registry_id', $entry->registryId)->value('id');
+
+            if ($id !== null) {
+                return (int) $id;
+            }
+
+            Log::warning('AddonSettingSync: no addon row for registry_id '.$entry->registryId.'; falling back to namespace');
         }
 
-        $id = $query->value('id');
+        $id = Addon::query()->where('namespace', $entry->namespace)->value('id');
 
         return $id === null ? null : (int) $id;
     }

--- a/app/Services/Installer/MigrationService.php
+++ b/app/Services/Installer/MigrationService.php
@@ -12,6 +12,7 @@ use Exception;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
@@ -47,25 +48,79 @@ class MigrationService extends Service
             'core' => App::databasePath().'/'.$dir,
         ];
 
-        // During a fresh install this runs *before* the core migrations that
-        // create the addons table, so querying enabled addons would 42P01.
-        // No addons can be enabled pre-install anyway — skip to core-only paths.
-        $modules = Schema::hasTable('addons') ? $this->addonRegistry->enabled() : collect();
-        foreach ($modules as $module) {
-            if (!is_dir($module->getPath())) {
+        // Pre-install, the `addons` table doesn't exist yet, so the enabled
+        // registry can't be queried. But create_addons_table (the core
+        // migration that creates it) scans disk and inserts every module it
+        // finds as enabled — so the set of addons that *will* be enabled is
+        // exactly what's on disk right now. Scan disk directly rather than
+        // waiting for a table that a single migration pass will create.
+        $modules = Schema::hasTable('addons')
+            ? $this->addonRegistry->enabled()->mapWithKeys(fn ($module): array => [$module->getName() => $module->getPath()])
+            : $this->scanAddonPathsOnDisk();
+
+        foreach ($modules as $name => $path) {
+            if (!is_dir($path)) {
                 Log::warning(sprintf(
                     'Addon "%s" is enabled but its path does not exist on disk: %s',
-                    $module->getName(),
-                    $module->getPath(),
+                    $name,
+                    $path,
                 ));
 
                 continue;
             }
 
-            $module_path = $module->getPath().'/database/'.$dir;
+            $module_path = $path.'/database/'.$dir;
             if (file_exists($module_path)) {
-                $paths[$module->getName()] = $module_path;
+                $paths[$name] = $module_path;
             }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Scan disk for addon directories, mirroring
+     * AddonDiscoveryService::scanLocation()'s conventions: immediate child
+     * directories of the addon base that contain a module.json. Used only
+     * pre-install, before the `addons` table exists to be the source of
+     * truth (see getMigrationPaths()).
+     *
+     * Direct-child symlinks are permitted (e.g. modules/phpvms-acars
+     * symlinked to an external checkout); anything that isn't a direct
+     * child of the base, or has no module.json, is skipped.
+     *
+     * @return array<string, string> addon directory basename => absolute path
+     */
+    private function scanAddonPathsOnDisk(): array
+    {
+        $base = config('addons.paths.base');
+
+        if (!is_dir($base)) {
+            return [];
+        }
+
+        $realBase = realpath($base);
+
+        if ($realBase === false) {
+            return [];
+        }
+
+        $paths = [];
+
+        foreach (File::directories($base) as $subDir) {
+            $resolved = realpath($subDir);
+            if ($resolved === false) {
+                continue;
+            }
+            if (realpath(dirname((string) $subDir)) !== $realBase) {
+                continue;
+            }
+
+            if (!file_exists($resolved.'/module.json')) {
+                continue;
+            }
+
+            $paths[basename($subDir)] = $resolved;
         }
 
         return $paths;

--- a/app/Services/Installer/SeederService.php
+++ b/app/Services/Installer/SeederService.php
@@ -125,9 +125,19 @@ class SeederService extends Service
                     $this->runSeederFile($file);
                 }
             } catch (Throwable $throwable) {
-                Log::error(sprintf('Addon "%s" seeder failed; continuing', $addon->getName()), [
-                    'exception' => $throwable,
-                ]);
+                // Fold the exception's own message into the log message (not just
+                // the context) so it is visible wherever the message alone is
+                // rendered — e.g. Laravel Pail's header box shows the message and
+                // exception class, but not the context array. Collapsed to one
+                // line: QueryException messages embed the raw SQL and often carry
+                // newlines from the underlying PDO driver message, and Pail's
+                // bordered box wraps multi-line text badly. The context still
+                // carries the full $throwable for the file log's stack trace.
+                Log::error(sprintf(
+                    'Addon "%s" seeder failed; continuing: %s',
+                    $addon->getName(),
+                    preg_replace('/\s+/', ' ', trim($throwable->getMessage())),
+                ), ['exception' => $throwable]);
 
                 continue;
             }
@@ -142,11 +152,20 @@ class SeederService extends Service
     /**
      * Remove every seed marker for an addon (all versions), so a later reinstall
      * re-runs its seeders. Called when uninstalling an addon with table removal.
+     *
+     * Keyed on registry_id (falling back to namespace), not the display name: the
+     * name is nullable, non-unique and mutable, so an addon rebrand would leave
+     * this unable to find its own markers.
+     *
+     * Safe to interpolate into a LIKE pattern: seedMarkerIdentity() runs the
+     * identity through keyed_str(), which leaves only letters, digits and the
+     * `-` delimiter — no backslash (whose LIKE-escape meaning differs across
+     * MySQL, Postgres and sqlite) and no `%` or `_` wildcards.
      */
     public function clearAddonSeedMarkers(Addon $addon): void
     {
         Kvp::query()
-            ->where('key', 'like', 'addon_seeded:'.$addon->getName().':%')
+            ->where('key', 'like', 'addon_seeded:'.$this->seedMarkerIdentity($addon).':%')
             ->delete();
     }
 
@@ -243,9 +262,38 @@ class SeederService extends Service
     /**
      * KVP marker key for an addon's seed state, versioned so an addon update
      * re-runs its seeders.
+     *
+     * Keyed on registry_id, falling back to namespace, not the display name: the
+     * name is nullable, non-unique and mutable, so an addon rebrand would move
+     * it, stranding the marker and leaving addonSeedsPending() permanently true.
+     * A bare registry_id would collide bundled addons that declare none (Awards,
+     * Sample both resolve to null) on addon_seeded::base, so namespace — unique
+     * and always present — is the fallback.
      */
     private function seedMarkerKey(Addon $addon): string
     {
-        return 'addon_seeded:'.$addon->getName().':'.($addon->version ?? 'base');
+        return 'addon_seeded:'.$this->seedMarkerIdentity($addon).':'.($addon->version ?? 'base');
+    }
+
+    /**
+     * The stable identity segment of an addon's seed marker.
+     *
+     * Uses filled() rather than ?? so an empty-string registry_id — which the
+     * backfill tolerates and Addon::isLegacy() already treats as absent — falls
+     * back to namespace instead of collapsing every such addon onto
+     * `addon_seeded::{version}`.
+     *
+     * keyed_str() then slugifies it the same way AddonRegistry::safeName() and
+     * PermissionRegistry::moduleKey() key off an addon, so `phpvms/acars` and
+     * `Modules\Sample` become `phpvms-acars` and `modules-sample`. Keeping the
+     * separator as `-` (rather than dropping it, as Str::slug would) preserves
+     * the segment boundary, so `Modules\Sample` cannot collide with a different
+     * addon named `ModulesSample`.
+     */
+    private function seedMarkerIdentity(Addon $addon): string
+    {
+        $identity = filled($addon->registry_id) ? (string) $addon->registry_id : (string) $addon->namespace;
+
+        return keyed_str(strtolower($identity));
     }
 }

--- a/database/migrations_data/2026_07_25_000000_backfill_addon_registry_ids.php
+++ b/database/migrations_data/2026_07_25_000000_backfill_addon_registry_ids.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Data migration: populate the addons.registry_id column from each addon's
+     * module.json.
+     *
+     * create_addons_table has already shipped and deliberately stays untouched —
+     * it seeds every row with registry_id = null, so this migration is the only
+     * thing that ever populates the column. Fresh installs are covered too: the
+     * installer runs `migrate` and then `migrate-data` in one pass, so a new
+     * database gets the value right after the table is seeded.
+     *
+     * Without it, AddonSettingSyncService::resolveAddonId() looks an addon up by
+     * the registry_id its manifest declares, misses the null column, and silently
+     * syncs none of that addon's declared settings.
+     *
+     * Derives the value from each addon's module.json `registry_id`. Idempotent:
+     * only rows whose registry_id is null or blank are touched, so operator-set
+     * values are preserved. Rows whose manifest is missing, invalid, or declares
+     * no registry_id are left null — they continue to resolve by namespace.
+     *
+     * Guarded on the registry_id column existing so it is a safe no-op on a
+     * schema that has not yet gained the column.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('addons') || !Schema::hasColumn('addons', 'registry_id')) {
+            return;
+        }
+
+        DB::table('addons')
+            ->where(function ($query): void {
+                $query->whereNull('registry_id')->orWhere('registry_id', '');
+            })
+            ->get(['id', 'path'])
+            ->each(function (object $addon): void {
+                $registryId = $this->resolveRegistryId((string) $addon->path);
+
+                if ($registryId === null) {
+                    return;
+                }
+
+                DB::table('addons')
+                    ->where('id', $addon->id)
+                    ->update(['registry_id' => $registryId]);
+            });
+    }
+
+    /**
+     * Resolve the declared registry_id from module.json, or null when the
+     * file is missing, invalid, or declares nothing.
+     */
+    private function resolveRegistryId(string $path): ?string
+    {
+        $manifestPath = $path.'/module.json';
+
+        if (!File::exists($manifestPath)) {
+            return null;
+        }
+
+        $data = json_decode(File::get($manifestPath), true);
+
+        if (!is_array($data) || !isset($data['registry_id'])) {
+            return null;
+        }
+
+        // A non-scalar registry_id (a third-party manifest declaring an array or
+        // object) would raise "Array to string conversion" on the cast below and
+        // abort migrate-data, blocking the whole install. Skip it instead.
+        if (!is_scalar($data['registry_id'])) {
+            return null;
+        }
+
+        // D-03: blank/whitespace-only registry_id normalises to null, matching
+        // ManifestParser — otherwise the row and the boot cache disagree.
+        $trimmed = trim((string) $data['registry_id']);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+};

--- a/database/migrations_data/2026_07_25_000001_rekey_addon_seed_markers.php
+++ b/database/migrations_data/2026_07_25_000001_rekey_addon_seed_markers.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Data migration: rekey `addon_seeded:%` kvp markers from the display name to
+     * `registry_id ?? namespace`. SeederService::seedMarkerKey() used to build
+     * the marker from the addon's display name, which is nullable, non-unique
+     * and mutable — an addon rebrand moves the name, stranding the old marker and
+     * leaving addonSeedsPending() permanently true for that addon.
+     *
+     * The key segment after `addon_seeded:` is split on the *last* colon so a
+     * name containing one is not mis-parsed; the left part is the old name, the
+     * right part is the version. The name is resolved against `addons.name` and
+     * the key rewritten to the new identity. A name that matches no addon has its
+     * marker deleted instead, so that addon's seeders simply re-run once on the
+     * next update — addon seeders are expected to be idempotent.
+     *
+     * Idempotent: a key already in the new form carries an identity segment
+     * (registry_id or namespace), not a display name, so it is skipped rather
+     * than treated as unresolvable and deleted.
+     *
+     * Guarded on both tables existing so it is a safe no-op on a schema that
+     * predates them.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('kvp') || !Schema::hasTable('addons')) {
+            return;
+        }
+
+        $addons = DB::table('addons')->get(['name', 'namespace', 'registry_id']);
+
+        // Both identities go in the skip set, not just the one seedMarkerKey()
+        // would pick today: a marker written on an addon's namespace before its
+        // registry_id was populated is still new-format and must not be treated
+        // as an unresolvable display name and deleted. Slugified the same way
+        // SeederService::seedMarkerIdentity() does, since that is the form the
+        // keys actually carry.
+        $identities = $addons
+            ->flatMap(fn (object $addon): array => array_map(
+                fn (string $value): string => keyed_str(strtolower($value)),
+                array_filter([$addon->registry_id, $addon->namespace]),
+            ))
+            ->flip();
+
+        $byName = $addons->keyBy('name');
+
+        DB::table('kvp')
+            ->where('key', 'like', 'addon_seeded:%')
+            ->get(['key'])
+            ->each(function (object $kvp) use ($identities, $byName): void {
+                $identitySegment = substr($kvp->key, strlen('addon_seeded:'));
+                $lastColon = strrpos($identitySegment, ':');
+
+                if ($lastColon === false) {
+                    return;
+                }
+
+                $identity = substr($identitySegment, 0, $lastColon);
+                $version = substr($identitySegment, $lastColon + 1);
+
+                // Already keyed on registry_id/namespace — nothing to do.
+                if ($identities->has($identity)) {
+                    return;
+                }
+
+                $addon = $byName->get($identity);
+
+                if ($addon === null) {
+                    DB::table('kvp')->where('key', $kvp->key)->delete();
+
+                    return;
+                }
+
+                // filled(), not ??, so an empty-string registry_id falls back to
+                // namespace rather than producing `addon_seeded::{version}`, then
+                // keyed_str() to match SeederService::seedMarkerIdentity() exactly.
+                $identityValue = filled($addon->registry_id) ? $addon->registry_id : $addon->namespace;
+
+                $newKey = 'addon_seeded:'.keyed_str(strtolower((string) $identityValue)).':'.$version;
+
+                DB::table('kvp')->where('key', $kvp->key)->update(['key' => $newKey]);
+            });
+    }
+};

--- a/resources/lang/de/installer.php
+++ b/resources/lang/de/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed.',
     'install_completed'                 => 'phpvms Installation completed successfully.',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/lang/en/installer.php
+++ b/resources/lang/en/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed',
     'install_completed'                 => 'phpvms Installation completed successfully',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/lang/es-es/installer.php
+++ b/resources/lang/es-es/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed.',
     'install_completed'                 => 'phpvms Installation completed successfully.',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/lang/fr/installer.php
+++ b/resources/lang/fr/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Étape suivante',
     'back'                              => 'Étape précédente',
     'finish'                            => 'Installation',
-    'output'                            => 'Sortie de la console',
     'already_installed'                 => 'phpvms est déjà installé.',
     'install_completed'                 => 'Installation de phpvms terminée avec succès.',
     'complete_setup'                    => 'Terminer la configuration',

--- a/resources/lang/it/installer.php
+++ b/resources/lang/it/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed.',
     'install_completed'                 => 'phpvms Installation completed successfully.',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/lang/jp/installer.php
+++ b/resources/lang/jp/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed.',
     'install_completed'                 => 'phpvms Installation completed successfully.',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/lang/pt-br/installer.php
+++ b/resources/lang/pt-br/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed.',
     'install_completed'                 => 'phpvms Installation completed successfully.',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/lang/tr/installer.php
+++ b/resources/lang/tr/installer.php
@@ -12,7 +12,6 @@ return [
     'next'                              => 'Next Step',
     'back'                              => 'Previous',
     'finish'                            => 'Install',
-    'output'                            => 'Console Output',
     'already_installed'                 => 'phpvms is already installed.',
     'install_completed'                 => 'phpvms Installation completed successfully.',
     'complete_setup'                    => 'Complete Setup',

--- a/resources/views/filament/infolists/components/stream-entry.blade.php
+++ b/resources/views/filament/infolists/components/stream-entry.blade.php
@@ -3,7 +3,7 @@
     :entry="$entry"
 >
   <div class="fi-in-code">
-    <pre class="phiki language-log github-light phiki-themes github-dark-high-contrast" data-language="log"
+    <pre class="phiki language-log github-light phiki-themes github-dark-high-contrast max-h-96 overflow-y-auto" data-language="log"
          style="background-color: #fff;color: #24292e;--phiki-dark-background-color: #0a0c10;--phiki-dark-color: #f0f3f6"><code @if($stream) wire:stream="{{ $stream }}" @endif {{ $getExtraAttributeBag() }}>{{ $getState() }}</code></pre>
   </div>
 </x-dynamic-component>

--- a/tests/Feature/Addons/AddonRegistryIdBackfillTest.php
+++ b/tests/Feature/Addons/AddonRegistryIdBackfillTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Addons\Models\AddonBootCache;
+use App\Addons\Support\BootCache;
+use App\Models\Addon;
+use App\Models\AddonSetting;
+use App\Services\AddonSettingSyncService;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Modules\Sample\Providers\SampleServiceProvider;
+
+/**
+ * Run the backfill_addon_registry_ids data migration in isolation.
+ */
+function runRegistryIdBackfill(): void
+{
+    (require base_path('database/migrations_data/2026_07_25_000000_backfill_addon_registry_ids.php'))->up();
+}
+
+/**
+ * Drop a module.json with the given registry_id (or no registry_id key when
+ * null) at a fresh temp directory and return its path.
+ */
+function makeManifestDir(?string $registryId): string
+{
+    $dir = sys_get_temp_dir().'/registry-id-backfill-'.uniqid('', true);
+    File::ensureDirectoryExists($dir);
+
+    $manifest = ['name' => 'Widget'];
+    if ($registryId !== null) {
+        $manifest['registry_id'] = $registryId;
+    }
+
+    File::put($dir.'/module.json', json_encode($manifest));
+
+    return $dir;
+}
+
+// ── Backfill migration (Testing #2) ─────────────────────────────────────────
+
+it('fills a null registry_id from a manifest that declares one', function (): void {
+    $dir = makeManifestDir('vendor/widget');
+    $addon = Addon::factory()->create(['registry_id' => null, 'path' => $dir]);
+
+    runRegistryIdBackfill();
+
+    expect($addon->fresh()->registry_id)->toBe('vendor/widget');
+});
+
+it('leaves an already-populated registry_id untouched', function (): void {
+    $dir = makeManifestDir('vendor/other');
+    $addon = Addon::factory()->create(['registry_id' => 'vendor/original', 'path' => $dir]);
+
+    runRegistryIdBackfill();
+
+    expect($addon->fresh()->registry_id)->toBe('vendor/original');
+});
+
+it('leaves the row null when the manifest declares no registry_id', function (): void {
+    $dir = makeManifestDir(null);
+    $addon = Addon::factory()->create(['registry_id' => null, 'path' => $dir]);
+
+    runRegistryIdBackfill();
+
+    expect($addon->fresh()->registry_id)->toBeNull();
+});
+
+it('leaves the row null when the manifest file is missing', function (): void {
+    $addon = Addon::factory()->create([
+        'registry_id' => null,
+        'path'        => sys_get_temp_dir().'/registry-id-backfill-missing-'.uniqid('', true),
+    ]);
+
+    runRegistryIdBackfill();
+
+    expect($addon->fresh()->registry_id)->toBeNull();
+});
+
+it('leaves the row null when the manifest file is invalid JSON', function (): void {
+    $dir = sys_get_temp_dir().'/registry-id-backfill-'.uniqid('', true);
+    File::ensureDirectoryExists($dir);
+    File::put($dir.'/module.json', '{not valid json');
+
+    $addon = Addon::factory()->create(['registry_id' => null, 'path' => $dir]);
+
+    runRegistryIdBackfill();
+
+    expect($addon->fresh()->registry_id)->toBeNull();
+});
+
+it('normalises a blank or whitespace-only declared registry_id to null', function (): void {
+    $dir = makeManifestDir('   ');
+    $addon = Addon::factory()->create(['registry_id' => null, 'path' => $dir]);
+
+    runRegistryIdBackfill();
+
+    expect($addon->fresh()->registry_id)->toBeNull();
+});
+
+// ── Sync fallback (Testing #3) ──────────────────────────────────────────────
+
+it('falls back to namespace and logs when a declared registry_id matches no row', function (): void {
+    $addon = Addon::factory()->create(['registry_id' => null, 'namespace' => 'Modules\\Widget']);
+
+    $entry = new AddonBootCache(
+        name: 'Widget',
+        alias: 'widget',
+        type: 'module',
+        registryId: 'vendor/widget',
+        version: null,
+        namespace: 'Modules\\Widget',
+        providers: [],
+        path: $addon->path,
+        autoloadPath: $addon->path,
+        layout: 'app',
+        description: null,
+        enabled: true,
+    );
+
+    $fakeCache = mock(BootCache::class);
+    $fakeCache->allows('enabled')->andReturns(collect([$entry]));
+    app()->instance(BootCache::class, $fakeCache);
+
+    Log::spy();
+
+    app(AddonSettingSyncService::class)->sync();
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->with('AddonSettingSync: no addon row for registry_id vendor/widget; falling back to namespace');
+});
+
+// ── Regression (Testing #6) ─────────────────────────────────────────────────
+
+it('syncs declared settings when the addon row has a null registry_id but the boot cache declares one', function (): void {
+    // The namespace here is a fixture value distinct from the real bundled
+    // Sample module's `Modules\Sample` row (namespace is unique) — only the
+    // real Sample provider class matters for resolving the declared schema,
+    // and the fallback lookup just needs the row and entry namespaces to match.
+    $namespace = 'Modules\\Sample'.uniqid('', true);
+    $addon = Addon::factory()->create(['registry_id' => null, 'namespace' => $namespace]);
+
+    $entry = new AddonBootCache(
+        name: 'Sample',
+        alias: 'sample',
+        type: 'module',
+        registryId: 'phpvms/sample',
+        version: null,
+        namespace: $namespace,
+        providers: [SampleServiceProvider::class],
+        path: $addon->path,
+        autoloadPath: $addon->path,
+        layout: 'app',
+        description: null,
+        enabled: true,
+    );
+
+    $fakeCache = mock(BootCache::class);
+    $fakeCache->allows('enabled')->andReturns(collect([$entry]));
+    app()->instance(BootCache::class, $fakeCache);
+
+    Log::spy();
+
+    app(AddonSettingSyncService::class)->sync();
+
+    $greeting = AddonSetting::where('addon_id', $addon->id)->where('key', 'greeting')->first();
+
+    expect($greeting)->not->toBeNull()
+        ->and($greeting->value)->toBe('Hello from the Sample module!');
+});

--- a/tests/Feature/Addons/AddonSeedMarkerTest.php
+++ b/tests/Feature/Addons/AddonSeedMarkerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Addon;
+use App\Models\Kvp;
+use App\Services\Installer\SeederService;
+use Illuminate\Support\Facades\File;
+
+function rekeyAddonSeedMarkersMigration(): object
+{
+    return require base_path('database/migrations_data/2026_07_25_000001_rekey_addon_seed_markers.php');
+}
+
+/**
+ * Create a fixture addon with a seeder directory, so seedAddons() has
+ * something to run and mark. Mirrors AddonSeederTest's fixture.
+ */
+function makeSeedableAddon(array $attributes): Addon
+{
+    $path = sys_get_temp_dir().'/phpvms-addon-seedmarker-'.uniqid('', true);
+    $seedDir = $path.'/database/seeders';
+    File::ensureDirectoryExists($seedDir);
+
+    File::put($seedDir.'/FixtureDatabaseSeeder.php', <<<'PHP'
+        <?php
+
+        namespace PhpvmsTests\Fixtures\AddonSeedMarker;
+
+        use Illuminate\Database\Seeder;
+
+        class FixtureDatabaseSeeder extends Seeder
+        {
+            public function run(): void
+            {
+            }
+        }
+        PHP);
+
+    return Addon::factory()->create([...$attributes, 'path' => $path, 'enabled' => true]);
+}
+
+beforeEach(function (): void {
+    // The addons migration seeds bundled module rows; clear them so each test
+    // starts with a known-empty state and only our fixture addons are present.
+    Addon::query()->delete();
+});
+
+afterEach(function (): void {
+    foreach (Addon::query()->pluck('path') as $path) {
+        if (is_string($path) && str_starts_with($path, sys_get_temp_dir())) {
+            File::deleteDirectory($path);
+        }
+    }
+});
+
+it('keys the seed marker on registry_id when present', function (): void {
+    makeSeedableAddon([
+        'registry_id' => 'phpvms/acars',
+        'namespace'   => 'Modules\\Acars',
+        'version'     => '1.1.0',
+    ]);
+
+    app(SeederService::class)->seedAddons();
+
+    expect(Kvp::where('key', 'addon_seeded:phpvms-acars:1.1.0')->exists())->toBeTrue();
+});
+
+it('falls back to namespace when registry_id is null', function (): void {
+    makeSeedableAddon([
+        'registry_id' => null,
+        'namespace'   => 'Modules\\Sample',
+        'version'     => '2.0.0',
+    ]);
+
+    app(SeederService::class)->seedAddons();
+
+    expect(Kvp::where('key', 'addon_seeded:modules-sample:2.0.0')->exists())->toBeTrue();
+});
+
+it('does not collide two null-registry_id addons on different namespaces', function (): void {
+    makeSeedableAddon([
+        'registry_id' => null,
+        'namespace'   => 'Modules\\Awards',
+        'version'     => null,
+    ]);
+
+    makeSeedableAddon([
+        'registry_id' => null,
+        'namespace'   => 'Modules\\Sample',
+        'version'     => null,
+    ]);
+
+    $seederSvc = app(SeederService::class);
+    $seederSvc->seedAddons();
+
+    expect(Kvp::where('key', 'addon_seeded:modules-awards:base')->exists())->toBeTrue()
+        ->and(Kvp::where('key', 'addon_seeded:modules-sample:base')->exists())->toBeTrue()
+        ->and($seederSvc->addonSeedsPending())->toBeFalse();
+});
+
+it('clears every version of an addon marker on uninstall', function (): void {
+    $addon = Addon::factory()->create([
+        'registry_id' => 'phpvms/acars',
+        'namespace'   => 'Modules\\Acars',
+        'version'     => '1.1.0',
+    ]);
+
+    Kvp::create(['key' => 'addon_seeded:phpvms-acars:1.0.0', 'value' => 'x']);
+    Kvp::create(['key' => 'addon_seeded:phpvms-acars:1.1.0', 'value' => 'x']);
+    Kvp::create(['key' => 'addon_seeded:phpvms-other:1.0.0', 'value' => 'x']);
+
+    app(SeederService::class)->clearAddonSeedMarkers($addon);
+
+    expect(Kvp::where('key', 'like', 'addon_seeded:phpvms-acars:%')->exists())->toBeFalse()
+        ->and(Kvp::where('key', 'addon_seeded:phpvms-other:1.0.0')->exists())->toBeTrue();
+});
+
+it('slugifies the identity so the key carries no LIKE metacharacters', function (): void {
+    // keyed_str() strips the backslash of a namespace and the slash of a
+    // registry_id, along with any % or _ wildcard. That keeps the key safe to
+    // interpolate into the uninstall LIKE pattern: a raw `Modules\Sample` would
+    // behave differently on MySQL and Postgres (backslash is their default LIKE
+    // escape character) than on sqlite (which has none).
+    $addon = Addon::factory()->create([
+        'registry_id' => null,
+        'namespace'   => 'Modules\\Sample',
+        'version'     => '1.0.0',
+    ]);
+
+    Kvp::create(['key' => 'addon_seeded:modules-sample:1.0.0', 'value' => 'x']);
+
+    // Distinct addon whose namespace has no separator — keyed_str keeps the `-`
+    // delimiter, so it must not collapse onto the same identity.
+    Kvp::create(['key' => 'addon_seeded:modulessample:1.0.0', 'value' => 'x']);
+
+    app(SeederService::class)->clearAddonSeedMarkers($addon);
+
+    expect(Kvp::where('key', 'addon_seeded:modules-sample:1.0.0')->exists())->toBeFalse()
+        ->and(Kvp::where('key', 'addon_seeded:modulessample:1.0.0')->exists())->toBeTrue();
+});
+
+it('rewrites a name-keyed marker to the new identity form', function (): void {
+    Addon::factory()->create([
+        'name'        => 'VMSAcars',
+        'registry_id' => 'phpvms/acars',
+        'namespace'   => 'Modules\\Acars',
+    ]);
+
+    Kvp::create(['key' => 'addon_seeded:VMSAcars:1.1.0', 'value' => '2026-01-01 00:00:00']);
+
+    rekeyAddonSeedMarkersMigration()->up();
+
+    expect(Kvp::where('key', 'addon_seeded:VMSAcars:1.1.0')->exists())->toBeFalse()
+        ->and(Kvp::where('key', 'addon_seeded:phpvms-acars:1.1.0')->exists())->toBeTrue();
+});
+
+it('deletes a marker whose name resolves to no addon', function (): void {
+    Kvp::create(['key' => 'addon_seeded:GhostAddon:1.0.0', 'value' => '2026-01-01 00:00:00']);
+
+    rekeyAddonSeedMarkersMigration()->up();
+
+    expect(Kvp::where('key', 'like', 'addon_seeded:GhostAddon:%')->exists())->toBeFalse();
+});
+
+it('is a no-op the second time it runs', function (): void {
+    Addon::factory()->create([
+        'name'        => 'VMSAcars',
+        'registry_id' => 'phpvms/acars',
+        'namespace'   => 'Modules\\Acars',
+    ]);
+
+    Kvp::create(['key' => 'addon_seeded:VMSAcars:1.1.0', 'value' => '2026-01-01 00:00:00']);
+
+    $migration = rekeyAddonSeedMarkersMigration();
+    $migration->up();
+    $migration->up();
+
+    expect(Kvp::where('key', 'addon_seeded:phpvms-acars:1.1.0')->count())->toBe(1)
+        ->and(Kvp::where('key', 'like', 'addon_seeded:VMSAcars:%')->exists())->toBeFalse();
+});

--- a/tests/Feature/Addons/AddonSeederAutoloadTest.php
+++ b/tests/Feature/Addons/AddonSeederAutoloadTest.php
@@ -76,5 +76,5 @@ it("registers an enabled addon's namespace so its seeder can load the addon's ow
     // PSR-4 namespace was registered first).
     expect(Kvp::where('key', 'seedfixture_ran')->value('value'))->toBe('widget-loaded')
         // ...and a per-addon seed marker was written, so it won't re-run forever.
-        ->and(Kvp::where('key', 'like', 'addon_seeded:SeedFixture:%')->exists())->toBeTrue();
+        ->and(Kvp::where('key', 'like', 'addon_seeded:modules-seedfixture:%')->exists())->toBeTrue();
 });

--- a/tests/Feature/Addons/AddonSeederTest.php
+++ b/tests/Feature/Addons/AddonSeederTest.php
@@ -7,7 +7,6 @@ use App\Models\Kvp;
 use App\Services\Installer\SeederService;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
-use Throwable;
 
 beforeEach(function (): void {
     // The addons migration seeds bundled module rows; clear them so each test

--- a/tests/Feature/Addons/AddonSeederTest.php
+++ b/tests/Feature/Addons/AddonSeederTest.php
@@ -6,6 +6,8 @@ use App\Models\Addon;
 use App\Models\Kvp;
 use App\Services\Installer\SeederService;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 beforeEach(function (): void {
     // The addons migration seeds bundled module rows; clear them so each test
@@ -47,10 +49,11 @@ afterEach(function (): void {
 function makeFixtureAddon(string $path): Addon
 {
     return Addon::factory()->create([
-        'name'    => 'FixtureAddon',
-        'version' => '1.0.0',
-        'path'    => $path,
-        'enabled' => true,
+        'name'      => 'FixtureAddon',
+        'namespace' => 'Modules\\FixtureAddon',
+        'version'   => '1.0.0',
+        'path'      => $path,
+        'enabled'   => true,
     ]);
 }
 
@@ -66,7 +69,7 @@ it('runs addon seeders by file path and records a seed marker', function (): voi
     $this->seederSvc->seedAddons();
 
     expect(Kvp::where('key', 'fixture_addon_proof')->exists())->toBeTrue()
-        ->and(Kvp::where('key', 'addon_seeded:FixtureAddon:1.0.0')->exists())->toBeTrue()
+        ->and(Kvp::where('key', 'addon_seeded:modules-fixtureaddon:1.0.0')->exists())->toBeTrue()
         ->and($this->seederSvc->addonSeedsPending())->toBeFalse();
 });
 
@@ -94,4 +97,60 @@ it('surfaces addon seed state through seedsPending()', function (): void {
     $this->seederSvc->seedAddons();
 
     expect($this->seederSvc->seedsPending())->toBeFalse();
+});
+
+it('logs the underlying exception message when an addon seeder throws, and still seeds the next addon', function (): void {
+    // Use a dedicated addon path/class rather than the beforeEach fixture:
+    // runSeederFile() checks class_exists($class, false) before requiring the
+    // file, so re-declaring FixtureAddonDatabaseSeeder here would be shadowed
+    // by the non-throwing class definition an earlier test already loaded into
+    // this PHP process.
+    $throwingPath = sys_get_temp_dir().'/phpvms-addon-seed-throwing-'.uniqid('', true);
+    $throwingSeedDir = $throwingPath.'/database/seeders';
+    File::ensureDirectoryExists($throwingSeedDir);
+    File::put($throwingSeedDir.'/ThrowingAddonDatabaseSeeder.php', <<<'PHP'
+        <?php
+
+        namespace PhpvmsTests\Fixtures\AddonSeed;
+
+        use Illuminate\Database\Seeder;
+        use RuntimeException;
+
+        class ThrowingAddonDatabaseSeeder extends Seeder
+        {
+            public function run(): void
+            {
+                throw new RuntimeException("SQLSTATE[42P01]: Undefined table:\n  relation \"vmsacars_rules\" does not exist");
+            }
+        }
+        PHP);
+
+    Addon::factory()->create([
+        'name'      => 'ThrowingAddon',
+        'namespace' => 'Modules\\ThrowingAddon',
+        'version'   => '1.0.0',
+        'path'      => $throwingPath,
+        'enabled'   => true,
+    ]);
+
+    // A second, well-behaved addon must still seed even though the throwing
+    // addon above fails.
+    makeFixtureAddon($this->addonPath);
+
+    Log::spy();
+
+    $this->seederSvc->seedAddons();
+
+    Log::shouldHaveReceived('error')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => str_starts_with($message, 'Addon "ThrowingAddon" seeder failed; continuing: ')
+            && str_contains($message, 'SQLSTATE[42P01]: Undefined table: relation "vmsacars_rules" does not exist')
+            && !str_contains($message, "\n")
+            && ($context['exception'] ?? null) instanceof Throwable);
+
+    expect(Kvp::where('key', 'addon_seeded:modules-throwingaddon:1.0.0')->exists())->toBeFalse()
+        ->and(Kvp::where('key', 'fixture_addon_proof')->exists())->toBeTrue()
+        ->and(Kvp::where('key', 'addon_seeded:modules-fixtureaddon:1.0.0')->exists())->toBeTrue();
+
+    File::deleteDirectory($throwingPath);
 });

--- a/tests/Feature/Addons/AddonUninstallContractTest.php
+++ b/tests/Feature/Addons/AddonUninstallContractTest.php
@@ -61,10 +61,11 @@ beforeEach(function (): void {
         PHP);
 
     Addon::factory()->create([
-        'name'    => 'FixtureContract',
-        'version' => '1.0.0',
-        'path'    => $this->addonPath,
-        'enabled' => false,
+        'name'      => 'FixtureContract',
+        'namespace' => 'Modules\\FixtureContract',
+        'version'   => '1.0.0',
+        'path'      => $this->addonPath,
+        'enabled'   => false,
     ]);
 
     Artisan::call('migrate', [
@@ -85,13 +86,13 @@ afterEach(function (): void {
 it('drops declared tables on uninstall even when down() is a no-op', function (): void {
     expect(Schema::hasTable('fixture_contract_things'))->toBeTrue();
 
-    Kvp::updateOrCreate(['key' => 'addon_seeded:FixtureContract:1.0.0'], ['value' => '1']);
+    Kvp::updateOrCreate(['key' => 'addon_seeded:modules-fixturecontract:1.0.0'], ['value' => '1']);
 
     $this->registry->delete('FixtureContract', true);
 
     expect(Schema::hasTable('fixture_contract_things'))->toBeFalse()
         ->and(DB::table('migrations')->where('migration', 'like', '%create_fixture_contract_things_table')->exists())->toBeFalse()
-        ->and(Kvp::where('key', 'addon_seeded:FixtureContract:1.0.0')->exists())->toBeFalse()
+        ->and(Kvp::where('key', 'addon_seeded:modules-fixturecontract:1.0.0')->exists())->toBeFalse()
         ->and(Addon::query()->where('name', 'FixtureContract')->exists())->toBeFalse();
 });
 

--- a/tests/Feature/Addons/AddonUninstallTest.php
+++ b/tests/Feature/Addons/AddonUninstallTest.php
@@ -46,10 +46,11 @@ beforeEach(function (): void {
     $this->migrationDir = $migrationDir;
 
     Addon::factory()->create([
-        'name'    => 'FixtureUninstall',
-        'version' => '1.0.0',
-        'path'    => $this->addonPath,
-        'enabled' => false,
+        'name'      => 'FixtureUninstall',
+        'namespace' => 'Modules\\FixtureUninstall',
+        'version'   => '1.0.0',
+        'path'      => $this->addonPath,
+        'enabled'   => false,
     ]);
 
     Artisan::call('migrate', [
@@ -70,13 +71,13 @@ afterEach(function (): void {
 it('drops the addon tables and migration records when removeTables is true', function (): void {
     expect(Schema::hasTable('fixture_addon_things'))->toBeTrue();
 
-    Kvp::updateOrCreate(['key' => 'addon_seeded:FixtureUninstall:1.0.0'], ['value' => '1']);
+    Kvp::updateOrCreate(['key' => 'addon_seeded:modules-fixtureuninstall:1.0.0'], ['value' => '1']);
 
     $this->registry->delete('FixtureUninstall', true);
 
     expect(Schema::hasTable('fixture_addon_things'))->toBeFalse()
         ->and(DB::table('migrations')->where('migration', 'like', '%create_fixture_addon_things_table')->exists())->toBeFalse()
-        ->and(Kvp::where('key', 'addon_seeded:FixtureUninstall:1.0.0')->exists())->toBeFalse()
+        ->and(Kvp::where('key', 'addon_seeded:modules-fixtureuninstall:1.0.0')->exists())->toBeFalse()
         ->and(Addon::query()->where('name', 'FixtureUninstall')->exists())->toBeFalse();
 });
 

--- a/tests/Feature/Installer/AddonMigrationOrderingTest.php
+++ b/tests/Feature/Installer/AddonMigrationOrderingTest.php
@@ -60,6 +60,22 @@ function makeDiskAddon(string $base, string $dirName, array $options = []): stri
 }
 
 /**
+ * Drop the addons table to simulate the pre-install state getMigrationPaths()
+ * has to cope with.
+ *
+ * addon_settings carries a foreign key to addons, so Postgres and MySQL refuse a
+ * bare `drop table addons` ("Dependent objects still exist") where sqlite allows
+ * it. Dropping the child first is portable across all three, and avoids both a
+ * driver-specific CASCADE and toggling foreign key constraints. RefreshDatabase
+ * restores both tables for the next test.
+ */
+function dropAddonsTable(): void
+{
+    Schema::dropIfExists('addon_settings');
+    Schema::dropIfExists('addons');
+}
+
+/**
  * Create a fixture addon backed by a real DB row (App\Models\Addon), with a
  * matching directory + migration on disk so a `getMigrationPaths()` lookup
  * against AddonRegistry::enabled() actually resolves.
@@ -87,7 +103,7 @@ afterEach(function (): void {
 
 describe('pre-install (no addons table)', function (): void {
     beforeEach(function (): void {
-        Schema::drop('addons');
+        dropAddonsTable();
     });
 
     it('includes a disk addon with a module.json and a migrations directory', function (): void {
@@ -169,7 +185,7 @@ describe('post-install (addons table present)', function (): void {
 it('runs an addon migration in the same pass as core on a simulated fresh install', function (): void {
     makeDiskAddon($this->addonBase, 'Demo', ['migrations' => true]);
 
-    Schema::drop('addons');
+    dropAddonsTable();
 
     $service = app(MigrationService::class);
 

--- a/tests/Feature/Installer/AddonMigrationOrderingTest.php
+++ b/tests/Feature/Installer/AddonMigrationOrderingTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Addon;
+use App\Services\Installer\MigrationService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create a fixture addon directory on disk (module.json, optionally a
+ * database/migrations directory with a real migration), so
+ * MigrationService::getMigrationPaths() has something to discover. Mirrors
+ * makeSeedableAddon() in AddonSeedMarkerTest.
+ */
+function makeDiskAddon(string $base, string $dirName, array $options = []): string
+{
+    $path = $base.'/'.$dirName;
+    File::ensureDirectoryExists($path);
+
+    if ($options['module_json'] ?? true) {
+        File::put($path.'/module.json', json_encode(['name' => $dirName, 'providers' => []]));
+    }
+
+    if ($options['migrations'] ?? false) {
+        $migrationDir = $path.'/database/migrations';
+        File::ensureDirectoryExists($migrationDir);
+
+        $slug = substr(md5($path), 0, 8);
+        $table = 'fixture_migration_'.$slug;
+
+        // Filename (sans .php) is the migration's unique key in the migrations
+        // table, so it must differ per fixture addon.
+        File::put($migrationDir.sprintf('/2026_07_25_000001_create_fixture_table_%s.php', $slug), <<<PHP
+            <?php
+
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class() extends Migration
+            {
+                public function up(): void
+                {
+                    Schema::create('{$table}', function (Blueprint \$table): void {
+                        \$table->id();
+                    });
+                }
+
+                public function down(): void
+                {
+                    Schema::dropIfExists('{$table}');
+                }
+            };
+            PHP);
+    }
+
+    return $path;
+}
+
+/**
+ * Create a fixture addon backed by a real DB row (App\Models\Addon), with a
+ * matching directory + migration on disk so a `getMigrationPaths()` lookup
+ * against AddonRegistry::enabled() actually resolves.
+ */
+function makeDbAddon(string $base, string $dirName, bool $enabled): Addon
+{
+    $path = makeDiskAddon($base, $dirName, ['migrations' => true]);
+
+    return Addon::factory()->create(['path' => $path, 'enabled' => $enabled]);
+}
+
+beforeEach(function (): void {
+    $this->addonBase = sys_get_temp_dir().'/phpvms-addon-migration-ordering-'.uniqid('', true);
+    File::ensureDirectoryExists($this->addonBase);
+    Config::set('addons.paths.base', $this->addonBase);
+
+    // Bundled module rows seeded by the addons migration aren't relevant here
+    // and would leak into the "DB is source of truth" assertions.
+    Addon::query()->delete();
+});
+
+afterEach(function (): void {
+    File::deleteDirectory($this->addonBase);
+});
+
+describe('pre-install (no addons table)', function (): void {
+    beforeEach(function (): void {
+        Schema::drop('addons');
+    });
+
+    it('includes a disk addon with a module.json and a migrations directory', function (): void {
+        makeDiskAddon($this->addonBase, 'Demo', ['migrations' => true]);
+
+        $paths = app(MigrationService::class)->getMigrationPaths();
+
+        expect($paths)->toHaveKey('Demo')
+            ->and($paths['Demo'])->toBe(realpath($this->addonBase).'/Demo/database/migrations');
+    });
+
+    it('excludes a disk directory with no module.json', function (): void {
+        makeDiskAddon($this->addonBase, 'NoManifest', ['module_json' => false, 'migrations' => true]);
+
+        $paths = app(MigrationService::class)->getMigrationPaths();
+
+        expect($paths)->not->toHaveKey('NoManifest');
+    });
+
+    it('excludes a disk addon with no database/migrations subdirectory', function (): void {
+        makeDiskAddon($this->addonBase, 'NoMigrations', ['migrations' => false]);
+
+        $paths = app(MigrationService::class)->getMigrationPaths();
+
+        expect($paths)->not->toHaveKey('NoMigrations');
+    });
+
+    it('includes a symlinked module directory (phpvms-acars case)', function (): void {
+        $realParent = sys_get_temp_dir().'/phpvms-addon-migration-ordering-real-'.uniqid('', true);
+        $real = makeDiskAddon($realParent, 'ActualAcars', ['migrations' => true]);
+        symlink($real, $this->addonBase.'/Linked');
+
+        $paths = app(MigrationService::class)->getMigrationPaths();
+
+        expect($paths)->toHaveKey('Linked')
+            ->and($paths['Linked'])->toBe(realpath($real).'/database/migrations');
+
+        File::deleteDirectory($realParent);
+        @unlink($this->addonBase.'/Linked');
+    });
+
+    it('applies the same disk-scan behavior for the data migrations directory', function (): void {
+        $path = makeDiskAddon($this->addonBase, 'Demo', ['migrations' => false]);
+        File::ensureDirectoryExists($path.'/database/migrations_data');
+        File::put($path.'/database/migrations_data/2026_07_25_000001_seed_fixture.php', '<?php');
+
+        $paths = app(MigrationService::class)->getMigrationPaths('migrations_data');
+
+        expect($paths)->toHaveKey('Demo')
+            ->and($paths['Demo'])->toBe(realpath($path).'/database/migrations_data');
+    });
+});
+
+describe('post-install (addons table present)', function (): void {
+    it('includes an enabled addon and excludes a disabled one, even though both are on disk', function (): void {
+        $enabled = makeDbAddon($this->addonBase, 'Enabled', enabled: true);
+        $disabled = makeDbAddon($this->addonBase, 'Disabled', enabled: false);
+
+        $paths = app(MigrationService::class)->getMigrationPaths();
+
+        expect($paths)->toHaveKey($enabled->getName())
+            ->and($paths)->not->toHaveKey($disabled->getName());
+    });
+
+    it('applies the same enabled/disabled filtering for the data migrations directory', function (): void {
+        $enabled = makeDbAddon($this->addonBase, 'Enabled', enabled: true);
+        $disabled = makeDbAddon($this->addonBase, 'Disabled', enabled: false);
+
+        File::ensureDirectoryExists($enabled->getPath().'/database/migrations_data');
+        File::ensureDirectoryExists($disabled->getPath().'/database/migrations_data');
+
+        $paths = app(MigrationService::class)->getMigrationPaths('migrations_data');
+
+        expect($paths)->toHaveKey($enabled->getName())
+            ->and($paths)->not->toHaveKey($disabled->getName());
+    });
+});
+
+it('runs an addon migration in the same pass as core on a simulated fresh install', function (): void {
+    makeDiskAddon($this->addonBase, 'Demo', ['migrations' => true]);
+
+    Schema::drop('addons');
+
+    $service = app(MigrationService::class);
+
+    expect($service->migrationsAvailable())->not->toBeEmpty();
+
+    $service->runAllMigrations();
+
+    expect($service->migrationsAvailable())->toBe([]);
+});

--- a/tests/Unit/Addons/BootCacheDiskFingerprintTest.php
+++ b/tests/Unit/Addons/BootCacheDiskFingerprintTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Addons\Services\AddonDiscoveryService;
+use App\Addons\Support\BootCache;
+use App\Models\Addon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+
+// Boot-cache isolation is handled globally in tests/Pest.php (unique temp path
+// per test). This file additionally redirects addons.paths.base to a temp
+// directory so it can freely add/remove/edit addon directories.
+
+beforeEach(function (): void {
+    Addon::query()->delete();
+
+    $this->base = sys_get_temp_dir().'/addon-disk-fingerprint-'.uniqid('', true);
+    File::ensureDirectoryExists($this->base);
+    Config::set('addons.paths.base', $this->base);
+});
+
+afterEach(function (): void {
+    File::deleteDirectory($this->base);
+});
+
+/**
+ * Drop a valid addon on disk and an enabled DB row for it, mirroring
+ * AddonBootCacheReconcileTest's placeEnabledAddon() helper.
+ */
+function placeAddon(string $base, string $name): void
+{
+    $dir = $base.'/'.strtolower($name);
+    File::ensureDirectoryExists($dir);
+    File::put($dir.'/module.json', json_encode(['name' => $name, 'providers' => []]));
+    File::put($dir.'/composer.json', json_encode(['autoload' => ['psr-4' => ['Modules\\'.$name.'\\' => 'app/']]]));
+
+    Addon::factory()->create([
+        'name'      => $name,
+        'namespace' => 'Modules\\'.$name,
+        'path'      => $dir,
+        'enabled'   => true,
+    ]);
+}
+
+it('rebuilds when a module.json is edited but the DB is untouched', function (): void {
+    placeAddon($this->base, 'Alpha');
+    $svc = app(AddonDiscoveryService::class);
+    $svc->rebuildCache();
+
+    expect($svc->primeIfNeeded())->toBeFalse();
+
+    // Edit the manifest name on disk only — the DB row and its updated_at are
+    // untouched, so databaseFingerprint() alone would miss this.
+    $manifestPath = $this->base.'/alpha/module.json';
+    // Force the mtime forward: some filesystems have 1-second mtime
+    // resolution, and this edit can otherwise land in the same second as the
+    // original write above.
+    File::put($manifestPath, json_encode(['name' => 'AlphaRenamed', 'providers' => []]));
+    touch($manifestPath, time() + 1);
+
+    expect($svc->primeIfNeeded())->toBeTrue();
+
+    $cached = app(BootCache::class)->enabled()->firstWhere('namespace', 'Modules\\Alpha');
+    expect($cached->name)->toBe('AlphaRenamed');
+});
+
+it('changes the fingerprint when an addon directory is added', function (): void {
+    placeAddon($this->base, 'Alpha');
+    $svc = app(AddonDiscoveryService::class);
+    $svc->rebuildCache();
+
+    expect($svc->primeIfNeeded())->toBeFalse();
+
+    placeAddon($this->base, 'Beta');
+
+    expect($svc->primeIfNeeded())->toBeTrue()
+        ->and(app(BootCache::class)->enabled()->pluck('namespace')->all())
+        ->toContain('Modules\\Alpha', 'Modules\\Beta');
+});
+
+it('changes the fingerprint when an addon directory is removed', function (): void {
+    placeAddon($this->base, 'Alpha');
+    placeAddon($this->base, 'Beta');
+    $svc = app(AddonDiscoveryService::class);
+    $svc->rebuildCache();
+
+    expect($svc->primeIfNeeded())->toBeFalse();
+
+    File::deleteDirectory($this->base.'/beta');
+    Addon::where('namespace', 'Modules\\Beta')->delete();
+
+    expect($svc->primeIfNeeded())->toBeTrue()
+        ->and(app(BootCache::class)->enabled()->pluck('namespace')->all())
+        ->toBe(['Modules\\Alpha']);
+});
+
+it('does not rewrite the cache file when disk and DB are both unchanged', function (): void {
+    placeAddon($this->base, 'Alpha');
+    $svc = app(AddonDiscoveryService::class);
+    $svc->rebuildCache();
+
+    $path = app(BootCache::class)->path();
+    $mtimeBefore = filemtime($path);
+
+    // Filesystem mtime resolution can be coarse; sleeping a full second makes
+    // a spurious rewrite observable regardless of resolution.
+    sleep(1);
+
+    expect($svc->primeIfNeeded())->toBeFalse()
+        ->and(filemtime($path))->toBe($mtimeBefore);
+});
+
+it('treats a schema-3 cache as stale and rebuilds it', function (): void {
+    placeAddon($this->base, 'Alpha');
+
+    $runtime = app(BootCache::class);
+    $legacyEnvelope = [
+        'schema'       => 3,
+        'generated_at' => gmdate('c'),
+        'fingerprint'  => null,
+        'addons'       => [],
+    ];
+    file_put_contents(
+        $runtime->path(),
+        '<?php'.PHP_EOL.'return '.var_export($legacyEnvelope, true).';'.PHP_EOL,
+    );
+
+    $svc = app(AddonDiscoveryService::class);
+
+    expect($runtime->isFresh())->toBeFalse()
+        ->and($svc->primeIfNeeded())->toBeTrue()
+        ->and($runtime->isFresh())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Fresh install, addon enabled, migrations and seeder all reported success — but none of the addon's settings existed and every `addon_setting('acars', ...)` silently returned its default. Four defects behind that, plus the installer problems that fell out of the same root cause.

**Addon identity never resolved.** `create_addons_table` seeds every row with `registry_id = null`, while both settings services look an addon up by the `registry_id` its manifest declares. The lookup missed and `syncEntry()` returned early with no log at all. A data migration now populates the column, and both resolvers fall through to the unique `namespace` when a declared `registry_id` matches no row. The shipped migration is deliberately untouched — one that has already run everywhere fixes nothing on an existing install, and the installer runs `migrate-data` right after `migrate`, so fresh installs are covered in the same pass.

**Seed markers keyed on the display name.** The name is nullable, non-unique and mutable, so rebranding an addon stranded its marker and left `addonSeedsPending()` permanently true. Now keyed on `registry_id ?? namespace`, slugified through `keyed_str()` the same way `AddonRegistry::safeName()` and `PermissionRegistry::moduleKey()` already derive keys. That also keeps the identity safe in the uninstall `LIKE` pattern: a raw namespace carries backslashes, and escaping is not portable — MySQL and Postgres treat backslash as the default LIKE escape character, sqlite has none. A data migration rewrites existing markers.

**Boot cache never noticed disk.** It fingerprinted only the `addons` table, so editing a `module.json` left a cache considered current forever. It now also hashes the mtime and size of every `module.json`/`composer.json`; `SCHEMA` goes to 4, which forces one self-healing rebuild.

**Addon migrations never ran on a fresh install.** `getMigrationPaths()` bailed to core-only when the `addons` table did not exist — which on a fresh install is always, since the table is created and populated by `create_addons_table` during the very run whose `--path` list was already fixed. The comment claimed no addons could be enabled pre-install, but that migration scans disk and inserts everything it finds as enabled, so the disk *is* the enabled set. Scanning it directly means one pass migrates core and addon migrations together, ordered by filename across paths. This is why the installer reported success while Next stayed blocked on 13 pending migrations, and why the ACARS seeder died on a missing `vmsacars_rules`.

Also: addon seeder failures now carry the exception message (it previously travelled only in the log context, so Pail showed a bare exception class), and the streamed console has a bounded scrolling height without its redundant label.

## Test plan

- `vendor/bin/pest` — 1054 passed, 0 failed
- Verified against a real broken install: the backfill resolves ACARS to `phpvms/acars`, which is what lets the settings sync find it
- Confirmed on Postgres that an unescaped backslash LIKE pattern matches zero rows, which is what motivated slugifying the marker identity
- Baseline-compared throughout — a checkout whose Sample module had just gained a `registry_id` went from 7 failing addon tests to 0

Not yet exercised: a real fresh install walked through the installer UI against Postgres with symlinked module directories. Unit coverage only for that flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-on boot caches now also detect changes to on-disk add-on manifests, including additions, edits, and removals.
  * Fresh installs can discover add-ons directly from the filesystem.
  * Add-on seed tracking is now more stable across renames/rebrands and identifier changes.
* **Bug Fixes**
  * Improved settings synchronization by falling back to namespace matching when registry data doesn’t resolve.
  * Added automatic registry_id backfilling and rekeying of existing seed markers during upgrade.
  * Installer/updater console output display is now cleaner and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->