### PR TITLE
fix(http): Trust reverse proxies so HTTPS is detected behind TLS termination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ APP_KEY=
 # The full public URL of your installation, including the scheme (e.g. https://).
 APP_URL=
 
+# Reverse proxies (Caddy/nginx/load balancer) to trust for X-Forwarded-* headers
+# so HTTPS is detected behind TLS termination. "*" trusts all (fine when the
+# proxy is your only ingress); or a comma-separated list of proxy IPs.
+TRUSTED_PROXIES=*
+
 # Environment type: production, local, staging, etc.
 # In production, set this to "production".
 APP_ENV=production

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException as IlluminateValidationException;
@@ -58,6 +59,22 @@ return Application::configure(basePath: dirname(__DIR__))
             'permission'         => PermissionMiddleware::class,
             'role_or_permission' => RoleOrPermissionMiddleware::class,
         ]);
+    })
+    ->booted(function (): void {
+        // Trust the reverse proxy (e.g. Caddy/nginx) that terminates TLS so
+        // Request::isSecure() honours X-Forwarded-Proto and generated URLs use
+        // https. Configured here (not in withMiddleware) because config is not
+        // yet bound when the middleware closure runs, and trustProxies(at:) does
+        // not accept a Closure. See config/http.php 'trusted_proxies'.
+        $proxies = config('http.trusted_proxies');
+        TrustProxies::at($proxies === '*' ? '*' : explode(',', $proxies));
+        TrustProxies::withHeaders(
+            Request::HEADER_X_FORWARDED_FOR |
+            Request::HEADER_X_FORWARDED_HOST |
+            Request::HEADER_X_FORWARDED_PORT |
+            Request::HEADER_X_FORWARDED_PROTO |
+            Request::HEADER_X_FORWARDED_AWS_ELB
+        );
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->dontReport([

--- a/config/http.php
+++ b/config/http.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Trusted Proxies
+    |--------------------------------------------------------------------------
+    |
+    | Reverse proxies (Caddy/nginx/load balancer) to trust for X-Forwarded-*
+    | headers so HTTPS is detected behind TLS termination. Without this,
+    | generated URLs fall back to http on an https site and browsers warn
+    | about posting over an insecure connection. "*" trusts all (fine when the
+    | proxy is your only ingress), or a comma-separated list of proxy IPs.
+    |
+    */
+
+    'trusted_proxies' => env('TRUSTED_PROXIES', '*'),
+
+];

--- a/tests/Feature/TrustedProxyTest.php
+++ b/tests/Feature/TrustedProxyTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\User;
+
+test('login form action uses https when behind a TLS-terminating proxy', function (): void {
+    // A user must exist or InstalledCheck redirects to the installer.
+    User::factory()->create();
+
+    // Caddy terminates TLS and forwards plain HTTP with X-Forwarded-Proto: https.
+    $response = $this->get('/login', ['X-Forwarded-Proto' => 'https']);
+
+    $response->assertOk();
+    // The form action must honour the forwarded scheme, otherwise the browser
+    // warns about posting from an https page to an http action.
+    $response->assertSee('action="https://', false);
+});


### PR DESCRIPTION
Restore trusted-proxy configuration so `Request::isSecure()` honours `X-Forwarded-Proto` when phpVMS runs behind a TLS-terminating proxy (Caddy, nginx, a load balancer). Without it, generated URLs fall back to `http` on an `https` site, and the browser warns about posting the login form over an insecure connection.

This is a regression. The move to the modern Laravel bootstrap structure in 7de823a0 dropped the app-level `TrustProxies` middleware and didn't carry the trust setting into `bootstrap/app.php`, so installs that upgraded through it lost HTTPS detection.

**Configured in `booted()`, not `withMiddleware()`**

`trustProxies(at:)` takes a value immediately and doesn't accept a Closure, and config isn't bound yet when the middleware closure runs. Reading `config('http.trusted_proxies')` in a `booted()` hook resolves it after config loads and stays safe under `config:cache`.

The new `TRUSTED_PROXIES` env var defaults to `*`, which matches the old middleware and works out of the box when the proxy is the only ingress. Tighten it to specific IPs if the app is ever directly reachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HTTPS detection when the application runs behind a reverse proxy or TLS-terminating load balancer.
  * Added configuration for trusted proxy addresses and forwarded headers.

* **Bug Fixes**
  * Login form URLs now correctly use HTTPS when secure traffic is forwarded through a proxy.

* **Documentation**
  * Updated the environment configuration template with trusted proxy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->