### PR TITLE
fix(pireps): typed_value preserves a null value

### DIFF
--- a/app/Models/PirepFieldValue.php
+++ b/app/Models/PirepFieldValue.php
@@ -93,7 +93,7 @@ class PirepFieldValue extends Model
     public function typedValue(): Attribute
     {
         return Attribute::make(
-            get: fn (): float|bool|Carbon|string|null => match ($this->type) {
+            get: fn (): float|bool|Carbon|string|null => $this->value === null ? null : match ($this->type) {
                 PirepFieldType::NUMBER    => (float) $this->value,
                 PirepFieldType::BOOLEAN   => filter_var($this->value, FILTER_VALIDATE_BOOLEAN),
                 PirepFieldType::TIMESTAMP => Carbon::parse($this->value),


### PR DESCRIPTION
Guard the null value before the type match in `typed_value`. A NUMBER, BOOLEAN, or TIMESTAMP row with a null `value` was returning a cast default (0.0, false, or a parse of '') instead of null, which the accessor's contract documents.