### PR TITLE
feat(pireps): Typed custom field values

### DIFF
--- a/app/Enums/PirepFieldType.php
+++ b/app/Enums/PirepFieldType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Value type of a pirep custom field, as declared by ACARS. A null/absent type
+ * means an untyped legacy value — treat it as plain text.
+ */
+enum PirepFieldType: string
+{
+    case NUMBER = 'NUMBER';
+    case TEXT = 'TEXT';
+    case TIMESTAMP = 'TIMESTAMP';
+    case BOOLEAN = 'BOOLEAN';
+}

--- a/app/Enums/PirepFieldType.php
+++ b/app/Enums/PirepFieldType.php
@@ -4,14 +4,29 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasSelect;
+use Filament\Support\Contracts\HasLabel;
+
 /**
  * Value type of a pirep custom field, as declared by ACARS. A null/absent type
  * means an untyped legacy value — treat it as plain text.
  */
-enum PirepFieldType: string
+enum PirepFieldType: string implements HasLabel
 {
+    use HasSelect;
+
     case NUMBER = 'NUMBER';
     case TEXT = 'TEXT';
     case TIMESTAMP = 'TIMESTAMP';
     case BOOLEAN = 'BOOLEAN';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NUMBER    => 'Number',
+            self::TEXT      => 'Text',
+            self::TIMESTAMP => 'Timestamp',
+            self::BOOLEAN   => 'Boolean',
+        };
+    }
 }

--- a/app/Models/PirepFieldValue.php
+++ b/app/Models/PirepFieldValue.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Contracts\Model;
 use App\Enums\PirepFieldSource;
+use App\Enums\PirepFieldType;
 use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -13,16 +14,19 @@ use Illuminate\Support\Str;
 use Override;
 
 /**
- * @property int              $id
- * @property string           $pirep_id
- * @property string           $name
- * @property string|null      $slug
- * @property string|null      $value
- * @property PirepFieldSource $source
- * @property Carbon|null      $created_at
- * @property Carbon|null      $updated_at
+ * @property int                 $id
+ * @property string              $pirep_id
+ * @property string              $name
+ * @property string|null         $slug
+ * @property string|null         $value
+ * @property PirepFieldType|null $type
+ * @property string|null         $units
+ * @property PirepFieldSource    $source
+ * @property Carbon|null         $created_at
+ * @property Carbon|null         $updated_at
  * @property-read Pirep|null $pirep
  * @property-read bool $read_only
+ * @property-read float|bool|Carbon|string|null $typed_value
  *
  * @method static Builder<static>|PirepFieldValue newModelQuery()
  * @method static Builder<static>|PirepFieldValue newQuery()
@@ -49,6 +53,8 @@ class PirepFieldValue extends Model
         'name',
         'slug',
         'value',
+        'type',
+        'units',
         'source',
     ];
 
@@ -80,6 +86,23 @@ class PirepFieldValue extends Model
     }
 
     /**
+     * `value`, cast per the ACARS-declared `type`: NUMBER → float, BOOLEAN →
+     * bool, TIMESTAMP → Carbon. TEXT or an untyped row returns the raw string,
+     * so this is safe to use on any field value.
+     */
+    public function typedValue(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): float|bool|Carbon|string|null => match ($this->type) {
+                PirepFieldType::NUMBER    => (float) $this->value,
+                PirepFieldType::BOOLEAN   => filter_var($this->value, FILTER_VALIDATE_BOOLEAN),
+                PirepFieldType::TIMESTAMP => Carbon::parse($this->value),
+                default                   => $this->value,
+            }
+        );
+    }
+
+    /**
      * Relationships
      */
     public function pirep(): BelongsTo
@@ -92,6 +115,7 @@ class PirepFieldValue extends Model
     {
         return [
             'source' => PirepFieldSource::class,
+            'type'   => PirepFieldType::class,
         ];
     }
 }

--- a/database/migrations/2026_07_31_000000_add_type_units_to_pirep_field_values.php
+++ b/database/migrations/2026_07_31_000000_add_type_units_to_pirep_field_values.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Contracts\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ACARS-written custom fields carry a value type (NUMBER/TEXT/TIMESTAMP/BOOLEAN)
+ * and an AIXM unit code (FT, KT, ...). Both nullable — writes that only set
+ * name/value/source leave them null, meaning an untyped plain-string value.
+ */
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('pirep_field_values', function (Blueprint $table): void {
+            $table->string('type', 20)->nullable()->after('value');
+            $table->string('units', 20)->nullable()->after('type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pirep_field_values', function (Blueprint $table): void {
+            $table->dropColumn(['type', 'units']);
+        });
+    }
+};


### PR DESCRIPTION
Store the value type and unit ACARS declares for a custom field, and let callers read the value back in its real type.

`pirep_field_values` gains nullable string `type` (NUMBER/TEXT/TIMESTAMP/BOOLEAN, cast to the new `PirepFieldType` enum) and `units` (AIXM code like FT_MIN). A new `typed_value` accessor casts the stored string per type - NUMBER to float, BOOLEAN to bool, TIMESTAMP to Carbon, TEXT or untyped to the raw string.

**No behavior change for existing readers**

`value` stays the plain string it always was and nothing existing is rewritten to use `typed_value`. Rows written by anything that only sets name/value/source keep a null type and read back as plain text. The columns are filled by the ACARS plugin's write path; the round-trip is covered by its contract test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for typed PIREP field values, including numbers, text, timestamps, and booleans.
  * Added optional units for field values.
  * Values are automatically presented in their appropriate format, such as numeric, boolean, or date/time values.
  * Untyped legacy values continue to be treated as plain text.
  * Field type labels are available for clearer selection and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->