### PR TITLE
fix(admin): Show the sidebar scrollbar only on hover

### DIFF
--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -228,6 +228,21 @@ body[class*="fi-panel-"]::after {
   border-right: 0;
 }
 
+/* Sidebar nav scrollbar: thin, and only visible on hover. */
+.fi-panel-admin .fi-sidebar-nav {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 150ms ease;
+}
+
+.fi-panel-admin .fi-sidebar-nav:hover {
+  scrollbar-color: #d1d5dc transparent;
+}
+
+.dark .fi-panel-admin .fi-sidebar-nav:hover {
+  scrollbar-color: #364153 transparent;
+}
+
 /* Group label (docs custom.css:537-545) */
 .fi-panel-admin .fi-sidebar-group-label {
   font-family: var(--font-mono-display), ui-monospace, monospace;


### PR DESCRIPTION
The admin sidebar nav kept a scrollbar visible at all times. It now stays hidden until you hover the nav, and it renders as a thin line instead of a full-width track.

**No `::-webkit-scrollbar` fallback**

This uses the standard `scrollbar-width` and `scrollbar-color` properties, which Chrome has supported since 121 and Safari since 18.2. Older Safari just keeps the current always-on scrollbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the admin sidebar navigation scrollbar with a slimmer appearance.
  * Scrollbar colors now appear on hover and adapt to light and dark themes.
  * Added a smooth transition for scrollbar visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->