### PR TITLE
fix(acars): marshal phase as PirepPhase enum

### DIFF
--- a/app/Http/Requests/Acars/PositionRequest.php
+++ b/app/Http/Requests/Acars/PositionRequest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Requests\Acars;
 
 use App\Contracts\FormRequest;
+use App\Enums\PirepPhase;
 use App\Models\Pirep;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Override;
 
 class PositionRequest extends FormRequest
@@ -30,6 +32,7 @@ class PositionRequest extends FormRequest
             'positions.*.lat'          => 'required|numeric',
             'positions.*.lon'          => 'required|numeric',
             'positions.*.status'       => 'sometimes',
+            'positions.*.phase'        => ['sometimes', 'nullable', Rule::enum(PirepPhase::class)],
             'positions.*.altitude'     => 'sometimes|numeric',
             'positions.*.altitude_agl' => 'sometimes|numeric',
             'positions.*.altitude_msl' => 'sometimes|numeric',

--- a/app/Models/Acars.php
+++ b/app/Models/Acars.php
@@ -7,6 +7,7 @@ use App\Casts\FuelCast;
 use App\Contracts\Model;
 use App\Enums\AcarsType;
 use App\Enums\NavaidType;
+use App\Enums\PirepPhase;
 use App\Traits\HasNanoIds;
 use Database\Factories\AcarsFactory;
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -22,7 +23,7 @@ use Override;
  * @property string          $id
  * @property string          $pirep_id
  * @property AcarsType       $type
- * @property string|null     $phase
+ * @property PirepPhase|null $phase
  * @property NavaidType|null $nav_type
  * @property int             $order
  * @property string|null     $name
@@ -97,10 +98,9 @@ class Acars extends Model
         'id',
         'pirep_id',
         'type',
-        // The flight phase this row was recorded in. A plain string, not the
-        // PirepPhase enum: the ACARS contract sends an open vocabulary, so a
-        // code phpVMS does not yet define must still store. `status` holds the
-        // recognised code for anything still reading the old column.
+        // The flight phase this row was recorded in, a PirepPhase code.
+        // `status` holds the same code for anything still reading the old
+        // column.
         'phase',
         'nav_type',
         'order',
@@ -150,6 +150,7 @@ class Acars extends Model
     {
         return [
             'type'         => AcarsType::class,
+            'phase'        => PirepPhase::class,
             'order'        => 'integer',
             'nav_type'     => NavaidType::class,
             'lat'          => 'float',

--- a/tests/Feature/PirepPhaseEnumTest.php
+++ b/tests/Feature/PirepPhaseEnumTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Enums\AcarsType;
 use App\Enums\PirepPhase;
 use App\Enums\PirepStatus;
 use App\Http\Resources\PirepResource;
+use App\Models\Acars;
 use App\Models\Pirep;
 use Illuminate\Support\Facades\DB;
 
@@ -37,6 +39,20 @@ test('phase values stored before the rename read back to the same cases', functi
     expect($reloaded->status)->toBe(PirepPhase::ENROUTE)
         ->and($reloaded->status)->toBe(PirepStatus::ENROUTE)
         ->and($reloaded->status->value)->toBe('ENR');
+});
+
+test('acars rows marshal phase to the enum', function (): void {
+    $pirep = Pirep::factory()->create();
+    $acars = Acars::factory()->create([
+        'pirep_id' => $pirep->id,
+        'type'     => AcarsType::FLIGHT_PATH,
+        'phase'    => 'ENR',
+    ]);
+
+    $reloaded = Acars::find($acars->id);
+
+    expect($reloaded->phase)->toBe(PirepPhase::ENROUTE)
+        ->and($reloaded->phase->value)->toBe('ENR');
 });
 
 test('the API still publishes the value under phase', function (): void {


### PR DESCRIPTION
Cast `acars.phase` to the `PirepPhase` enum and validate incoming position payloads against it. The column was stored as a raw string on the theory that the ACARS contract sends an open vocabulary - it doesn't, the values come from `PirepPhase`, so an unknown code is now a 422 at the API boundary instead of silently stored.

No wire change: the column already holds the enum's three-letter codes, and serialization still emits them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * ACARS position phases are now validated against supported flight-phase values.
  * ACARS phase data is consistently represented using recognized phase values when retrieved.
* **Tests**
  * Added coverage confirming that the `ENR` phase is correctly interpreted as “Enroute.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->