### PR TITLE
test(simbrief): assert the briefing Content-Type header

### DIFF
--- a/tests/Feature/SimBriefTest.php
+++ b/tests/Feature/SimBriefTest.php
@@ -146,9 +146,11 @@ test('api calls', function (): void {
     // The briefing URL is keyed by the flight ID, not the SimBrief primary key
     expect(str_ends_with($url, $briefing->flight_id.'/briefing'))->toBeTrue();
 
-    // Retrieve the briefing via API, and then check the doctype
+    // Retrieve the briefing via API, and then check the doctype. The ACARS client picks its
+    // XML-vs-JSON parser off this header, so it has to be present on the response.
     $response = $this->get('/api/flights/'.$briefing->flight_id.'/briefing');
     $response->assertOk();
+    $response->assertHeader('Content-Type', 'application/json');
 
     $json = $response->json();
 


### PR DESCRIPTION
The `api calls` test fetched `/api/flights/{id}/briefing` and only checked the body wasn't empty, so nothing guarded the response header.

- The ACARS client picks its XML-vs-JSON parser off that header, so dropping it would break briefing parsing without failing a single test.
- No production change, `FlightController::briefing` already sets `application/json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that SimBrief briefing responses include the expected `application/json` content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->