### PR TITLE
feat(simbrief): Pick airframes from a searchable dropdown, tolerate empty TLR

### DIFF
--- a/app/Filament/Resources/Subfleets/Resources/Aircraft/Schemas/AircraftForm.php
+++ b/app/Filament/Resources/Subfleets/Resources/Aircraft/Schemas/AircraftForm.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\Subfleets\Resources\Aircraft\Schemas;
 
 use App\Enums\AircraftStatus;
 use App\Models\Airport;
+use App\Models\SimBriefAirframe;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
@@ -27,9 +28,29 @@ class AircraftForm
                             ->required()
                             ->string(),
 
-                        TextInput::make('icao')
+                        Select::make('icao')
                             ->label('ICAO')
-                            ->string(),
+                            ->searchable()
+                            ->native(false)
+                            ->getSearchResultsUsing(fn (string $search): array => SimBriefAirframe::query()
+                                ->where(function ($query) use ($search): void {
+                                    $query->where('icao', 'like', sprintf('%%%s%%', $search))
+                                        ->orWhere('name', 'like', sprintf('%%%s%%', $search));
+                                })
+                                ->orderBy('icao')
+                                ->limit(50)
+                                ->get()
+                                ->mapWithKeys(fn (SimBriefAirframe $airframe): array => [$airframe->icao => $airframe->icao.' - '.$airframe->name])
+                                ->all())
+                            ->getOptionLabelUsing(function (?string $value): ?string {
+                                if (blank($value)) {
+                                    return null;
+                                }
+
+                                $name = SimBriefAirframe::where('icao', $value)->value('name');
+
+                                return filled($name) ? $value.' - '.$name : $value;
+                            }),
 
                         Select::make('status')
                             ->label(__('common.status'))

--- a/app/Filament/Resources/Subfleets/Schemas/SubfleetForm.php
+++ b/app/Filament/Resources/Subfleets/Schemas/SubfleetForm.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Subfleets\Schemas;
 use App\Enums\FlightType;
 use App\Enums\FuelType;
 use App\Models\Airport;
+use App\Models\SimBriefAirframe;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
@@ -40,9 +41,32 @@ class SubfleetForm
                             ->required()
                             ->string(),
 
-                        TextInput::make('simbrief_type')
+                        Select::make('simbrief_type')
                             ->label(__('common.simbrief_airframe_id'))
-                            ->string(),
+                            ->searchable()
+                            ->native(false)
+                            ->getSearchResultsUsing(fn (string $search): array => SimBriefAirframe::query()
+                                ->whereNotNull('airframe_id')
+                                ->where('airframe_id', '!=', '')
+                                ->where(function ($query) use ($search): void {
+                                    $query->where('name', 'like', sprintf('%%%s%%', $search))
+                                        ->orWhere('icao', 'like', sprintf('%%%s%%', $search))
+                                        ->orWhere('airframe_id', 'like', sprintf('%%%s%%', $search));
+                                })
+                                ->orderBy('name')
+                                ->limit(50)
+                                ->get()
+                                ->mapWithKeys(fn (SimBriefAirframe $airframe): array => [$airframe->airframe_id => $airframe->name.' ('.$airframe->icao.')'])
+                                ->all())
+                            ->getOptionLabelUsing(function (?string $value): ?string {
+                                if (blank($value)) {
+                                    return null;
+                                }
+
+                                $airframe = SimBriefAirframe::where('airframe_id', $value)->first(['name', 'icao']);
+
+                                return $airframe ? $airframe->name.' ('.$airframe->icao.')' : $value;
+                            }),
 
                         TextInput::make('name')
                             ->label(__('common.name'))

--- a/app/Support/Dto/SimBriefOfp/SimBriefOfpTlr.php
+++ b/app/Support/Dto/SimBriefOfp/SimBriefOfpTlr.php
@@ -7,15 +7,15 @@ use Spatie\LaravelData\Dto;
 final class SimBriefOfpTlr extends Dto
 {
     public function __construct(
-        public SimBriefOfpTlrTakeoff $takeoff,
-        public SimBriefOfpTlrLanding $landing,
+        public ?SimBriefOfpTlrTakeoff $takeoff,
+        public ?SimBriefOfpTlrLanding $landing,
     ) {}
 
     public static function fromArray(array $data): self
     {
         return new self(
-            takeoff: SimBriefOfpTlrTakeoff::from($data['takeoff'] ?? []),
-            landing: SimBriefOfpTlrLanding::from($data['landing'] ?? []),
+            takeoff: filled($data['takeoff'] ?? null) ? SimBriefOfpTlrTakeoff::from($data['takeoff']) : null,
+            landing: filled($data['landing'] ?? null) ? SimBriefOfpTlrLanding::from($data['landing']) : null,
         );
     }
 }

--- a/tests/Feature/Filament/AircraftResourceTest.php
+++ b/tests/Feature/Filament/AircraftResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Subfleets\Resources\Aircraft\Pages\EditAircraft;
+use App\Models\Aircraft;
+use App\Models\SimBriefAirframe;
+use Database\Seeders\RolesPermissionsSeeder;
+
+it('renders the icao airframe dropdown with the stored value resolved from the airframes table', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $aircraft = Aircraft::factory()->create(['icao' => 'B738']);
+
+    SimBriefAirframe::create([
+        'icao'        => 'B738',
+        'name'        => 'iniBuilds (MSFS) - 737-800',
+        'airframe_id' => '3_1677576294832',
+    ]);
+
+    // Nested resource under Subfleets; the real route provides the parent.
+    $url = EditAircraft::getUrl([
+        'record'   => $aircraft->id,
+        'subfleet' => $aircraft->subfleet_id,
+    ]);
+
+    // getOptionLabelUsing resolves the stored icao against the airframes table,
+    // so the page renders the airframe name alongside the code.
+    $this->actingAs($admin)
+        ->get($url)
+        ->assertOk()
+        ->assertSee('B738 - iniBuilds (MSFS) - 737-800');
+});

--- a/tests/Feature/Filament/SubfleetResourceTest.php
+++ b/tests/Feature/Filament/SubfleetResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\FlightType;
 use App\Filament\Resources\Subfleets\Pages\EditSubfleet;
+use App\Models\SimBriefAirframe;
 use App\Models\Subfleet;
 use Database\Seeders\RolesPermissionsSeeder;
 use Illuminate\Support\Collection;
@@ -51,6 +52,27 @@ it('persists capability values through the cast', function (): void {
     $rawJson = DB::table('subfleets')->where('id', $subfleet->id)->value('route_types');
     expect(json_decode((string) $rawJson, true))
         ->toMatchArray([FlightType::SCHED_PAX->value, FlightType::CHARTER_PAX_ONLY->value]);
+});
+
+it('persists the simbrief airframe_id selected from the airframes table', function (): void {
+    $this->seed(RolesPermissionsSeeder::class);
+
+    $admin = createAdminUser();
+    $subfleet = Subfleet::factory()->create();
+
+    SimBriefAirframe::create([
+        'icao'        => 'B738',
+        'name'        => 'iniBuilds (MSFS) - 737-800',
+        'airframe_id' => '3_1677576294832',
+    ]);
+
+    Livewire::test(EditSubfleet::class, ['record' => $subfleet->id])
+        ->set('data.simbrief_type', '3_1677576294832')
+        ->call('save')
+        ->assertHasNoFormErrors()
+        ->assertNotified();
+
+    expect($subfleet->refresh()->simbrief_type)->toBe('3_1677576294832');
 });
 
 it('persists empty route_types selection as empty collection', function (): void {

--- a/tests/Feature/SimBriefTest.php
+++ b/tests/Feature/SimBriefTest.php
@@ -13,6 +13,7 @@ use App\Models\SimBrief;
 use App\Models\Subfleet;
 use App\Models\User;
 use App\Services\SimBriefService;
+use App\Support\Dto\SimBriefOfp\SimBriefOfpTlr;
 use App\Support\Utils;
 use Carbon\Carbon;
 
@@ -71,6 +72,18 @@ function downloadOfp(User $user, $flight, $aircraft, array $fares): ?SimBrief
 
     return app(SimBriefService::class)->downloadOfp($user, 'static_id', Utils::generateNewId(), $flight->id, $aircraft->id, $fares);
 }
+
+test('parses an OFP with an empty TLR takeoff/landing section', function (): void {
+    // SimBrief omits the takeoff/landing report for some airframes and routes,
+    // returning empty nodes. The DTO must tolerate that instead of failing to
+    // construct the required takeoff/landing sub-objects.
+    $tlr = SimBriefOfpTlr::from(['takeoff' => [], 'landing' => []]);
+
+    expect($tlr->takeoff)->toBeNull()
+        ->and($tlr->landing)->toBeNull();
+
+    expect(fn (): SimBriefOfpTlr => SimBriefOfpTlr::from([]))->not->toThrow(Exception::class);
+});
 
 test('read simbrief', function (): void {
     $userinfo = createUserData();


### PR DESCRIPTION
The SimBrief airframe ID on a subfleet and the ICAO on an aircraft were free-text inputs, so operators had to know the exact code. Both are now typeahead selects backed by the `simbrief_airframes` table - the subfleet field stores an `airframe_id`, the aircraft field stores an `icao`. Search matches on name, icao, and (for the airframe field) airframe_id, capped at 50 results with server-side pagination, so nothing loads the full table up front.

This also fixes a crash in OFP parsing: SimBrief omits the TLR takeoff/landing report for some airframes and routes, returning empty nodes. `SimBriefOfpTlr` now leaves `takeoff`/`landing` null in that case instead of failing to build the required sub-objects. Nothing reads those two properties yet, so making them nullable is safe.

**No index added on `simbrief_airframes`**

The table is ~466 rows and search uses `LIKE '%term%'`, which a btree index can't accelerate anyway. Not worth the dead weight at this size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable airframe selectors for aircraft ICAO and subfleet SimBrief types.
  * Search supports aircraft names, ICAO codes, and airframe IDs, with clearer combined labels.
  * Existing selections now display their matching airframe names when available.

* **Bug Fixes**
  * SimBrief flight data now handles missing takeoff or landing details without errors.

* **Tests**
  * Added coverage for airframe selection, label display, persistence, and incomplete SimBrief data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->